### PR TITLE
Potential fix for code scanning alerts: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:
         default: ubuntu-latest
         description: Runner OS (ubuntu-latest, windows-latest, macos-latest)
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ inputs.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/Kryptos-FR/MarkView.Avalonia/security/code-scanning/1](https://github.com/Kryptos-FR/MarkView.Avalonia/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so every job has a constrained default token, then keep/override job-specific permissions only where needed.  
Best single fix here (without changing functionality) is:

- In `.github/workflows/ci.yml`, add a top-level:
  - `permissions:`
  - `contents: read`

This gives `build` an explicit minimal permission and satisfies the rule.  
Keep `publish` job’s existing job-level `permissions` block (`id-token: write`) unchanged so it can still request OIDC token issuance. Job-level permissions override/augment workflow defaults for that job context, preserving intended behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
