### PR TITLE
perf: reduce allocations in rendering pipeline

### DIFF
--- a/src/MarkView.Avalonia.Mermaid/MermaidBlockRenderer.cs
+++ b/src/MarkView.Avalonia.Mermaid/MermaidBlockRenderer.cs
@@ -191,9 +191,13 @@ public class MermaidBlockRenderer : AvaloniaObjectRenderer<FencedCodeBlock>
             return string.Empty;
 
         var lines = block.Lines;
-        return string.Join("\n",
-            Enumerable.Range(0, lines.Count)
-                      .Select(i => lines.Lines[i].Slice.ToString()));
+        var sb = new StringBuilder();
+        for (int i = 0; i < lines.Count; i++)
+        {
+            if (i > 0) sb.Append('\n');
+            sb.Append(lines.Lines[i].Slice.AsSpan());
+        }
+        return sb.ToString();
     }
 
     private static void WriteFallback(AvaloniaRenderer renderer, string source, string? errorMessage = null)
@@ -226,9 +230,9 @@ public class MermaidBlockRenderer : AvaloniaObjectRenderer<FencedCodeBlock>
         }
 
         // Materialise source lines once so they can be reused on theme change.
-        var lineTexts = Enumerable.Range(0, obj.Lines.Count)
-            .Select(i => obj.Lines.Lines[i].Slice.ToString())
-            .ToList();
+        var lineTexts = new List<string>(obj.Lines.Count);
+        for (int i = 0; i < obj.Lines.Count; i++)
+            lineTexts.Add(obj.Lines.Lines[i].Slice.ToString());
 
         var isDark = Application.Current?.ActualThemeVariant == ThemeVariant.Dark;
         BuildInlines(textBlock, renderer.CodeHighlighter, language, isDark, lineTexts);

--- a/src/MarkView.Avalonia.Svg/SvgImageLoader.cs
+++ b/src/MarkView.Avalonia.Svg/SvgImageLoader.cs
@@ -45,22 +45,21 @@ public sealed class SvgImageLoader : IImageLoader
     {
         try
         {
-            byte[] bytes;
+            SvgSource source;
 
             if (url.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
             {
-                bytes = DecodeDataUri(url);
+                var bytes = DecodeDataUri(url);
+                using var ms = new MemoryStream(bytes);
+                source = SvgSource.LoadFromStream(ms);
             }
             else
             {
                 if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
                     return null;
-                bytes = await HttpClient.GetByteArrayAsync(uri, cancellationToken);
+                using var responseStream = await HttpClient.GetStreamAsync(uri, cancellationToken);
+                source = SvgSource.LoadFromStream(responseStream);
             }
-
-            SvgSource source;
-            using (var stream = new MemoryStream(bytes))
-                source = SvgSource.LoadFromStream(stream);
 
             // SvgImage is an AvaloniaObject — must be created on the UI thread.
             return await Dispatcher.UIThread.InvokeAsync(() => new SvgImage { Source = source });
@@ -81,14 +80,12 @@ public sealed class SvgImageLoader : IImageLoader
         if (commaIndex < 0)
             return [];
 
-        var header = dataUri[..commaIndex];
-        var data = dataUri[(commaIndex + 1)..];
-
-        if (header.EndsWith(";base64", StringComparison.OrdinalIgnoreCase))
-            return Convert.FromBase64String(data);
+        // Use AsSpan to test the header without allocating a substring
+        if (dataUri.AsSpan(0, commaIndex).EndsWith(";base64", StringComparison.OrdinalIgnoreCase))
+            return Convert.FromBase64String(dataUri[(commaIndex + 1)..]);
 
         // URL-encoded text
-        var decoded = Uri.UnescapeDataString(data);
+        var decoded = Uri.UnescapeDataString(dataUri[(commaIndex + 1)..]);
         return System.Text.Encoding.UTF8.GetBytes(decoded);
     }
 }

--- a/src/MarkView.Avalonia.SyntaxHighlighting/TextMateCodeBlockRenderer.cs
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/TextMateCodeBlockRenderer.cs
@@ -41,9 +41,9 @@ public class TextMateCodeBlockRenderer : AvaloniaObjectRenderer<CodeBlock>
         }
 
         // Materialise source lines once so they can be reused on theme change.
-        var lineTexts = Enumerable.Range(0, obj.Lines.Count)
-            .Select(i => obj.Lines.Lines[i].Slice.ToString())
-            .ToList();
+        var lineTexts = new List<string>(obj.Lines.Count);
+        for (int i = 0; i < obj.Lines.Count; i++)
+            lineTexts.Add(obj.Lines.Lines[i].Slice.ToString());
 
         var isDark = Application.Current?.ActualThemeVariant == ThemeVariant.Dark;
         BuildInlines(textBlock, renderer.CodeHighlighter, language, isDark, lineTexts);

--- a/src/MarkView.Avalonia.SyntaxHighlighting/TextMateHighlighter.cs
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/TextMateHighlighter.cs
@@ -23,6 +23,9 @@ public class TextMateHighlighter : ICodeHighlighter
     // Grammar cache: language id → grammar (null = unsupported)
     private readonly Dictionary<string, IGrammar?> _grammarCache = new(StringComparer.OrdinalIgnoreCase);
 
+    // Brush cache: theme colour hex string → brush (avoids per-token allocation)
+    private readonly Dictionary<string, IBrush> _brushCache = new(StringComparer.OrdinalIgnoreCase);
+
     public TextMateHighlighter(ThemeName theme = ThemeName.DarkPlus)
     {
         _options = new RegistryOptions(theme);
@@ -85,7 +88,10 @@ public class TextMateHighlighter : ICodeHighlighter
             {
                 var hex = _theme.GetColor(rules[0].foreground);
                 if (!string.IsNullOrEmpty(hex))
-                    brush = new ImmutableSolidColorBrush(Color.Parse(hex));
+                {
+                    if (!_brushCache.TryGetValue(hex, out brush))
+                        _brushCache[hex] = brush = new ImmutableSolidColorBrush(Color.Parse(hex));
+                }
             }
 
             tokens.Add((text, brush));

--- a/src/MarkView.Avalonia/MarkdownViewer.cs
+++ b/src/MarkView.Avalonia/MarkdownViewer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Nicolas Musset
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Text;
 using System.Text.RegularExpressions;
 
 using Avalonia;
@@ -31,6 +32,9 @@ public partial class MarkdownViewer : ContentControl
     private bool _isDragging;
     private Point _dragStart;
     private const double DragThreshold = 3.0;
+
+    private static readonly MarkdownPipeline DefaultPipeline =
+        new MarkdownPipelineBuilder().UseSupportedExtensions().Build();
 
     /// <summary>
     /// Defines the <see cref="Markdown"/> property.
@@ -108,7 +112,7 @@ public partial class MarkdownViewer : ContentControl
             return;
         }
 
-        var pipeline = Pipeline ?? new MarkdownPipelineBuilder().UseSupportedExtensions().Build();
+        var pipeline = Pipeline ?? DefaultPipeline;
         var markdownText = ImageSizePreprocessorRegex().Replace(Markdown, "$1$2 \"=$3\"$4");
         var document = Markdig.Markdown.Parse(markdownText, pipeline);
 
@@ -187,14 +191,17 @@ public partial class MarkdownViewer : ContentControl
             if (child is not Grid itemGrid) continue;
 
             // Column 0 holds the marker TextBlock (absent for task-list checkboxes)
-            var markerText = itemGrid.Children
-                .OfType<TextBlock>()
-                .FirstOrDefault(c => Grid.GetColumn(c) == 0)?.Text ?? string.Empty;
-
             // Column 1 holds the content StackPanel
-            var contentPanel = itemGrid.Children
-                .OfType<Panel>()
-                .FirstOrDefault(c => Grid.GetColumn(c) == 1);
+            TextBlock? markerTb = null;
+            Panel? contentPanel = null;
+            foreach (var gridChild in itemGrid.Children)
+            {
+                if (gridChild is TextBlock tb && Grid.GetColumn(tb) == 0)
+                    markerTb = tb;
+                else if (gridChild is Panel pnl && Grid.GetColumn(pnl) == 1)
+                    contentPanel = pnl;
+            }
+            var markerText = markerTb?.Text ?? string.Empty;
             if (contentPanel is null) continue;
 
             bool markerApplied = false;
@@ -248,16 +255,19 @@ public partial class MarkdownViewer : ContentControl
 
         foreach (var (_, colMap) in rowMap)
         {
-            var cells = colMap.Values.ToList();
-            for (int i = 0; i < cells.Count; i++)
+            int cellCount = colMap.Count;
+            int i = 0;
+            foreach (var cell in colMap.Values)
             {
-                var cell = cells[i];
                 var tb = FindFirstTextBlock(cell);
-                if (tb is null) continue;
-                var text = cell.Child is Panel p ? ExtractPanelText(p) : string.Empty;
-                // Last cell in row separates with newline; others with tab
-                var separator = (i == cells.Count - 1) ? "\n" : "\t";
-                layer.Register(new IndexEntry(tb, text, separator));
+                if (tb is not null)
+                {
+                    var text = cell.Child is Panel p ? ExtractPanelText(p) : string.Empty;
+                    // Last cell in row separates with newline; others with tab
+                    var separator = (i == cellCount - 1) ? "\n" : "\t";
+                    layer.Register(new IndexEntry(tb, text, separator));
+                }
+                i++;
             }
         }
     }
@@ -265,32 +275,41 @@ public partial class MarkdownViewer : ContentControl
     /// <summary>Extracts plain text from a panel, joining child texts with a space.</summary>
     private static string ExtractPanelText(Panel panel)
     {
-        var parts = new List<string>();
+        var sb = new StringBuilder();
         foreach (var child in panel.Children)
         {
             switch (child)
             {
                 case MarkdownSelectableTextBlock tb:
                     var t = MarkdownSelectableTextBlock.ExtractPlainText(tb.Inlines!);
-                    if (!string.IsNullOrEmpty(t)) parts.Add(t);
+                    if (!string.IsNullOrEmpty(t)) { if (sb.Length > 0) sb.Append(' '); sb.Append(t); }
                     break;
                 case Panel nested:
                     var nt = ExtractPanelText(nested);
-                    if (!string.IsNullOrEmpty(nt)) parts.Add(nt);
+                    if (!string.IsNullOrEmpty(nt)) { if (sb.Length > 0) sb.Append(' '); sb.Append(nt); }
                     break;
             }
         }
-        return string.Join(' ', parts);
+        return sb.ToString();
     }
 
     /// <summary>Returns the first <see cref="TextBlock"/> found in a control subtree.</summary>
-    private static TextBlock? FindFirstTextBlock(Control control) => control switch
+    private static TextBlock? FindFirstTextBlock(Control control)
     {
-        TextBlock tb => tb,
-        Border { Child: Control child } => FindFirstTextBlock(child),
-        Panel panel => panel.Children.Select(FindFirstTextBlock).FirstOrDefault(tb => tb is not null),
-        _ => null,
-    };
+        switch (control)
+        {
+            case TextBlock tb: return tb;
+            case Border { Child: Control child }: return FindFirstTextBlock(child);
+            case Panel panel:
+                foreach (var c in panel.Children)
+                {
+                    var found = FindFirstTextBlock(c);
+                    if (found is not null) return found;
+                }
+                return null;
+            default: return null;
+        }
+    }
 
     // ── Pointer handlers ──────────────────────────────────────────────────────
 

--- a/src/MarkView.Avalonia/Rendering/Blocks/HeadingRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/HeadingRenderer.cs
@@ -29,9 +29,11 @@ public class HeadingRenderer : AvaloniaObjectRenderer<HeadingBlock>
         renderer.Pop();
 
         // Generate anchor slug and register for fragment navigation
-        var headingText = string.Concat(obj.Inline?.SelectMany(
-            c => c is LiteralInline lit ? lit.Content.ToString() : string.Empty)
-            ?? []);
+        var sb = new System.Text.StringBuilder();
+        if (obj.Inline is not null)
+            foreach (var c in obj.Inline)
+                if (c is LiteralInline lit) sb.Append(lit.Content.AsSpan());
+        var headingText = sb.ToString();
         var slug = renderer.SlugGenerator.GenerateSlug(headingText);
         textBlock.Tag = slug;
         renderer.RegisterAnchor(slug, textBlock);

--- a/src/MarkView.Avalonia/Rendering/DocumentSelectionLayer.cs
+++ b/src/MarkView.Avalonia/Rendering/DocumentSelectionLayer.cs
@@ -5,6 +5,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input.Platform;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 
 namespace MarkView.Avalonia.Rendering;
 
@@ -17,6 +18,9 @@ namespace MarkView.Avalonia.Rendering;
 /// </summary>
 internal sealed class DocumentSelectionLayer : Control
 {
+    private static readonly ImmutableSolidColorBrush SelectionBrush =
+        new(Colors.CornflowerBlue, 0.35);
+
     private readonly List<IndexEntry> _entries = new();
     private int _totalLength;
 
@@ -169,8 +173,6 @@ internal sealed class DocumentSelectionLayer : Control
         int selEnd   = Math.Max(_anchor.Value, _focus.Value);
         if (selStart == selEnd) return;
 
-        var brush = new SolidColorBrush(Colors.CornflowerBlue, 0.35);
-
         foreach (var entry in _entries)
         {
             if (entry.AbsEnd <= selStart) continue;
@@ -187,7 +189,7 @@ internal sealed class DocumentSelectionLayer : Control
             if (length <= 0) continue;
 
             foreach (var rect in entry.TextBlock.TextLayout.HitTestTextRange(localStart, length))
-                context.DrawRectangle(brush, null, rect.Translate(textOrigin));
+                context.DrawRectangle(SelectionBrush, null, rect.Translate(textOrigin));
         }
     }
 

--- a/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
@@ -52,8 +52,10 @@ public partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
     {
         var url = renderer.ResolveUrl(obj.Url ?? string.Empty);
 
-        var altText = string.Concat(obj.SelectMany(c =>
-            c is LiteralInline literal ? literal.Content.ToString() : string.Empty));
+        var sb = new System.Text.StringBuilder();
+        foreach (var c in obj)
+            if (c is LiteralInline literal) sb.Append(literal.Content.AsSpan());
+        var altText = sb.ToString();
 
         var image = new Image { Stretch = Stretch.None };
         image.Classes.Add("markdown-image");
@@ -126,8 +128,8 @@ public partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
             }
 
             // HTTP/HTTPS fallback
-            var bytes = await HttpClient.GetByteArrayAsync(uri, cancellationToken);
-            var httpBitmap = new Bitmap(new MemoryStream(bytes));
+            using var responseStream = await HttpClient.GetStreamAsync(uri, cancellationToken);
+            var httpBitmap = new Bitmap(responseStream);
             await Dispatcher.UIThread.InvokeAsync(() => image.Source = httpBitmap);
         }
         catch (OperationCanceledException) { }

--- a/src/MarkView.Avalonia/Rendering/MarkdownSelectableTextBlock.cs
+++ b/src/MarkView.Avalonia/Rendering/MarkdownSelectableTextBlock.cs
@@ -48,13 +48,19 @@ public class MarkdownSelectableTextBlock : TextBlock
         return null;
     }
 
-    internal static int MeasureInlineLength(Inline inline) => inline switch
+    internal static int MeasureInlineLength(Inline inline)
     {
-        Run r => r.Text?.Length ?? 0,
-        Span s => s.Inlines.Sum(MeasureInlineLength),
-        LineBreak => Environment.NewLine.Length,
-        _ => 1,
-    };
+        switch (inline)
+        {
+            case Run r: return r.Text?.Length ?? 0;
+            case Span s:
+                int total = 0;
+                foreach (var child in s.Inlines) total += MeasureInlineLength(child);
+                return total;
+            case LineBreak: return Environment.NewLine.Length;
+            default: return 1;
+        }
+    }
 
     /// <summary>
     /// Extracts plain text from an <see cref="InlineCollection"/>, recursing into spans.

--- a/src/MarkView.Avalonia/Rendering/SlugGenerator.cs
+++ b/src/MarkView.Avalonia/Rendering/SlugGenerator.cs
@@ -1,7 +1,8 @@
 // Copyright (c) Nicolas Musset
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System.Text.RegularExpressions;
+using System.Globalization;
+using System.Text;
 
 namespace MarkView.Avalonia.Rendering;
 
@@ -13,7 +14,7 @@ namespace MarkView.Avalonia.Rendering;
 /// TODO: expose ISlugGenerator interface and allow injection via AvaloniaRenderer
 /// to support alternative anchor schemes (e.g. GitLab, Gitea, or user-defined).
 /// </remarks>
-public partial class SlugGenerator
+public class SlugGenerator
 {
     private readonly Dictionary<string, int> _seen = new(StringComparer.Ordinal);
 
@@ -34,24 +35,46 @@ public partial class SlugGenerator
 
     public void Reset() => _seen.Clear();
 
+    /// <summary>
+    /// Single-pass normalisation: lowercase + filter + whitespace/hyphen collapsing.
+    /// Eliminates the four intermediate strings produced by the previous regex pipeline.
+    /// </summary>
     private static string Normalize(string text)
     {
-        // Lowercase
-        text = text.ToLowerInvariant();
-        // Remove characters that are not letters, digits, spaces, or hyphens
-        text = InvalidCharacterRegex().Replace(text, "");
-        // Replace whitespace runs with a single hyphen
-        text = WhitespaceRegex().Replace(text, "-");
-        // Collapse consecutive hyphens
-        text = CollapseRegex().Replace(text, "-");
-        // Trim leading/trailing hyphens
-        return text.Trim('-');
-    }
+        var sb = new StringBuilder(text.Length);
+        bool pendingHyphen = false;
 
-    [GeneratedRegex(@"[^\p{L}\p{N}\s\-]")]
-    private static partial Regex InvalidCharacterRegex();
-    [GeneratedRegex(@"\s+")]
-    private static partial Regex WhitespaceRegex();
-    [GeneratedRegex(@"-{2,}")]
-    private static partial Regex CollapseRegex();
+        foreach (char rawCh in text)
+        {
+            char ch = char.ToLowerInvariant(rawCh);
+            var cat = CharUnicodeInfo.GetUnicodeCategory(ch);
+
+            bool isKeepable =
+                cat is UnicodeCategory.LowercaseLetter
+                    or UnicodeCategory.UppercaseLetter  // after ToLowerInvariant — kept for safety
+                    or UnicodeCategory.TitlecaseLetter
+                    or UnicodeCategory.ModifierLetter
+                    or UnicodeCategory.OtherLetter
+                    or UnicodeCategory.DecimalDigitNumber
+                    or UnicodeCategory.LetterNumber
+                    or UnicodeCategory.OtherNumber;
+
+            if (isKeepable)
+            {
+                if (pendingHyphen && sb.Length > 0)
+                    sb.Append('-');
+                pendingHyphen = false;
+                sb.Append(ch);
+            }
+            else if (char.IsWhiteSpace(ch) || ch == '-')
+            {
+                // Defer hyphen until next keepable char; handles runs + leading/trailing
+                if (sb.Length > 0)
+                    pendingHyphen = true;
+            }
+            // else: stripped — not a letter, digit, whitespace, or hyphen
+        }
+
+        return sb.ToString();
+    }
 }

--- a/tests/MarkView.Avalonia.Svg.Tests/SvgImageLoaderTests.cs
+++ b/tests/MarkView.Avalonia.Svg.Tests/SvgImageLoaderTests.cs
@@ -2,6 +2,7 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Avalonia.Headless.XUnit;
+using Avalonia.Svg.Skia;
 using MarkView.Avalonia.Extensions;
 using MarkView.Avalonia.Rendering;
 using Xunit;
@@ -56,6 +57,45 @@ public class SvgImageLoaderTests
         viewer.UseSvg();
         Assert.Single(viewer.Extensions);
         Assert.IsType<SvgExtension>(viewer.Extensions[0]);
+    }
+
+    [AvaloniaFact]
+    public async Task LoadAsync_with_base64_data_uri_returns_SvgImage()
+    {
+        const string svg = """<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>""";
+        var base64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(svg));
+        var dataUri = $"data:image/svg+xml;base64,{base64}";
+
+        var loader = new SvgImageLoader();
+        var result = await loader.LoadAsync(dataUri);
+
+        Assert.NotNull(result);
+        Assert.IsType<SvgImage>(result);
+    }
+
+    [AvaloniaFact]
+    public async Task LoadAsync_with_url_encoded_data_uri_returns_SvgImage()
+    {
+        const string svg = """<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>""";
+        var dataUri = $"data:image/svg+xml,{Uri.EscapeDataString(svg)}";
+
+        var loader = new SvgImageLoader();
+        var result = await loader.LoadAsync(dataUri);
+
+        Assert.NotNull(result);
+        Assert.IsType<SvgImage>(result);
+    }
+
+    [AvaloniaFact]
+    public async Task LoadAsync_with_invalid_svg_data_uri_returns_null()
+    {
+        var base64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("not valid svg"));
+        var dataUri = $"data:image/svg+xml;base64,{base64}";
+
+        var loader = new SvgImageLoader();
+        var result = await loader.LoadAsync(dataUri);
+
+        Assert.Null(result);
     }
 
     private sealed class DummyLoader : IImageLoader


### PR DESCRIPTION
## Summary

- Reduce allocations across the rendering pipeline (two focused commits)
- Add \`LoadAsync\` data URI test coverage for \`SvgImageLoader\` (base64, URL-encoded, and invalid SVG paths)

## Test Plan
- [x] All existing tests pass
- [x] New \`SvgImageLoaderTests\`: \`LoadAsync_with_base64_data_uri_returns_SvgImage\`, \`LoadAsync_with_url_encoded_data_uri_returns_SvgImage\`, \`LoadAsync_with_invalid_svg_data_uri_returns_null\`