### PR TITLE
docs: add READMEs for extension packages and pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+
+<!--
+One bullet per logical change (•). Be specific: class/method names, packages
+affected, behaviour before → after.
+-->
+
+•
+
+## Type of change
+
+<!-- Check all that apply. -->
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Performance improvement
+- [ ] Refactoring (no behaviour change)
+- [ ] Documentation
+- [ ] CI / build
+
+## Test plan
+
+<!--
+Check each item that was verified. Add new lines for any scenario specific to
+this PR. Reference new test names where applicable.
+-->
+
+- [ ] `dotnet test` — all tests pass
+- [ ] Manual smoke-test in the demo app
+
+## Related issues
+
+<!-- Optional. Link with "Closes #N" or "Ref #N". Delete this section if not applicable. -->

--- a/src/MarkView.Avalonia.Mermaid/MarkView.Avalonia.Mermaid.csproj
+++ b/src/MarkView.Avalonia.Mermaid/MarkView.Avalonia.Mermaid.csproj
@@ -5,10 +5,14 @@
     <PackageId>MarkView.Avalonia.Mermaid</PackageId>
     <Description>Mermaid diagram rendering extension for MarkView.Avalonia.</Description>
     <PackageTags>avalonia;markdown;mermaid;diagram</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MarkView.Avalonia\MarkView.Avalonia.csproj" />
     <PackageReference Include="Mermaider" />
     <PackageReference Include="Svg.Controls.Skia.Avalonia" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>

--- a/src/MarkView.Avalonia.Mermaid/README.md
+++ b/src/MarkView.Avalonia.Mermaid/README.md
@@ -1,0 +1,97 @@
+# MarkView.Avalonia.Mermaid
+
+[![NuGet Version](https://img.shields.io/nuget/v/MarkView.Avalonia.Mermaid)](https://www.nuget.org/packages/MarkView.Avalonia.Mermaid)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/MarkView.Avalonia.Mermaid)](https://www.nuget.org/packages/MarkView.Avalonia.Mermaid)
+[![Avalonia](https://img.shields.io/badge/Avalonia-12-blue)](https://avaloniaui.net)
+[![CI](https://github.com/Kryptos-FR/MarkView.Avalonia/actions/workflows/ci.yml/badge.svg)](https://github.com/Kryptos-FR/MarkView.Avalonia/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/Kryptos-FR/MarkView.Avalonia)](../../LICENSE.md)
+
+Mermaid diagram rendering extension for [MarkView.Avalonia](https://www.nuget.org/packages/MarkView.Avalonia). Renders fenced `mermaid` code blocks as vector diagrams using [Mermaider](https://github.com/nullean/mermaider) — a pure managed .NET parser and renderer. No browser, no WebView, and no JavaScript runtime required.
+
+## Installation
+
+```bash
+dotnet add package MarkView.Avalonia.Mermaid
+```
+
+## Quick Start
+
+Call `UseMermaid()` before setting `Markdown`:
+
+```csharp
+var viewer = new MarkdownViewer();
+viewer.UseMermaid();
+viewer.Markdown = markdownText;
+```
+
+Diagrams are written in standard [Mermaid](https://mermaid.js.org) syntax inside a fenced code block:
+
+````markdown
+```mermaid
+graph TD
+  A[Start] --> B{Decision}
+  B -- Yes --> C[End]
+  B -- No  --> A
+```
+````
+
+## Supported Diagram Types
+
+The extension targets the diagram types supported by the referenced Mermaider version, including common diagrams such as:
+
+- Flowcharts (`graph TD`, `flowchart LR`)
+- Sequence diagrams (`sequenceDiagram`)
+- Class diagrams (`classDiagram`)
+- State diagrams (`stateDiagram-v2`)
+- Entity-relationship diagrams (`erDiagram`)
+- Gantt charts (`gantt`)
+- Pie charts (`pie`)
+- Git graphs (`gitGraph`)
+- Mind maps (`mindmap`)
+- Timeline (`timeline`)
+
+See the [Mermaid documentation](https://mermaid.js.org/intro/) for syntax reference. If a diagram fails to render, the extension falls back to a plain-text block containing the original source.
+
+## Theme Awareness
+
+Diagrams are rendered with colours matching the active Avalonia theme variant:
+
+| Variant | Background | Foreground | Accent |
+|---------|-----------|-----------|--------|
+| Dark | `#18181B` | `#FAFAFA` | `#60a5fa` |
+| Light | `#FFFFFF` | `#27272A` | `#3b82f6` |
+
+When the user switches between light and dark, the diagram is automatically re-rendered. The `Border` container stays in place — scroll position is preserved and other document elements are not affected.
+
+## Combining with Syntax Highlighting
+
+When `MarkView.Avalonia.SyntaxHighlighting` is also registered, non-mermaid fenced code blocks in the same document get full syntax highlighting. Registration order does not matter:
+
+```csharp
+viewer
+    .UseTextMateHighlighting()
+    .UseMermaid();
+```
+
+`MermaidBlockRenderer` handles all `FencedCodeBlock` nodes. Mermaid blocks are rendered as diagrams; all other fenced blocks are rendered as styled code blocks using any `ICodeHighlighter` registered by the SyntaxHighlighting extension.
+
+## Platform Notes
+
+Mermaider renders diagrams in managed .NET code (no JavaScript runtime). If diagram rendering fails for any reason, this extension automatically falls back to a plain-text `Border` containing the original Mermaid source.
+
+## How It Works
+
+`UseMermaid()` registers a `MermaidExtension` which inserts `MermaidBlockRenderer` at index 0 of `renderer.ObjectRenderers`. Being first in the renderer list, it intercepts every `FencedCodeBlock` before the default `CodeBlockRenderer`.
+
+For mermaid blocks:
+1. Source lines are extracted from the fenced block.
+2. `MermaidRenderer.RenderSvg` produces an SVG string with Mermaider's CSS custom properties.
+3. CSS variable references (`var(--_text)` etc.) are inlined with computed hex values so SkiaSharp can render the diagram.
+4. The SVG is loaded into an `SvgImage` and displayed in an `Image` control.
+5. `MaxWidth` is constrained to the `ScrollViewer` viewport and updated on resize.
+
+For non-mermaid blocks, rendering is delegated to the standard code block path (with theme-aware in-place `TextBlock.Inlines` rebuild if a `IThemeAwareCodeHighlighter` is registered).
+
+## License
+
+[MIT](../../LICENSE.md) © Nicolas Musset

--- a/src/MarkView.Avalonia.Svg/MarkView.Avalonia.Svg.csproj
+++ b/src/MarkView.Avalonia.Svg/MarkView.Avalonia.Svg.csproj
@@ -5,11 +5,15 @@
     <PackageId>MarkView.Avalonia.Svg</PackageId>
     <Description>SVG image rendering extension for MarkView.Avalonia.</Description>
     <PackageTags>avalonia;markdown;svg</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Svg.Controls.Skia.Avalonia" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MarkView.Avalonia\MarkView.Avalonia.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>

--- a/src/MarkView.Avalonia.Svg/README.md
+++ b/src/MarkView.Avalonia.Svg/README.md
@@ -1,0 +1,93 @@
+# MarkView.Avalonia.Svg
+
+[![NuGet Version](https://img.shields.io/nuget/v/MarkView.Avalonia.Svg)](https://www.nuget.org/packages/MarkView.Avalonia.Svg)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/MarkView.Avalonia.Svg)](https://www.nuget.org/packages/MarkView.Avalonia.Svg)
+[![Avalonia](https://img.shields.io/badge/Avalonia-12-blue)](https://avaloniaui.net)
+[![CI](https://github.com/Kryptos-FR/MarkView.Avalonia/actions/workflows/ci.yml/badge.svg)](https://github.com/Kryptos-FR/MarkView.Avalonia/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/Kryptos-FR/MarkView.Avalonia)](../../LICENSE.md)
+
+SVG image rendering extension for [MarkView.Avalonia](https://www.nuget.org/packages/MarkView.Avalonia). Renders SVG files referenced in markdown images using [Svg.Skia](https://github.com/wieslawsoltes/Svg.Skia) — the same backend that Avalonia itself uses for vector icons.
+
+## Installation
+
+```bash
+dotnet add package MarkView.Avalonia.Svg
+```
+
+## Quick Start
+
+Call `UseSvg()` before setting `Markdown`:
+
+```csharp
+var viewer = new MarkdownViewer();
+viewer.UseSvg();
+viewer.Markdown = markdownText;
+```
+
+Markdown syntax is unchanged — standard image syntax with an `.svg` URL:
+
+```markdown
+![Logo](https://example.com/logo.svg)
+![Badge](https://shields.io/badge/build-passing-green)
+![Inline](data:image/svg+xml;base64,PHN2Zy8+)
+```
+
+## Supported URL Formats
+
+| URL form | Handled by |
+|----------|-----------|
+| `https://example.com/icon.svg` | HTTP download, SVG parse |
+| `relative/path/icon.svg` (with `BaseUri` set) | Resolved first; handled if the resolved URL is supported by `SvgImageLoader` |
+| Any `https://` / `http://` URL | Attempted speculatively; returns `null` if response is not valid SVG, letting the bitmap fallback load it |
+| `data:image/svg+xml;base64,…` | Base64 decode, SVG parse |
+| `data:image/svg+xml,…` | URL-decode, SVG parse |
+| `data:image/png;base64,…` | Not handled — passed to the next loader |
+
+The speculative HTTP/HTTPS rule means badge services like `shields.io` that return SVG without a `.svg` extension are handled transparently.
+
+When using relative image paths, set `MarkdownViewer.BaseUri` to an HTTP/HTTPS base URL if you want this extension to fetch and parse those images as SVG.
+
+## How It Works
+
+`UseSvg()` registers a `SvgExtension` which inserts `SvgImageLoader` at index 0 of `renderer.ImageLoaders`. Being first in the chain, it gets first pick on every image URL. If `CanLoad` returns `false` (e.g. a `data:image/png` URI), or if `LoadAsync` returns `null` (e.g. the HTTP response is not valid SVG), the next loader in the chain is tried.
+
+Loading is asynchronous. The `Image` control is placed in the visual tree immediately; the SVG source is set once the download and parse complete. `SvgImage` is an `AvaloniaObject` and is created on the UI thread via `Dispatcher.UIThread`.
+
+## Writing a Custom Image Loader
+
+Implement `IImageLoader` from the core package to handle any image source:
+
+```csharp
+using MarkView.Avalonia.Extensions;
+
+public class MyLoader : IImageLoader
+{
+    public bool CanLoad(string url) => url.StartsWith("myscheme://");
+
+    public async Task<IImage?> LoadAsync(string url, CancellationToken ct = default)
+    {
+        // Return null to fall through to the next loader
+        var bitmap = await FetchBitmapAsync(url, ct);
+        return bitmap;
+    }
+}
+
+// Insert at 0 to take priority, or Add() to run after built-in loaders
+renderer.ImageLoaders.Insert(0, new MyLoader());
+```
+
+Or register via a `IMarkViewExtension`:
+
+```csharp
+public class MyExtension : IMarkViewExtension
+{
+    public void Register(AvaloniaRenderer renderer)
+        => renderer.ImageLoaders.Insert(0, new MyLoader());
+}
+
+viewer.Extensions.Add(new MyExtension());
+```
+
+## License
+
+[MIT](../../LICENSE.md) © Nicolas Musset

--- a/src/MarkView.Avalonia.SyntaxHighlighting/MarkView.Avalonia.SyntaxHighlighting.csproj
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/MarkView.Avalonia.SyntaxHighlighting.csproj
@@ -5,6 +5,7 @@
     <PackageId>MarkView.Avalonia.SyntaxHighlighting</PackageId>
     <Description>TextMate syntax highlighting extension for MarkView.Avalonia.</Description>
     <PackageTags>avalonia;markdown;syntax-highlighting;textmate</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="TextMateSharp" />
@@ -12,5 +13,8 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MarkView.Avalonia\MarkView.Avalonia.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>

--- a/src/MarkView.Avalonia.SyntaxHighlighting/README.md
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/README.md
@@ -1,0 +1,124 @@
+# MarkView.Avalonia.SyntaxHighlighting
+
+[![NuGet Version](https://img.shields.io/nuget/v/MarkView.Avalonia.SyntaxHighlighting)](https://www.nuget.org/packages/MarkView.Avalonia.SyntaxHighlighting)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/MarkView.Avalonia.SyntaxHighlighting)](https://www.nuget.org/packages/MarkView.Avalonia.SyntaxHighlighting)
+[![Avalonia](https://img.shields.io/badge/Avalonia-12-blue)](https://avaloniaui.net)
+[![CI](https://github.com/Kryptos-FR/MarkView.Avalonia/actions/workflows/ci.yml/badge.svg)](https://github.com/Kryptos-FR/MarkView.Avalonia/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/Kryptos-FR/MarkView.Avalonia)](../../LICENSE.md)
+
+TextMate grammar-based syntax highlighting for [MarkView.Avalonia](https://www.nuget.org/packages/MarkView.Avalonia) fenced code blocks. Colours update in-place when the user switches between light and dark themes — no document rebuild or scroll reset.
+
+## Installation
+
+```bash
+dotnet add package MarkView.Avalonia.SyntaxHighlighting
+```
+
+## Quick Start
+
+Call `UseTextMateHighlighting()` before setting `Markdown`:
+
+```csharp
+var viewer = new MarkdownViewer();
+viewer.UseTextMateHighlighting();
+viewer.Markdown = markdownText;
+```
+
+By default, `DarkPlus` is used for dark themes and `LightPlus` for light themes. Both highlighters are created lazily — only the one matching the active variant is loaded at startup.
+
+## Theme Selection
+
+Pass explicit `ThemeName` values to override the defaults:
+
+```csharp
+using TextMateSharp.Grammars;
+
+viewer.UseTextMateHighlighting(
+    darkTheme:  ThemeName.Monokai,
+    lightTheme: ThemeName.QuietLight);
+```
+
+Available themes (from `TextMateSharp.Grammars.ThemeName`):
+
+| Dark | Light |
+|------|-------|
+| `DarkPlus` | `LightPlus` |
+| `Monokai` | `QuietLight` |
+| `SolarizedDark` | `SolarizedLight` |
+| `TomorrowNightBlue` | `Abyss` |
+| `HighContrastLight` | `HighContrastLight` |
+| `KimbieDark` | — |
+
+## How It Works
+
+`UseTextMateHighlighting()` registers a `TextMateExtension` which:
+
+1. Creates a `DualThemeTextMateHighlighter` wrapping two `TextMateHighlighter` instances (one per variant).
+2. Replaces the built-in `CodeBlockRenderer` with `TextMateCodeBlockRenderer`.
+
+At render time, each line is tokenised via `IGrammar.TokenizeLine` and emitted as coloured `Run` elements inside a `TextBlock`. Grammars are cached per language per highlighter instance.
+
+When the user switches between light and dark themes, only `TextBlock.Inlines` is rebuilt — the surrounding `Border` and the rest of the document are untouched. Images stay loaded, scroll position is preserved, and Mermaid diagrams are not retriggered.
+
+Languages not supported by the grammar registry fall back to the default monochrome rendering automatically.
+
+## Low-Level API
+
+Use `TextMateExtension` directly for full control:
+
+```csharp
+using MarkView.Avalonia.SyntaxHighlighting;
+using MarkView.Avalonia.Rendering;
+using TextMateSharp.Grammars;
+
+var renderer = new AvaloniaRenderer();
+new TextMateExtension(ThemeName.Monokai, ThemeName.QuietLight).Register(renderer);
+```
+
+Or supply a `TextMateHighlighter` as a standalone `ICodeHighlighter` (for use outside `MarkdownViewer`):
+
+```csharp
+var highlighter = new TextMateHighlighter(ThemeName.DarkPlus);
+var tokens = highlighter.Highlight("var x = 1;", "csharp");
+```
+
+## Implementing a Custom Highlighter
+
+Any `ICodeHighlighter` from the core package can be used instead:
+
+```csharp
+using Avalonia.Media;
+using MarkView.Avalonia.Extensions;
+
+public class MyHighlighter : ICodeHighlighter
+{
+    public IReadOnlyList<(string Text, IBrush? Foreground)>? Highlight(string line, string? language)
+    {
+        // return null to fall back to monochrome rendering
+        return null;
+    }
+}
+
+renderer.CodeHighlighter = new MyHighlighter();
+```
+
+For automatic dark/light updates without a document rebuild, implement `IThemeAwareCodeHighlighter` instead:
+
+```csharp
+public class MyHighlighter : IThemeAwareCodeHighlighter
+{
+    public IReadOnlyList<(string Text, IBrush? Foreground)>? Highlight(string line, string? language)
+        => HighlightVariant(line, language, isDark: false);
+
+    public IReadOnlyList<(string Text, IBrush? Foreground)>? HighlightVariant(
+        string line, string? language, bool isDark)
+    {
+        // return coloured tokens for the requested variant
+        return null;
+    }
+}
+```
+
+## License
+
+[MIT](../../LICENSE.md) © Nicolas Musset


### PR DESCRIPTION
## Summary

- Add `README.md` to each extension package (`MarkView.Avalonia.SyntaxHighlighting`, `MarkView.Avalonia.Svg`, `MarkView.Avalonia.Mermaid`): installation, quick start, supported features, how-it-works, and low-level API sections
- Align extension READMEs with core package style: Avalonia + CI badges, consistent section order and wording
- Correct Mermaider repository link and runtime description (pure .NET, no JavaScript runtime) to match upstream docs
- Add accurate `BaseUri` / relative URL note to the SVG README
- Add missing `using` directives to SyntaxHighlighting low-level API code snippets
- Add `.github/PULL_REQUEST_TEMPLATE.md` inferred from previous PR patterns

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [x] Documentation
- [ ] CI / build

## Test plan

- [x] `dotnet test` -- all tests pass
- [x] Manual smoke-test in the demo app

## Related issues

N/A
