### PR TITLE
feat: image loading fixes, size syntax, and theme-aware syntax highlighting

### DIFF
--- a/src/MarkView.Avalonia.Mermaid/MermaidBlockRenderer.cs
+++ b/src/MarkView.Avalonia.Mermaid/MermaidBlockRenderer.cs
@@ -13,6 +13,7 @@ using Avalonia.Styling;
 using Avalonia.Svg.Skia;
 using Avalonia.VisualTree;
 using Markdig.Syntax;
+using MarkView.Avalonia.Extensions;
 using MarkView.Avalonia.Rendering;
 using Mermaider;
 
@@ -218,34 +219,68 @@ public class MermaidBlockRenderer : AvaloniaObjectRenderer<FencedCodeBlock>
         if (!string.IsNullOrEmpty(language))
             border.Classes.Add($"language-{language}");
 
-        if (obj.Lines.Lines != null)
+        if (obj.Lines.Lines == null)
         {
-            var lines = obj.Lines;
-            for (int i = 0; i < lines.Count; i++)
+            renderer.WriteBlock(border);
+            return;
+        }
+
+        // Materialise source lines once so they can be reused on theme change.
+        var lineTexts = Enumerable.Range(0, obj.Lines.Count)
+            .Select(i => obj.Lines.Lines[i].Slice.ToString())
+            .ToList();
+
+        var isDark = Application.Current?.ActualThemeVariant == ThemeVariant.Dark;
+        BuildInlines(textBlock, renderer.CodeHighlighter, language, isDark, lineTexts);
+
+        // If the highlighter is theme-aware, rebuild only TextBlock.Inlines when the
+        // theme changes — the Border and its position in the document stay untouched.
+        if (renderer.CodeHighlighter is IThemeAwareCodeHighlighter themeAware)
+        {
+            void OnThemeChanged(object? s, AvaloniaPropertyChangedEventArgs e)
             {
-                if (i > 0)
-                    textBlock.Inlines!.Add(new LineBreak());
-
-                var lineText = lines.Lines[i].Slice.ToString();
-                var tokens = renderer.CodeHighlighter?.Highlight(lineText, language);
-
-                if (tokens != null)
-                {
-                    foreach (var (text, foreground) in tokens)
-                    {
-                        var run = new Run(text);
-                        if (foreground != null)
-                            run.Foreground = foreground;
-                        textBlock.Inlines!.Add(run);
-                    }
-                }
-                else
-                {
-                    textBlock.Inlines!.Add(new Run(lineText));
-                }
+                if (e.Property.Name != nameof(Application.ActualThemeVariant)) return;
+                var newIsDark = Application.Current?.ActualThemeVariant == ThemeVariant.Dark;
+                textBlock.Inlines!.Clear();
+                BuildInlines(textBlock, themeAware, language, newIsDark, lineTexts);
             }
+            Application.Current!.PropertyChanged += OnThemeChanged;
+            border.DetachedFromVisualTree += (_, _) => Application.Current?.PropertyChanged -= OnThemeChanged;
         }
 
         renderer.WriteBlock(border);
+    }
+
+    private static void BuildInlines(
+        TextBlock textBlock,
+        ICodeHighlighter? highlighter,
+        string? language,
+        bool isDark,
+        IReadOnlyList<string> lineTexts)
+    {
+        for (int i = 0; i < lineTexts.Count; i++)
+        {
+            if (i > 0) textBlock.Inlines!.Add(new LineBreak());
+
+            var lineText = lineTexts[i];
+            var tokens = highlighter is IThemeAwareCodeHighlighter th
+                ? th.HighlightVariant(lineText, language, isDark)
+                : highlighter?.Highlight(lineText, language);
+
+            if (tokens != null)
+            {
+                foreach (var (text, foreground) in tokens)
+                {
+                    var run = new Run(text);
+                    if (foreground != null)
+                        run.Foreground = foreground;
+                    textBlock.Inlines!.Add(run);
+                }
+            }
+            else
+            {
+                textBlock.Inlines!.Add(new Run(lineText));
+            }
+        }
     }
 }

--- a/src/MarkView.Avalonia.Svg/SvgImageLoader.cs
+++ b/src/MarkView.Avalonia.Svg/SvgImageLoader.cs
@@ -27,7 +27,16 @@ public sealed class SvgImageLoader : IImageLoader
 
         // Check extension — ignore query string
         var path = url.Split('?')[0];
-        return path.EndsWith(".svg", StringComparison.OrdinalIgnoreCase);
+        if (path.EndsWith(".svg", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // Accept any absolute HTTP/HTTPS URL speculatively — LoadAsync will return null
+        // if the response is not valid SVG, letting the bitmap fallback take over.
+        if (Uri.TryCreate(url, UriKind.Absolute, out var uri) &&
+            (uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
+            return true;
+
+        return false;
     }
 
     public async Task<IImage?> LoadAsync(string url, CancellationToken cancellationToken = default)

--- a/src/MarkView.Avalonia.Svg/SvgImageLoader.cs
+++ b/src/MarkView.Avalonia.Svg/SvgImageLoader.cs
@@ -5,6 +5,8 @@ using System.Xml;
 
 using Avalonia.Media;
 using Avalonia.Svg.Skia;
+using Avalonia.Threading;
+
 using MarkView.Avalonia.Extensions;
 
 namespace MarkView.Avalonia.Svg;
@@ -56,9 +58,12 @@ public sealed class SvgImageLoader : IImageLoader
                 bytes = await HttpClient.GetByteArrayAsync(uri, cancellationToken);
             }
 
-            using var stream = new MemoryStream(bytes);
-            var source = SvgSource.LoadFromStream(stream);
-            return new SvgImage { Source = source };
+            SvgSource source;
+            using (var stream = new MemoryStream(bytes))
+                source = SvgSource.LoadFromStream(stream);
+
+            // SvgImage is an AvaloniaObject — must be created on the UI thread.
+            return await Dispatcher.UIThread.InvokeAsync(() => new SvgImage { Source = source });
         }
         catch (OperationCanceledException)
         {

--- a/src/MarkView.Avalonia.SyntaxHighlighting/DualThemeTextMateHighlighter.cs
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/DualThemeTextMateHighlighter.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia;
+using Avalonia.Media;
+using Avalonia.Styling;
+
+using MarkView.Avalonia.Extensions;
+
+namespace MarkView.Avalonia.SyntaxHighlighting;
+
+/// <summary>
+/// Wraps a dark and a light <see cref="TextMateHighlighter"/> and implements
+/// <see cref="IThemeAwareCodeHighlighter"/> so code block renderers can update
+/// token colours in-place when the theme changes.
+/// </summary>
+internal sealed class DualThemeTextMateHighlighter(TextMateHighlighter dark, TextMateHighlighter light)
+    : IThemeAwareCodeHighlighter
+{
+    public IReadOnlyList<(string Text, IBrush? Foreground)>? Highlight(string line, string? language)
+        => HighlightVariant(line, language, Application.Current?.ActualThemeVariant == ThemeVariant.Dark);
+
+    public IReadOnlyList<(string Text, IBrush? Foreground)>? HighlightVariant(string line, string? language, bool isDark)
+        => isDark ? dark.Highlight(line, language) : light.Highlight(line, language);
+}

--- a/src/MarkView.Avalonia.SyntaxHighlighting/MarkdownViewerExtensions.cs
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/MarkdownViewerExtensions.cs
@@ -13,12 +13,15 @@ public static class MarkdownViewerSyntaxHighlightingExtensions
     /// <summary>
     /// Adds <see cref="SyntaxHighlighting.TextMateExtension"/> to the viewer's
     /// <see cref="MarkdownViewer.Extensions"/> list.
+    /// The extension automatically selects the appropriate highlighter theme based on
+    /// the current <see cref="Avalonia.Styling.ThemeVariant"/>.
     /// </summary>
     public static MarkdownViewer UseTextMateHighlighting(
         this MarkdownViewer viewer,
-        ThemeName theme = ThemeName.DarkPlus)
+        ThemeName darkTheme = ThemeName.DarkPlus,
+        ThemeName lightTheme = ThemeName.LightPlus)
     {
-        viewer.Extensions.Add(new SyntaxHighlighting.TextMateExtension(theme));
+        viewer.Extensions.Add(new SyntaxHighlighting.TextMateExtension(darkTheme, lightTheme));
         return viewer;
     }
 }

--- a/src/MarkView.Avalonia.SyntaxHighlighting/TextMateCodeBlockRenderer.cs
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/TextMateCodeBlockRenderer.cs
@@ -1,10 +1,15 @@
 // Copyright (c) Nicolas Musset
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Documents;
 using Avalonia.Media;
+using Avalonia.Styling;
+
 using Markdig.Syntax;
+
+using MarkView.Avalonia.Extensions;
 using MarkView.Avalonia.Rendering;
 using MarkView.Avalonia.Rendering.Blocks;
 
@@ -12,9 +17,9 @@ namespace MarkView.Avalonia.SyntaxHighlighting;
 
 /// <summary>
 /// Replaces the built-in <see cref="CodeBlockRenderer"/> when syntax highlighting is active.
-/// For each source line it calls <see cref="AvaloniaRenderer.CodeHighlighter"/> and emits
-/// coloured <see cref="Run"/> elements; falls back to plain <see cref="Run"/> when the
-/// highlighter returns <c>null</c> (unsupported language or no highlighter registered).
+/// For fenced code blocks it calls <see cref="IThemeAwareCodeHighlighter.HighlightVariant"/>
+/// and subscribes to theme changes so token colours update in-place when the user switches
+/// between light and dark themes — without rebuilding the surrounding document tree.
 /// </summary>
 public class TextMateCodeBlockRenderer : AvaloniaObjectRenderer<CodeBlock>
 {
@@ -22,11 +27,7 @@ public class TextMateCodeBlockRenderer : AvaloniaObjectRenderer<CodeBlock>
     {
         var language = obj is FencedCodeBlock fenced ? fenced.Info : null;
 
-        var textBlock = new TextBlock
-        {
-            TextWrapping = TextWrapping.NoWrap,
-        };
-
+        var textBlock = new TextBlock { TextWrapping = TextWrapping.NoWrap };
         var border = new Border { Child = textBlock };
         border.Classes.Add("markdown-code-block");
 
@@ -39,14 +40,47 @@ public class TextMateCodeBlockRenderer : AvaloniaObjectRenderer<CodeBlock>
             return;
         }
 
-        var lines = obj.Lines;
-        for (int i = 0; i < lines.Count; i++)
-        {
-            if (i > 0)
-                textBlock.Inlines!.Add(new LineBreak());
+        // Materialise source lines once so they can be reused on theme change.
+        var lineTexts = Enumerable.Range(0, obj.Lines.Count)
+            .Select(i => obj.Lines.Lines[i].Slice.ToString())
+            .ToList();
 
-            var lineText = lines.Lines[i].Slice.ToString();
-            var tokens = renderer.CodeHighlighter?.Highlight(lineText, language);
+        var isDark = Application.Current?.ActualThemeVariant == ThemeVariant.Dark;
+        BuildInlines(textBlock, renderer.CodeHighlighter, language, isDark, lineTexts);
+
+        // If the highlighter is theme-aware, rebuild only TextBlock.Inlines when the
+        // theme changes — the Border and its position in the document stay untouched.
+        if (renderer.CodeHighlighter is IThemeAwareCodeHighlighter themeAware)
+        {
+            void OnThemeChanged(object? s, AvaloniaPropertyChangedEventArgs e)
+            {
+                if (e.Property.Name != nameof(Application.ActualThemeVariant)) return;
+                var newIsDark = Application.Current?.ActualThemeVariant == ThemeVariant.Dark;
+                textBlock.Inlines!.Clear();
+                BuildInlines(textBlock, themeAware, language, newIsDark, lineTexts);
+            }
+            Application.Current!.PropertyChanged += OnThemeChanged;
+            border.DetachedFromVisualTree += (_, _) => Application.Current?.PropertyChanged -= OnThemeChanged;
+        }
+
+        renderer.WriteBlock(border);
+    }
+
+    private static void BuildInlines(
+        TextBlock textBlock,
+        ICodeHighlighter? highlighter,
+        string? language,
+        bool isDark,
+        IReadOnlyList<string> lineTexts)
+    {
+        for (int i = 0; i < lineTexts.Count; i++)
+        {
+            if (i > 0) textBlock.Inlines!.Add(new LineBreak());
+
+            var lineText = lineTexts[i];
+            var tokens = highlighter is IThemeAwareCodeHighlighter th
+                ? th.HighlightVariant(lineText, language, isDark)
+                : highlighter?.Highlight(lineText, language);
 
             if (tokens != null)
             {
@@ -63,7 +97,5 @@ public class TextMateCodeBlockRenderer : AvaloniaObjectRenderer<CodeBlock>
                 textBlock.Inlines!.Add(new Run(lineText));
             }
         }
-
-        renderer.WriteBlock(border);
     }
 }

--- a/src/MarkView.Avalonia.SyntaxHighlighting/TextMateExtension.cs
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/TextMateExtension.cs
@@ -10,21 +10,31 @@ using TextMateSharp.Grammars;
 namespace MarkView.Avalonia.SyntaxHighlighting;
 
 /// <summary>
-/// Wires <see cref="TextMateHighlighter"/> and <see cref="TextMateCodeBlockRenderer"/>
-/// into an <see cref="AvaloniaRenderer"/>.
+/// Wires <see cref="DualThemeTextMateHighlighter"/> and <see cref="TextMateCodeBlockRenderer"/>
+/// into an <see cref="AvaloniaRenderer"/>. Two <see cref="TextMateHighlighter"/> instances are
+/// created lazily — one for dark themes and one for light — and exposed as an
+/// <see cref="IThemeAwareCodeHighlighter"/> so code block renderers can update token colours
+/// in-place when the theme changes without rebuilding the entire document.
 /// </summary>
 public sealed class TextMateExtension : IMarkViewExtension
 {
-    private readonly TextMateHighlighter _highlighter;
+    private readonly ThemeName _darkTheme;
+    private readonly ThemeName _lightTheme;
+    private TextMateHighlighter? _darkHighlighter;
+    private TextMateHighlighter? _lightHighlighter;
 
-    public TextMateExtension(ThemeName theme = ThemeName.DarkPlus)
+    public TextMateExtension(ThemeName darkTheme = ThemeName.DarkPlus, ThemeName lightTheme = ThemeName.LightPlus)
     {
-        _highlighter = new TextMateHighlighter(theme);
+        _darkTheme = darkTheme;
+        _lightTheme = lightTheme;
     }
 
     public void Register(AvaloniaRenderer renderer)
     {
-        renderer.CodeHighlighter = _highlighter;
+        renderer.CodeHighlighter = new DualThemeTextMateHighlighter(GetDark(), GetLight());
         renderer.ReplaceOrAdd<CodeBlockRenderer>(new TextMateCodeBlockRenderer());
     }
+
+    private TextMateHighlighter GetDark() => _darkHighlighter ??= new TextMateHighlighter(_darkTheme);
+    private TextMateHighlighter GetLight() => _lightHighlighter ??= new TextMateHighlighter(_lightTheme);
 }

--- a/src/MarkView.Avalonia/Extensions/ICodeHighlighter.cs
+++ b/src/MarkView.Avalonia/Extensions/ICodeHighlighter.cs
@@ -15,3 +15,13 @@ public interface ICodeHighlighter
 {
     IReadOnlyList<(string Text, IBrush? Foreground)>? Highlight(string line, string? language);
 }
+
+/// <summary>
+/// Extends <see cref="ICodeHighlighter"/> with explicit dark/light variant highlighting,
+/// enabling code block renderers to update token colours in-place when the theme changes
+/// without rebuilding the entire document.
+/// </summary>
+public interface IThemeAwareCodeHighlighter : ICodeHighlighter
+{
+    IReadOnlyList<(string Text, IBrush? Foreground)>? HighlightVariant(string line, string? language, bool isDark);
+}

--- a/src/MarkView.Avalonia/MarkdownViewer.cs
+++ b/src/MarkView.Avalonia/MarkdownViewer.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Nicolas Musset
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Text.RegularExpressions;
+
 using Avalonia;
 using Avalonia.Controls;
 
@@ -14,8 +16,13 @@ namespace MarkView.Avalonia;
 /// <summary>
 /// A control that renders Markdown text into Avalonia visual elements.
 /// </summary>
-public class MarkdownViewer : ContentControl
+public partial class MarkdownViewer : ContentControl
 {
+    // Converts the non-standard "![alt](url =WxH)" size hint to the title slot so Markdig
+    // can parse it: "![alt](url "=WxH")". CommonMark has no image-size syntax.
+    [GeneratedRegex(@"(\!\[[^\]]*\]\()([^\s\)]+)\s+=(\d+x\d+)(\))", RegexOptions.Compiled)]
+    private static partial Regex ImageSizePreprocessorRegex();
+
     private Dictionary<string, Control> _anchors = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
@@ -93,7 +100,8 @@ public class MarkdownViewer : ContentControl
         }
 
         var pipeline = Pipeline ?? new MarkdownPipelineBuilder().UseSupportedExtensions().Build();
-        var document = Markdig.Markdown.Parse(Markdown, pipeline);
+        var markdownText = ImageSizePreprocessorRegex().Replace(Markdown, "$1$2 \"=$3\"$4");
+        var document = Markdig.Markdown.Parse(markdownText, pipeline);
 
         var renderer = new AvaloniaRenderer { BaseUri = BaseUri };
         renderer.LinkClicked += OnLinkClicked;
@@ -150,4 +158,5 @@ public class MarkdownViewer : ContentControl
         const double topMargin = 16;
         scrollViewer.Offset = new Vector(scrollViewer.Offset.X, Math.Max(0, point.Value.Y - topMargin));
     }
+
 }

--- a/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
@@ -56,11 +56,18 @@ public class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
 
         image.Tag = url;
 
-        // CancellationToken tied to visual-tree lifetime
-        var cts = new CancellationTokenSource();
-        image.DetachedFromVisualTree += (_, _) => cts.Cancel();
-
-        _ = LoadImageAsync(renderer, image, url, cts.Token);
+        // Start loading on first attach; cancel on detach.
+        // Deferring to AttachedToVisualTree avoids spurious cancellations from
+        // Avalonia's layout passes that detach/reattach controls during initialisation.
+        CancellationTokenSource? cts = null;
+        image.AttachedToVisualTree += (_, _) =>
+        {
+            if (image.Source != null) return; // already loaded, no need to reload
+            cts?.Cancel();
+            cts = new CancellationTokenSource();
+            _ = LoadImageAsync(renderer, image, url, cts.Token);
+        };
+        image.DetachedFromVisualTree += (_, _) => cts?.Cancel();
 
         renderer.WriteInline(image);
     }

--- a/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
@@ -2,7 +2,9 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Avalonia.Controls;
+using Avalonia.Media;
 using Avalonia.Media.Imaging;
+using Avalonia.Threading;
 
 using Markdig.Syntax.Inlines;
 
@@ -46,7 +48,7 @@ public class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
         var altText = string.Concat(obj.SelectMany(c =>
             c is LiteralInline literal ? literal.Content.ToString() : string.Empty));
 
-        var image = new Image();
+        var image = new Image { Stretch = Stretch.None };
         image.Classes.Add("markdown-image");
 
         if (!string.IsNullOrEmpty(altText))
@@ -80,7 +82,7 @@ public class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
                 var loaded = await loader.LoadAsync(url, cancellationToken);
                 if (loaded != null)
                 {
-                    image.Source = loaded;
+                    await Dispatcher.UIThread.InvokeAsync(() => image.Source = loaded);
                     return;
                 }
             }
@@ -90,13 +92,10 @@ public class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
                 return;
 
             var bytes = await HttpClient.GetByteArrayAsync(uri, cancellationToken);
-            using var stream = new MemoryStream(bytes);
-            image.Source = new Bitmap(stream);
+            var bitmap = new Bitmap(new MemoryStream(bytes));
+            await Dispatcher.UIThread.InvokeAsync(() => image.Source = bitmap);
         }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
+        catch (OperationCanceledException) { }
         catch (HttpRequestException) { }
         catch (IOException) { }
     }

--- a/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Nicolas Musset
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Text.RegularExpressions;
+
 using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
@@ -14,9 +16,13 @@ namespace MarkView.Avalonia.Rendering.Inlines;
 /// <summary>
 /// Renders a Markdig <see cref="LinkInline"/> as a <see cref="MarkdownHyperlink"/> span or image.
 /// </summary>
-public class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
+public partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
 {
     private static readonly HttpClient HttpClient = new();
+
+    // Matches the "=WxH" title produced by MarkdownViewer's preprocessor.
+    [GeneratedRegex(@"^=(\d+)x(\d+)$", RegexOptions.Compiled)]
+    private static partial Regex DimensionTitleRegex();
 
     protected override void Write(AvaloniaRenderer renderer, LinkInline obj)
     {
@@ -54,6 +60,18 @@ public class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
 
         if (!string.IsNullOrEmpty(altText))
             ToolTip.SetTip(image, altText);
+
+        // Apply explicit dimensions from =WxH title (set by MarkdownViewer's preprocessor).
+        if (!string.IsNullOrEmpty(obj.Title))
+        {
+            var dim = DimensionTitleRegex().Match(obj.Title);
+            if (dim.Success)
+            {
+                image.Width = int.Parse(dim.Groups[1].Value);
+                image.Height = int.Parse(dim.Groups[2].Value);
+                image.Stretch = Stretch.Uniform;
+            }
+        }
 
         image.Tag = url;
 
@@ -116,4 +134,5 @@ public class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
         catch (HttpRequestException) { }
         catch (IOException) { }
     }
+
 }

--- a/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
@@ -4,6 +4,7 @@
 using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
+using Avalonia.Platform;
 using Avalonia.Threading;
 
 using Markdig.Syntax.Inlines;
@@ -94,13 +95,22 @@ public class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
                 }
             }
 
-            // HTTP fallback for absolute URLs
             if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
                 return;
 
+            // avares:// — Avalonia embedded resource
+            if (uri.Scheme == "avares")
+            {
+                using var stream = AssetLoader.Open(uri);
+                var bitmap = new Bitmap(stream);
+                await Dispatcher.UIThread.InvokeAsync(() => image.Source = bitmap);
+                return;
+            }
+
+            // HTTP/HTTPS fallback
             var bytes = await HttpClient.GetByteArrayAsync(uri, cancellationToken);
-            var bitmap = new Bitmap(new MemoryStream(bytes));
-            await Dispatcher.UIThread.InvokeAsync(() => image.Source = bitmap);
+            var httpBitmap = new Bitmap(new MemoryStream(bytes));
+            await Dispatcher.UIThread.InvokeAsync(() => image.Source = httpBitmap);
         }
         catch (OperationCanceledException) { }
         catch (HttpRequestException) { }

--- a/src/MarkView.Avalonia/Rendering/SlugGenerator.cs
+++ b/src/MarkView.Avalonia/Rendering/SlugGenerator.cs
@@ -13,7 +13,7 @@ namespace MarkView.Avalonia.Rendering;
 /// TODO: expose ISlugGenerator interface and allow injection via AvaloniaRenderer
 /// to support alternative anchor schemes (e.g. GitLab, Gitea, or user-defined).
 /// </remarks>
-public class SlugGenerator
+public partial class SlugGenerator
 {
     private readonly Dictionary<string, int> _seen = new(StringComparer.Ordinal);
 
@@ -39,12 +39,19 @@ public class SlugGenerator
         // Lowercase
         text = text.ToLowerInvariant();
         // Remove characters that are not letters, digits, spaces, or hyphens
-        text = Regex.Replace(text, @"[^\p{L}\p{N}\s\-]", "");
+        text = InvalidCharacterRegex().Replace(text, "");
         // Replace whitespace runs with a single hyphen
-        text = Regex.Replace(text, @"\s+", "-");
+        text = WhitespaceRegex().Replace(text, "-");
         // Collapse consecutive hyphens
-        text = Regex.Replace(text, @"-{2,}", "-");
+        text = CollapseRegex().Replace(text, "-");
         // Trim leading/trailing hyphens
         return text.Trim('-');
     }
+
+    [GeneratedRegex(@"[^\p{L}\p{N}\s\-]")]
+    private static partial Regex InvalidCharacterRegex();
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
+    [GeneratedRegex(@"-{2,}")]
+    private static partial Regex CollapseRegex();
 }

--- a/src/MarkView.Avalonia/Themes/MarkdownTheme.axaml
+++ b/src/MarkView.Avalonia/Themes/MarkdownTheme.axaml
@@ -3,6 +3,25 @@
         xmlns:mv="using:MarkView.Avalonia"
         xmlns:mri="using:MarkView.Avalonia.Rendering.Inlines">
 
+  <Styles.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Dark">
+          <SolidColorBrush x:Key="MarkdownCodeBlockBackground">#1E1E1E</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownCodeBlockForeground">#D4D4D4</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownCodeInlineBackground">#1A000000</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownCodeInlineForeground">#CE9178</SolidColorBrush>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="Light">
+          <SolidColorBrush x:Key="MarkdownCodeBlockBackground">#F3F3F3</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownCodeBlockForeground">#1E1E1E</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownCodeInlineBackground">#0A000000</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownCodeInlineForeground">#A31515</SolidColorBrush>
+        </ResourceDictionary>
+      </ResourceDictionary.ThemeDictionaries>
+    </ResourceDictionary>
+  </Styles.Resources>
+
   <!-- Headings — use :is() to match MarkdownSelectableTextBlock (a TextBlock subclass) -->
   <Style Selector=":is(TextBlock).markdown-h1">
     <Setter Property="FontSize" Value="28" />
@@ -42,7 +61,7 @@
 
   <!-- Code blocks -->
   <Style Selector="Border.markdown-code-block">
-    <Setter Property="Background" Value="#1E1E1E" />
+    <Setter Property="Background" Value="{DynamicResource MarkdownCodeBlockBackground}" />
     <Setter Property="CornerRadius" Value="4" />
     <Setter Property="Padding" Value="12,8" />
     <Setter Property="Margin" Value="0,4" />
@@ -50,14 +69,14 @@
   <Style Selector="Border.markdown-code-block > TextBlock">
     <Setter Property="FontFamily" Value="Cascadia Code, Consolas, Courier New, monospace" />
     <Setter Property="FontSize" Value="13" />
-    <Setter Property="Foreground" Value="#D4D4D4" />
+    <Setter Property="Foreground" Value="{DynamicResource MarkdownCodeBlockForeground}" />
   </Style>
 
   <!-- Inline code -->
   <Style Selector="Run.markdown-code-inline">
     <Setter Property="FontFamily" Value="Cascadia Code, Consolas, Courier New, monospace"/>
-    <Setter Property="Background" Value="#1A000000"/>
-    <Setter Property="Foreground" Value="#CE9178"/>
+    <Setter Property="Background" Value="{DynamicResource MarkdownCodeInlineBackground}"/>
+    <Setter Property="Foreground" Value="{DynamicResource MarkdownCodeInlineForeground}"/>
   </Style>
 
   <!-- Blockquote -->

--- a/tests/MarkView.Avalonia.Svg.Tests/SvgImageLoaderTests.cs
+++ b/tests/MarkView.Avalonia.Svg.Tests/SvgImageLoaderTests.cs
@@ -12,7 +12,8 @@ public class SvgImageLoaderTests
 {
     [Theory]
     [InlineData("https://example.com/icon.svg", true)]
-    [InlineData("https://example.com/image.png", false)]
+    [InlineData("https://example.com/image.png", true)]  // accepted speculatively; LoadAsync returns null if not SVG
+    [InlineData("https://shields.io/badge/build-passing-green", true)]  // no extension; may be SVG response
     [InlineData("data:image/svg+xml;base64,PHN2Zy8+", true)]
     [InlineData("data:image/png;base64,abc", false)]
     [InlineData("https://example.com/icon.SVG", true)]   // case-insensitive extension

--- a/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/TextMateCodeBlockRendererTests.cs
+++ b/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/TextMateCodeBlockRendererTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Documents;
 using Avalonia.Headless.XUnit;
 using Markdig;
+using MarkView.Avalonia.Extensions;
 using MarkView.Avalonia.Rendering;
 using TextMateSharp.Grammars;
 using Xunit;
@@ -76,5 +77,46 @@ public class TextMateCodeBlockRendererTests
         viewer.UseTextMateHighlighting();
         Assert.Single(viewer.Extensions);
         Assert.IsType<TextMateExtension>(viewer.Extensions[0]);
+    }
+
+    [AvaloniaFact]
+    public void TextMateExtension_Register_sets_theme_aware_CodeHighlighter()
+    {
+        var renderer = new AvaloniaRenderer();
+        new TextMateExtension().Register(renderer);
+        Assert.IsAssignableFrom<IThemeAwareCodeHighlighter>(renderer.CodeHighlighter);
+    }
+
+    [AvaloniaFact]
+    public void Theme_aware_highlighter_returns_tokens_for_both_variants()
+    {
+        var renderer = new AvaloniaRenderer();
+        new TextMateExtension().Register(renderer);
+        var themeAware = (IThemeAwareCodeHighlighter)renderer.CodeHighlighter!;
+
+        var darkTokens = themeAware.HighlightVariant("var x = 1;", "csharp", isDark: true);
+        var lightTokens = themeAware.HighlightVariant("var x = 1;", "csharp", isDark: false);
+
+        Assert.NotNull(darkTokens);
+        Assert.NotNull(lightTokens);
+        Assert.NotEmpty(darkTokens);
+        Assert.NotEmpty(lightTokens);
+    }
+
+    [AvaloniaFact]
+    public void Dark_and_light_variants_produce_different_token_colours()
+    {
+        var renderer = new AvaloniaRenderer();
+        new TextMateExtension().Register(renderer);
+        var themeAware = (IThemeAwareCodeHighlighter)renderer.CodeHighlighter!;
+
+        var dark = themeAware.HighlightVariant("var x = 1;", "csharp", isDark: true)!;
+        var light = themeAware.HighlightVariant("var x = 1;", "csharp", isDark: false)!;
+
+        // At least one token should differ in colour between dark and light themes.
+        var darkColours = dark.Select(t => t.Foreground?.ToString()).ToList();
+        var lightColours = light.Select(t => t.Foreground?.ToString()).ToList();
+        Assert.False(darkColours.SequenceEqual(lightColours),
+            "Expected dark and light themes to produce at least one different token colour.");
     }
 }

--- a/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Media;
 
+using MarkView.Avalonia;
 using MarkView.Avalonia.Extensions;
 using MarkView.Avalonia.Rendering;
 
@@ -67,8 +68,26 @@ public class ImageTests : RenderTestBase
         pipeline.Setup(renderer);
         renderer.Render(document);
 
-        // Loader was consulted — CanLoad must have been called
+        // Loading is deferred to AttachedToVisualTree; attach to a headless window so
+        // the event fires and CanLoad is called (synchronously, before the first await).
+        var window = new Window { Content = renderer.RootPanel };
+        window.Show();
+
         Assert.True(loader.CanLoadCalled);
+    }
+
+    [AvaloniaFact]
+    public void Image_size_hint_sets_Width_and_Height()
+    {
+        var viewer = new MarkdownViewer();
+        viewer.Markdown = "![logo](https://example.com/logo.png =200x100)";
+
+        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
+        var panel = Assert.IsType<StackPanel>(scrollViewer.Content);
+        var image = FindFirst<Image>(panel);
+        Assert.NotNull(image);
+        Assert.Equal(200.0, image.Width);
+        Assert.Equal(100.0, image.Height);
     }
 
     [AvaloniaFact]


### PR DESCRIPTION
## Summary

- **SVG image loading**: accept all HTTP/HTTPS URLs speculatively in `SvgImageLoader` so SVG responses without a `.svg` extension (e.g. shields.io badges) are handled correctly
- **Image threading**: dispatch `image.Source` assignment and `SvgImage` construction to the UI thread to respect `AvaloniaObject` thread affinity
- **Image loading lifecycle**: defer loading to `AttachedToVisualTree` instead of reacting to `DetachedFromVisualTree`, avoiding spurious cancellations during Avalonia's layout passes
- **Image display**: use `Stretch.None` for natural inline image sizing; support `avares://` URIs for embedded Avalonia resources
- **Image size syntax**: preprocess the non-standard `![alt](url =WxH)` notation into a quoted title so Markdig can parse it; `LinkInlineRenderer` applies `Width`/`Height` from the title
- **Theme-aware syntax highlighting**: add `IThemeAwareCodeHighlighter` / `DualThemeTextMateHighlighter`; code block renderers rebuild only `TextBlock.Inlines` on theme change via `Application.PropertyChanged` — no full document re-render, so scroll position, images, and Mermaid diagrams are unaffected
- **Code block theming**: `MarkdownTheme.axaml` uses `ResourceDictionary.ThemeDictionaries` for code block background/foreground and inline code colours, switching automatically with the Avalonia theme variant

## Test plan

- [x] Verify SVG images (including shields.io badges) load correctly in both light and dark theme
- [x] Verify bitmap images (`avares://` URIs) display at natural size
- [x] Verify `![alt](url =WxH)` resizes images as expected
- [x] Switch between light and dark theme — code block token colours update in place; scroll position and images are preserved
- [x] Verify code block background/foreground and inline code colours match the active theme
- [x] Run test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)