### PR TITLE
feat: global defaults, routed LinkClicked, and opt-in extension helpers

### DIFF
--- a/samples/MarkView.Avalonia.Demo/App.axaml.cs
+++ b/samples/MarkView.Avalonia.Demo/App.axaml.cs
@@ -1,6 +1,10 @@
+using System.Diagnostics;
+
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+
+using Markdig;
 
 namespace MarkView.Avalonia.Demo;
 
@@ -13,6 +17,34 @@ public class App : Application
 
     public override void OnFrameworkInitializationCompleted()
     {
+        // Global pipeline — applies to every MarkdownViewer in the app
+        MarkdownViewerDefaults.Pipeline = new MarkdownPipelineBuilder()
+            .UseSupportedExtensions()
+            .UseFootnotes()
+            .UseAlertBlocks()
+            .UseAbbreviations()
+            .UseFigures()
+            .UseMediaLinks()
+            .Build();
+
+        // Global extensions — applies to every MarkdownViewer in the app
+        MarkdownViewerDefaults.Extensions.AddTextMateHighlighting();
+        MarkdownViewerDefaults.Extensions.AddSvg();
+        MarkdownViewerDefaults.Extensions.AddMermaid();
+
+        // Global link handler — handles external links for every MarkdownViewer in the app
+        MarkdownViewer.LinkClickedEvent.AddClassHandler<MarkdownViewer>((_, e) =>
+        {
+            try
+            {
+                Process.Start(new ProcessStartInfo(e.Url) { UseShellExecute = true });
+            }
+            catch
+            {
+                // Ignore failures to open browser
+            }
+        });
+
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
             desktop.MainWindow = new MainWindow();

--- a/samples/MarkView.Avalonia.Demo/MainViewModel.cs
+++ b/samples/MarkView.Avalonia.Demo/MainViewModel.cs
@@ -169,11 +169,89 @@ public sealed class MainViewModel : INotifyPropertyChanged
         *End of showcase.*
         """;
 
+    private const string ExtensionsShowcaseMarkdown = """
+        # Opt-In Extensions Showcase
+
+        This page demonstrates the five opt-in extensions added to MarkView.Avalonia.
+        All are activated via a combined pipeline in this demo.
+
+        ---
+
+        ## Footnotes
+
+        The CommonMark spec does not define footnotes, but Markdig supports them.[^1]
+        You can reference the same note multiple times.[^1]
+        Or add a second footnote.[^2]
+
+        [^1]: This is the first footnote definition. It can contain **formatted** text.
+        [^2]: This is the second footnote definition.
+
+        ---
+
+        ## Alert Blocks
+
+        GitHub-style alert blocks use `> [!KIND]` syntax:
+
+        > [!NOTE]
+        > The NOTE alert is used for supplementary information.
+
+        > [!TIP]
+        > The TIP alert highlights useful advice and best practices.
+
+        > [!IMPORTANT]
+        > The IMPORTANT alert highlights key information required for success.
+
+        > [!WARNING]
+        > The WARNING alert indicates potential issues that could cause problems.
+
+        > [!CAUTION]
+        > The CAUTION alert advises about risks or negative consequences.
+
+        ---
+
+        ## Abbreviations
+
+        Define abbreviations once; every occurrence in the document gets a tooltip automatically.
+
+        HTML and CSS are the building blocks of the web. The W3C maintains their specifications.
+        API stands for Application Programming Interface. JSON is a common data format.
+
+        *[HTML]: HyperText Markup Language
+        *[CSS]: Cascading Style Sheets
+        *[W3C]: World Wide Web Consortium
+        *[API]: Application Programming Interface
+        *[JSON]: JavaScript Object Notation
+
+        ---
+
+        ## Figures
+
+        Figures wrap block content in a borderd, centred container with an optional caption:
+
+        ^^^
+        ![Avalonia Logo](avares://MarkView.Avalonia.Demo/Assets/avalonia-logo.png =80x80)
+
+        ^^^ **Figure 1** — The Avalonia UI logo (embedded avares:// resource).
+
+        ---
+
+        ## YouTube Thumbnail Embed
+
+        UseMediaLinks turns image-syntax YouTube links into clickable thumbnails.
+        Click the thumbnail below to open the video in your browser:
+
+        ![Rick Astley — Never Gonna Give You Up](https://www.youtube.com/watch?v=dQw4w9WgXcQ)
+
+        Short URLs are also supported:
+
+        ![Big Buck Bunny trailer](https://youtu.be/aqz-KE-bpKQ)
+        """;
+
     private string? _markdown;
     private int _selectedIndex;
     private bool _isLightTheme;
 
-    public string[] Views { get; } = ["Feature Showcase", "README"];
+    public string[] Views { get; } = ["Feature Showcase", "Extensions Showcase", "README"];
 
     public int SelectedIndex
     {
@@ -208,7 +286,12 @@ public sealed class MainViewModel : INotifyPropertyChanged
 
     private void LoadContent()
     {
-        Markdown = _selectedIndex == 0 ? ShowcaseMarkdown : ReadmeMarkdown;
+        Markdown = _selectedIndex switch
+        {
+            0 => ShowcaseMarkdown,
+            1 => ExtensionsShowcaseMarkdown,
+            _ => ReadmeMarkdown,
+        };
     }
 
     private static string LoadReadme()

--- a/samples/MarkView.Avalonia.Demo/MainWindow.axaml.cs
+++ b/samples/MarkView.Avalonia.Demo/MainWindow.axaml.cs
@@ -1,7 +1,4 @@
-using System.Diagnostics;
-
 using Avalonia.Controls;
-using Markdig;
 
 namespace MarkView.Avalonia.Demo;
 
@@ -10,35 +7,6 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
-
-        // Combine all opt-in Markdig extensions into one pipeline
-        MarkdownView.Pipeline = new MarkdownPipelineBuilder()
-            .UseSupportedExtensions()
-            .UseFootnotes()
-            .UseAlertBlocks()
-            .UseAbbreviations()
-            .UseFigures()
-            .UseMediaLinks()
-            .Build();
-
-        MarkdownView.UseTextMateHighlighting()
-                    .UseSvg()
-                    .UseMermaid();
-
         DataContext = new MainViewModel();
-
-        MarkdownView.LinkClicked += OnLinkClicked;
-    }
-
-    private void OnLinkClicked(object? sender, MarkView.Avalonia.Rendering.LinkClickedEventArgs e)
-    {
-        try
-        {
-            Process.Start(new ProcessStartInfo(e.Url) { UseShellExecute = true });
-        }
-        catch
-        {
-            // Ignore failures to open browser
-        }
     }
 }

--- a/samples/MarkView.Avalonia.Demo/MainWindow.axaml.cs
+++ b/samples/MarkView.Avalonia.Demo/MainWindow.axaml.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 
 using Avalonia.Controls;
+using Markdig;
 
 namespace MarkView.Avalonia.Demo;
 
@@ -9,6 +10,16 @@ public partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+
+        // Combine all opt-in Markdig extensions into one pipeline
+        MarkdownView.Pipeline = new MarkdownPipelineBuilder()
+            .UseSupportedExtensions()
+            .UseFootnotes()
+            .UseAlertBlocks()
+            .UseAbbreviations()
+            .UseFigures()
+            .UseMediaLinks()
+            .Build();
 
         MarkdownView.UseTextMateHighlighting()
                     .UseSvg()

--- a/src/MarkView.Avalonia.Mermaid/MarkdownViewerExtensions.cs
+++ b/src/MarkView.Avalonia.Mermaid/MarkdownViewerExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Nicolas Musset
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using MarkView.Avalonia.Extensions;
+
 namespace MarkView.Avalonia;
 
 /// <summary>
@@ -9,12 +11,28 @@ namespace MarkView.Avalonia;
 public static class MarkdownViewerMermaidExtensions
 {
     /// <summary>
+    /// Adds <see cref="Mermaid.MermaidExtension"/> to the extension list.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// // Global (App.axaml.cs)
+    /// MarkdownViewerDefaults.Extensions.AddMermaid();
+    /// // Per-instance
+    /// viewer.Extensions.AddMermaid();
+    /// </code>
+    /// </example>
+    public static void AddMermaid(this IList<IMarkViewExtension> extensions)
+    {
+        extensions.Add(new Mermaid.MermaidExtension());
+    }
+
+    /// <summary>
     /// Adds <see cref="Mermaid.MermaidExtension"/> to the viewer's
     /// <see cref="MarkdownViewer.Extensions"/> list.
     /// </summary>
     public static MarkdownViewer UseMermaid(this MarkdownViewer viewer)
     {
-        viewer.Extensions.Add(new Mermaid.MermaidExtension());
+        viewer.Extensions.AddMermaid();
         return viewer;
     }
 }

--- a/src/MarkView.Avalonia.Svg/MarkdownViewerExtensions.cs
+++ b/src/MarkView.Avalonia.Svg/MarkdownViewerExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Nicolas Musset
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using MarkView.Avalonia.Extensions;
+
 namespace MarkView.Avalonia;
 
 /// <summary>
@@ -9,12 +11,28 @@ namespace MarkView.Avalonia;
 public static class MarkdownViewerSvgExtensions
 {
     /// <summary>
+    /// Adds <see cref="Svg.SvgExtension"/> to the extension list.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// // Global (App.axaml.cs)
+    /// MarkdownViewerDefaults.Extensions.AddSvg();
+    /// // Per-instance
+    /// viewer.Extensions.AddSvg();
+    /// </code>
+    /// </example>
+    public static void AddSvg(this IList<IMarkViewExtension> extensions)
+    {
+        extensions.Add(new Svg.SvgExtension());
+    }
+
+    /// <summary>
     /// Adds <see cref="Svg.SvgExtension"/> to the viewer's
     /// <see cref="MarkdownViewer.Extensions"/> list.
     /// </summary>
     public static MarkdownViewer UseSvg(this MarkdownViewer viewer)
     {
-        viewer.Extensions.Add(new Svg.SvgExtension());
+        viewer.Extensions.AddSvg();
         return viewer;
     }
 }

--- a/src/MarkView.Avalonia.SyntaxHighlighting/MarkdownViewerExtensions.cs
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/MarkdownViewerExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Nicolas Musset
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using MarkView.Avalonia.Extensions;
 using TextMateSharp.Grammars;
 
 namespace MarkView.Avalonia;
@@ -10,6 +11,26 @@ namespace MarkView.Avalonia;
 /// </summary>
 public static class MarkdownViewerSyntaxHighlightingExtensions
 {
+    /// <summary>
+    /// Adds <see cref="SyntaxHighlighting.TextMateExtension"/> to the extension list.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// // Global (App.axaml.cs)
+    /// MarkdownViewerDefaults.Extensions.AddTextMateHighlighting();
+    /// // Per-instance
+    /// viewer.Extensions.AddTextMateHighlighting();
+    /// </code>
+    /// </example>
+    public static void AddTextMateHighlighting(
+        this IList<IMarkViewExtension> extensions,
+        ThemeName darkTheme = ThemeName.DarkPlus,
+        ThemeName lightTheme = ThemeName.LightPlus)
+    {
+        extensions.Add(
+            new SyntaxHighlighting.TextMateExtension(darkTheme, lightTheme));
+    }
+
     /// <summary>
     /// Adds <see cref="SyntaxHighlighting.TextMateExtension"/> to the viewer's
     /// <see cref="MarkdownViewer.Extensions"/> list.
@@ -21,7 +42,7 @@ public static class MarkdownViewerSyntaxHighlightingExtensions
         ThemeName darkTheme = ThemeName.DarkPlus,
         ThemeName lightTheme = ThemeName.LightPlus)
     {
-        viewer.Extensions.Add(new SyntaxHighlighting.TextMateExtension(darkTheme, lightTheme));
+        viewer.Extensions.AddTextMateHighlighting(darkTheme, lightTheme);
         return viewer;
     }
 }

--- a/src/MarkView.Avalonia/Extensions/BitmapImageLoader.cs
+++ b/src/MarkView.Avalonia/Extensions/BitmapImageLoader.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform;
+
+namespace MarkView.Avalonia.Extensions;
+
+/// <summary>
+/// Default image loader for bitmap formats (PNG, JPEG, GIF, BMP, WebP, …).
+/// Handles <c>avares://</c> embedded resources, <c>http/https</c> URLs, and
+/// <c>data:image/…;base64,…</c> data URIs.
+/// Registered last in <see cref="Rendering.AvaloniaRenderer.ImageLoaders"/> so that
+/// specialised loaders (e.g. SVG) take priority.
+/// </summary>
+internal sealed class BitmapImageLoader : IImageLoader
+{
+    private static readonly HttpClient HttpClient = new();
+
+    public bool CanLoad(string url)
+    {
+        if (string.IsNullOrEmpty(url)) return false;
+
+        if (url.StartsWith("avares://", StringComparison.OrdinalIgnoreCase)) return true;
+
+        if (url.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase)) return true;
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps;
+
+        return false;
+    }
+
+    public async Task<IImage?> LoadAsync(string url, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (url.StartsWith("data:image/", StringComparison.OrdinalIgnoreCase))
+            {
+                var bytes = DecodeDataUri(url);
+                using var ms = new MemoryStream(bytes);
+                return new Bitmap(ms);
+            }
+
+            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+                return null;
+
+            if (uri.Scheme == "avares")
+            {
+                using var stream = AssetLoader.Open(uri);
+                return new Bitmap(stream);
+            }
+
+            using var responseStream = await HttpClient.GetStreamAsync(uri, cancellationToken);
+            using var buffer = new MemoryStream();
+            await responseStream.CopyToAsync(buffer, cancellationToken);
+            buffer.Position = 0;
+            return new Bitmap(buffer);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (HttpRequestException) { return null; }
+        catch (IOException) { return null; }
+    }
+
+    private static byte[] DecodeDataUri(string dataUri)
+    {
+        var commaIndex = dataUri.IndexOf(',');
+        if (commaIndex < 0) return [];
+
+        if (dataUri.AsSpan(0, commaIndex).EndsWith(";base64", StringComparison.OrdinalIgnoreCase))
+            return Convert.FromBase64String(dataUri[(commaIndex + 1)..]);
+
+        var decoded = Uri.UnescapeDataString(dataUri[(commaIndex + 1)..]);
+        return System.Text.Encoding.UTF8.GetBytes(decoded);
+    }
+}

--- a/src/MarkView.Avalonia/MarkdownExtensions.cs
+++ b/src/MarkView.Avalonia/MarkdownExtensions.cs
@@ -49,4 +49,13 @@ public static class MarkdownExtensions
     {
         return builder.Use<Markdig.Extensions.Abbreviations.AbbreviationExtension>();
     }
+
+    /// <summary>
+    /// Enables Markdig figure block parsing (^^^ fences with optional caption).
+    /// Activate on the viewer with <c>viewer.UseFigures()</c>.
+    /// </summary>
+    public static MarkdownPipelineBuilder UseFigures(this MarkdownPipelineBuilder builder)
+    {
+        return builder.Use<Markdig.Extensions.Figures.FigureExtension>();
+    }
 }

--- a/src/MarkView.Avalonia/MarkdownExtensions.cs
+++ b/src/MarkView.Avalonia/MarkdownExtensions.cs
@@ -40,4 +40,13 @@ public static class MarkdownExtensions
     {
         return builder.Use<Markdig.Extensions.Alerts.AlertExtension>();
     }
+
+    /// <summary>
+    /// Enables Markdig abbreviation parsing. Matched words gain tooltip definitions.
+    /// Activate on the viewer with <c>viewer.UseAbbreviations()</c>.
+    /// </summary>
+    public static MarkdownPipelineBuilder UseAbbreviations(this MarkdownPipelineBuilder builder)
+    {
+        return builder.Use<Markdig.Extensions.Abbreviations.AbbreviationExtension>();
+    }
 }

--- a/src/MarkView.Avalonia/MarkdownExtensions.cs
+++ b/src/MarkView.Avalonia/MarkdownExtensions.cs
@@ -31,4 +31,13 @@ public static class MarkdownExtensions
     {
         return builder.Use<Markdig.Extensions.Footnotes.FootnoteExtension>();
     }
+
+    /// <summary>
+    /// Enables Markdig GitHub-style alert block parsing (NOTE, WARNING, TIP, IMPORTANT, CAUTION).
+    /// Activate on the viewer with <c>viewer.UseAlertBlocks()</c>.
+    /// </summary>
+    public static MarkdownPipelineBuilder UseAlertBlocks(this MarkdownPipelineBuilder builder)
+    {
+        return builder.Use<Markdig.Extensions.Alerts.AlertExtension>();
+    }
 }

--- a/src/MarkView.Avalonia/MarkdownExtensions.cs
+++ b/src/MarkView.Avalonia/MarkdownExtensions.cs
@@ -58,4 +58,13 @@ public static class MarkdownExtensions
     {
         return builder.Use<Markdig.Extensions.Figures.FigureExtension>();
     }
+
+    /// <summary>
+    /// Enables Markdig media link parsing. YouTube image-syntax links are rendered
+    /// as clickable thumbnail embeds. Activate on the viewer with <c>viewer.UseMediaLinks()</c>.
+    /// </summary>
+    public static MarkdownPipelineBuilder UseMediaLinks(this MarkdownPipelineBuilder builder)
+    {
+        return builder.Use<Markdig.Extensions.MediaLinks.MediaLinkExtension>();
+    }
 }

--- a/src/MarkView.Avalonia/MarkdownExtensions.cs
+++ b/src/MarkView.Avalonia/MarkdownExtensions.cs
@@ -22,4 +22,13 @@ public static class MarkdownExtensions
             .UsePipeTables()
             .UseTaskLists();
     }
+
+    /// <summary>
+    /// Enables Markdig footnote parsing for use with MarkView.Avalonia's footnote renderers.
+    /// Activate on the viewer with <c>viewer.UseFootnotes()</c>.
+    /// </summary>
+    public static MarkdownPipelineBuilder UseFootnotes(this MarkdownPipelineBuilder builder)
+    {
+        return builder.Use<Markdig.Extensions.Footnotes.FootnoteExtension>();
+    }
 }

--- a/src/MarkView.Avalonia/MarkdownViewer.cs
+++ b/src/MarkView.Avalonia/MarkdownViewer.cs
@@ -87,7 +87,7 @@ public partial class MarkdownViewer : ContentControl
     /// a new <see cref="Pipeline"/>; each extension's
     /// <see cref="IMarkViewExtension.Register"/> is called once per render.
     /// </summary>
-    public IList<IMarkViewExtension> Extensions { get; } = new List<IMarkViewExtension>();
+    public IList<IMarkViewExtension> Extensions { get; } = [];
 
     /// <summary>
     /// Raised when a hyperlink in the rendered markdown is clicked.
@@ -260,7 +260,7 @@ public partial class MarkdownViewer : ContentControl
             int row = Grid.GetRow(cell);
             int col = Grid.GetColumn(cell);
             if (!rowMap.TryGetValue(row, out var cols))
-                rowMap[row] = cols = new SortedDictionary<int, Border>();
+                rowMap[row] = cols = [];
             cols[col] = cell;
         }
 

--- a/src/MarkView.Avalonia/MarkdownViewer.cs
+++ b/src/MarkView.Avalonia/MarkdownViewer.cs
@@ -90,9 +90,22 @@ public partial class MarkdownViewer : ContentControl
     public IList<IMarkViewExtension> Extensions { get; } = [];
 
     /// <summary>
-    /// Raised when a hyperlink in the rendered markdown is clicked.
+    /// Identifies the <see cref="LinkClicked"/> routed event.
     /// </summary>
-    public event EventHandler<LinkClickedEventArgs>? LinkClicked;
+    public static readonly RoutedEvent<LinkClickedEventArgs> LinkClickedEvent =
+        RoutedEvent.Register<MarkdownViewer, LinkClickedEventArgs>(
+            nameof(LinkClicked), RoutingStrategies.Bubble);
+
+    /// <summary>
+    /// Raised when a hyperlink in the rendered markdown is clicked.
+    /// Bubbles up the visual tree; subscribe globally with
+    /// <c>MarkdownViewer.LinkClickedEvent.AddClassHandler&lt;MarkdownViewer&gt;(...)</c>.
+    /// </summary>
+    public event EventHandler<LinkClickedEventArgs>? LinkClicked
+    {
+        add => AddHandler(LinkClickedEvent, value);
+        remove => RemoveHandler(LinkClickedEvent, value);
+    }
 
     static MarkdownViewer()
     {
@@ -442,7 +455,8 @@ public partial class MarkdownViewer : ContentControl
             ScrollToAnchor(e.Url[1..]);
             return;
         }
-        LinkClicked?.Invoke(this, e);
+        e.RoutedEvent = LinkClickedEvent;
+        RaiseEvent(e);
     }
 
     private void ScrollToAnchor(string anchorId)

--- a/src/MarkView.Avalonia/MarkdownViewer.cs
+++ b/src/MarkView.Avalonia/MarkdownViewer.cs
@@ -112,16 +112,27 @@ public partial class MarkdownViewer : ContentControl
             return;
         }
 
-        var pipeline = Pipeline ?? DefaultPipeline;
+        var pipeline = Pipeline ?? MarkdownViewerDefaults.Pipeline ?? DefaultPipeline;
         var markdownText = ImageSizePreprocessorRegex().Replace(Markdown, "$1$2 \"=$3\"$4");
         var document = Markdig.Markdown.Parse(markdownText, pipeline);
 
         var renderer = new AvaloniaRenderer { BaseUri = BaseUri };
         renderer.LinkClicked += OnLinkClicked;
 
-        // Extensions register before pipeline.Setup() so they can swap renderers
+        // Extensions register before pipeline.Setup() so they can swap renderers.
+        // Globals first, then per-instance; skip exact-reference duplicates.
+        var seen = new HashSet<IMarkViewExtension>(ReferenceEqualityComparer.Instance);
+
+        foreach (var ext in MarkdownViewerDefaults.Extensions)
+        {
+            if (seen.Add(ext))
+                ext.Register(renderer);
+        }
         foreach (var ext in Extensions)
-            ext.Register(renderer);
+        {
+            if (seen.Add(ext))
+                ext.Register(renderer);
+        }
 
         pipeline.Setup(renderer);
         renderer.Render(document);

--- a/src/MarkView.Avalonia/MarkdownViewerDefaults.cs
+++ b/src/MarkView.Avalonia/MarkdownViewerDefaults.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Markdig;
+
+using MarkView.Avalonia.Extensions;
+
+namespace MarkView.Avalonia;
+
+/// <summary>
+/// Application-wide defaults applied to every <see cref="MarkdownViewer"/> render pass.
+/// Set these once at startup (e.g. in <c>App.axaml.cs OnFrameworkInitializationCompleted</c>).
+/// </summary>
+/// <example>
+/// <code>
+/// // App.axaml.cs
+/// MarkdownViewerDefaults.Pipeline = new MarkdownPipelineBuilder()
+///     .UseSupportedExtensions()
+///     .UseAlertBlocks()
+///     .Build();
+/// MarkdownViewerDefaults.Extensions.Add(new SyntaxHighlightingExtension(theme));
+/// </code>
+/// </example>
+public static class MarkdownViewerDefaults
+{
+    /// <summary>
+    /// Global pipeline used by all <see cref="MarkdownViewer"/> instances that do not set their own
+    /// <see cref="MarkdownViewer.Pipeline"/>. If <see langword="null"/>, the built-in default
+    /// pipeline (<c>UseSupportedExtensions</c>) is used.
+    /// </summary>
+    public static MarkdownPipeline? Pipeline { get; set; }
+
+    /// <summary>
+    /// Extensions applied to every <see cref="MarkdownViewer"/> render pass, before per-instance
+    /// extensions. The same extension object must not appear in both this list and an instance's
+    /// <see cref="MarkdownViewer.Extensions"/> list; duplicate references are silently skipped.
+    /// </summary>
+    public static IList<IMarkViewExtension> Extensions { get; } = new List<IMarkViewExtension>();
+}

--- a/src/MarkView.Avalonia/MarkdownViewerDefaults.cs
+++ b/src/MarkView.Avalonia/MarkdownViewerDefaults.cs
@@ -35,5 +35,5 @@ public static class MarkdownViewerDefaults
     /// extensions. The same extension object must not appear in both this list and an instance's
     /// <see cref="MarkdownViewer.Extensions"/> list; duplicate references are silently skipped.
     /// </summary>
-    public static IList<IMarkViewExtension> Extensions { get; } = new List<IMarkViewExtension>();
+    public static IList<IMarkViewExtension> Extensions { get; } = [];
 }

--- a/src/MarkView.Avalonia/MarkdownViewerExtensions.cs
+++ b/src/MarkView.Avalonia/MarkdownViewerExtensions.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Markdig;
+
+namespace MarkView.Avalonia;
+
+/// <summary>
+/// Convenience extension methods for enabling opt-in Markdig features on a <see cref="MarkdownViewer"/>.
+/// Each method rebuilds the pipeline from <see cref="MarkdownExtensions.UseSupportedExtensions"/>
+/// plus the requested feature. To combine multiple opt-in features, build the pipeline explicitly:
+/// <code>
+/// viewer.Pipeline = new MarkdownPipelineBuilder()
+///     .UseSupportedExtensions()
+///     .UseFootnotes()
+///     .UseAlertBlocks()
+///     .Build();
+/// </code>
+/// </summary>
+public static class MarkdownViewerExtensions
+{
+    /// <summary>
+    /// Enables footnote rendering on the viewer.
+    /// </summary>
+    public static MarkdownViewer UseFootnotes(this MarkdownViewer viewer)
+    {
+        viewer.Pipeline = new MarkdownPipelineBuilder()
+            .UseSupportedExtensions()
+            .UseFootnotes()
+            .Build();
+        return viewer;
+    }
+
+    /// <summary>
+    /// Enables GitHub-style alert block rendering on the viewer.
+    /// </summary>
+    public static MarkdownViewer UseAlertBlocks(this MarkdownViewer viewer)
+    {
+        viewer.Pipeline = new MarkdownPipelineBuilder()
+            .UseSupportedExtensions()
+            .UseAlertBlocks()
+            .Build();
+        return viewer;
+    }
+
+    /// <summary>
+    /// Enables abbreviation tooltip rendering on the viewer.
+    /// </summary>
+    public static MarkdownViewer UseAbbreviations(this MarkdownViewer viewer)
+    {
+        viewer.Pipeline = new MarkdownPipelineBuilder()
+            .UseSupportedExtensions()
+            .UseAbbreviations()
+            .Build();
+        return viewer;
+    }
+
+    /// <summary>
+    /// Enables figure block rendering on the viewer.
+    /// </summary>
+    public static MarkdownViewer UseFigures(this MarkdownViewer viewer)
+    {
+        viewer.Pipeline = new MarkdownPipelineBuilder()
+            .UseSupportedExtensions()
+            .UseFigures()
+            .Build();
+        return viewer;
+    }
+
+    /// <summary>
+    /// Enables YouTube thumbnail embed rendering on the viewer.
+    /// </summary>
+    public static MarkdownViewer UseMediaLinks(this MarkdownViewer viewer)
+    {
+        viewer.Pipeline = new MarkdownPipelineBuilder()
+            .UseSupportedExtensions()
+            .UseMediaLinks()
+            .Build();
+        return viewer;
+    }
+}

--- a/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
@@ -121,6 +121,7 @@ public class AvaloniaRenderer : RendererBase
         ObjectRenderers.Add(new HtmlBlockRenderer());
         ObjectRenderers.Add(new TableRenderer());
         ObjectRenderers.Add(new FootnoteGroupRenderer());
+        ObjectRenderers.Add(new FigureRenderer());
 
         // Inline renderers
         ObjectRenderers.Add(new LiteralInlineRenderer());

--- a/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
@@ -3,6 +3,7 @@
 
 using Avalonia.Controls;
 using Avalonia.Controls.Documents;
+using Avalonia.Interactivity;
 
 using Markdig.Renderers;
 using Markdig.Syntax;
@@ -242,7 +243,7 @@ public class AvaloniaRenderer : RendererBase
 /// <summary>
 /// Event args for hyperlink click events.
 /// </summary>
-public class LinkClickedEventArgs(string url) : EventArgs
+public class LinkClickedEventArgs(string url) : RoutedEventArgs
 {
     /// <summary>
     /// The URL of the clicked link.

--- a/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
@@ -134,6 +134,7 @@ public class AvaloniaRenderer : RendererBase
         ObjectRenderers.Add(new HtmlInlineRenderer());
         ObjectRenderers.Add(new TaskListRenderer());
         ObjectRenderers.Add(new FootnoteLinkRenderer());
+        ObjectRenderers.Add(new AbbreviationInlineRenderer());
     }
 
     /// <summary>

--- a/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
@@ -68,7 +68,7 @@ public class AvaloniaRenderer : RendererBase
     /// <see cref="BitmapImageLoader"/> which handles avares://, http/https, and
     /// data URIs for bitmap formats. Extensions insert at index 0 to take priority.
     /// </summary>
-    public IList<IImageLoader> ImageLoaders { get; } = new List<IImageLoader> { new BitmapImageLoader() };
+    public IList<IImageLoader> ImageLoaders { get; } = [new BitmapImageLoader()];
 
     /// <summary>
     /// Removes the first registered renderer of type <typeparamref name="TRenderer"/>

--- a/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
@@ -117,6 +117,7 @@ public class AvaloniaRenderer : RendererBase
         ObjectRenderers.Add(new QuoteBlockRenderer());
         ObjectRenderers.Add(new HtmlBlockRenderer());
         ObjectRenderers.Add(new TableRenderer());
+        ObjectRenderers.Add(new FootnoteGroupRenderer());
 
         // Inline renderers
         ObjectRenderers.Add(new LiteralInlineRenderer());
@@ -129,6 +130,7 @@ public class AvaloniaRenderer : RendererBase
         ObjectRenderers.Add(new HtmlEntityInlineRenderer());
         ObjectRenderers.Add(new HtmlInlineRenderer());
         ObjectRenderers.Add(new TaskListRenderer());
+        ObjectRenderers.Add(new FootnoteLinkRenderer());
     }
 
     /// <summary>

--- a/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
@@ -114,6 +114,9 @@ public class AvaloniaRenderer : RendererBase
         ObjectRenderers.Add(new CodeBlockRenderer());
         ObjectRenderers.Add(new ListRenderer());
         ObjectRenderers.Add(new ThematicBreakRenderer());
+        // AlertBlockRenderer must precede QuoteBlockRenderer: AlertBlock extends QuoteBlock
+        // and Markdig dispatches to the first renderer whose Accept() matches.
+        ObjectRenderers.Add(new AlertBlockRenderer());
         ObjectRenderers.Add(new QuoteBlockRenderer());
         ObjectRenderers.Add(new HtmlBlockRenderer());
         ObjectRenderers.Add(new TableRenderer());

--- a/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
@@ -64,10 +64,11 @@ public class AvaloniaRenderer : RendererBase
     internal bool SkipNextTaskList { get; set; }
 
     /// <summary>
-    /// Ordered list of image loaders tried before the built-in HTTP fallback.
-    /// Extensions insert at index 0 to take priority.
+    /// Ordered list of image loaders. The last entry is always the built-in
+    /// <see cref="BitmapImageLoader"/> which handles avares://, http/https, and
+    /// data URIs for bitmap formats. Extensions insert at index 0 to take priority.
     /// </summary>
-    public IList<IImageLoader> ImageLoaders { get; } = new List<IImageLoader>();
+    public IList<IImageLoader> ImageLoaders { get; } = new List<IImageLoader> { new BitmapImageLoader() };
 
     /// <summary>
     /// Removes the first registered renderer of type <typeparamref name="TRenderer"/>

--- a/src/MarkView.Avalonia/Rendering/Blocks/AlertBlockRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/AlertBlockRenderer.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Controls;
+
+using Markdig.Extensions.Alerts;
+
+namespace MarkView.Avalonia.Rendering.Blocks;
+
+/// <summary>
+/// Renders a Markdig <see cref="AlertBlock"/> as a styled bordered panel with a header label.
+/// Supports GitHub GFM variants: NOTE, TIP, WARNING, IMPORTANT, CAUTION.
+/// BorderBrush per variant is provided by AXAML theme styles (markdown-alert-note, etc.).
+/// </summary>
+public class AlertBlockRenderer : AvaloniaObjectRenderer<AlertBlock>
+{
+    protected override void Write(AvaloniaRenderer renderer, AlertBlock obj)
+    {
+        var kind = obj.Kind.ToString().ToLowerInvariant();
+
+        var header = new TextBlock { Text = kind.ToUpperInvariant() };
+        header.Classes.Add("markdown-alert-header");
+
+        var contentPanel = new StackPanel { Spacing = 4 };
+        contentPanel.Classes.Add("markdown-alert-content");
+
+        var outer = new StackPanel { Spacing = 4 };
+        outer.Children.Add(header);
+        outer.Children.Add(contentPanel);
+
+        var border = new Border { Child = outer };
+        border.Classes.Add("markdown-alert");
+        border.Classes.Add($"markdown-alert-{kind}");
+
+        renderer.Push(contentPanel);
+        renderer.WriteChildren(obj);
+        renderer.Pop();
+
+        renderer.WriteBlock(border);
+    }
+}

--- a/src/MarkView.Avalonia/Rendering/Blocks/FigureRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/FigureRenderer.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+
+using Markdig.Extensions.Figures;
+
+namespace MarkView.Avalonia.Rendering.Blocks;
+
+/// <summary>
+/// Renders Markdig <see cref="Figure"/> blocks. <see cref="FigureCaption"/> children
+/// are rendered as an italic centred caption below the figure content.
+/// </summary>
+public class FigureRenderer : AvaloniaObjectRenderer<Figure>
+{
+    protected override void Write(AvaloniaRenderer renderer, Figure obj)
+    {
+        var contentPanel = new StackPanel { Spacing = 4 };
+
+        foreach (var child in obj)
+        {
+            if (child is FigureCaption caption)
+            {
+                var captionBlock = new MarkdownSelectableTextBlock
+                {
+                    TextWrapping = TextWrapping.Wrap,
+                    Renderer = renderer,
+                };
+                captionBlock.Classes.Add("markdown-figure-caption");
+                renderer.Push(captionBlock.Inlines!);
+                renderer.WriteLeafInline(caption);
+                renderer.Pop();
+                contentPanel.Children.Add(captionBlock);
+            }
+            else
+            {
+                renderer.Push(contentPanel);
+                renderer.Write(child);
+                renderer.Pop();
+            }
+        }
+
+        var border = new Border
+        {
+            Child = contentPanel,
+            HorizontalAlignment = HorizontalAlignment.Center,
+        };
+        border.Classes.Add("markdown-figure");
+
+        renderer.WriteBlock(border);
+    }
+}

--- a/src/MarkView.Avalonia/Rendering/Blocks/FootnoteGroupRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/FootnoteGroupRenderer.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+
+using Markdig.Extensions.Footnotes;
+
+namespace MarkView.Avalonia.Rendering.Blocks;
+
+/// <summary>
+/// Renders a Markdig <see cref="FootnoteGroup"/> block as a numbered definition list below a separator.
+/// Each footnote definition is registered as an anchor for back-navigation.
+/// </summary>
+public class FootnoteGroupRenderer : AvaloniaObjectRenderer<FootnoteGroup>
+{
+    protected override void Write(AvaloniaRenderer renderer, FootnoteGroup obj)
+    {
+        var separator = new Separator();
+        separator.Classes.Add("markdown-thematic-break");
+        renderer.WriteBlock(separator);
+
+        var group = new StackPanel { Spacing = 4 };
+        group.Classes.Add("markdown-footnote-group");
+
+        foreach (var item in obj)
+        {
+            if (item is not Footnote fn) continue;
+
+            var row = new Grid
+            {
+                ColumnDefinitions = new ColumnDefinitions("Auto,*"),
+            };
+            row.Classes.Add("markdown-footnote-item");
+
+            var label = new TextBlock
+            {
+                Text = $"{fn.Order}.",
+                Margin = new Thickness(0, 0, 8, 0),
+                VerticalAlignment = VerticalAlignment.Top,
+            };
+            Grid.SetColumn(label, 0);
+            row.Children.Add(label);
+
+            var content = new StackPanel { Spacing = 2 };
+            Grid.SetColumn(content, 1);
+            row.Children.Add(content);
+
+            renderer.Push(content);
+            renderer.WriteChildren(fn);
+            renderer.Pop();
+
+            renderer.RegisterAnchor($"fn-{fn.Order}", row);
+
+            group.Children.Add(row);
+        }
+
+        renderer.WriteBlock(group);
+    }
+}

--- a/src/MarkView.Avalonia/Rendering/DocumentBlock.cs
+++ b/src/MarkView.Avalonia/Rendering/DocumentBlock.cs
@@ -13,9 +13,9 @@ namespace MarkView.Avalonia.Rendering;
 /// </summary>
 internal sealed class IndexEntry
 {
-    public TextBlock TextBlock  { get; }
-    public string    PlainText  { get; }
-    public string    Separator  { get; }
+    public TextBlock TextBlock { get; }
+    public string PlainText { get; }
+    public string Separator { get; }
 
     /// <summary>
     /// Absolute start offset in the document's flat char space.
@@ -23,8 +23,8 @@ internal sealed class IndexEntry
     /// </summary>
     public int AbsStart { get; internal set; }
 
-    public int AbsEnd        => AbsStart + PlainText.Length;
-    public int AbsEndWithSep => AbsEnd   + Separator.Length;
+    public int AbsEnd => AbsStart + PlainText.Length;
+    public int AbsEndWithSep => AbsEnd + Separator.Length;
 
     public IndexEntry(TextBlock textBlock, string plainText, string separator = "\n")
     {

--- a/src/MarkView.Avalonia/Rendering/DocumentSelectionLayer.cs
+++ b/src/MarkView.Avalonia/Rendering/DocumentSelectionLayer.cs
@@ -21,7 +21,7 @@ internal sealed class DocumentSelectionLayer : Control
     private static readonly ImmutableSolidColorBrush SelectionBrush =
         new(Colors.CornflowerBlue, 0.35);
 
-    private readonly List<IndexEntry> _entries = new();
+    private readonly List<IndexEntry> _entries = [];
     private int _totalLength;
 
     // Anchor and focus as absolute char offsets.

--- a/src/MarkView.Avalonia/Rendering/DocumentSelectionLayer.cs
+++ b/src/MarkView.Avalonia/Rendering/DocumentSelectionLayer.cs
@@ -54,7 +54,7 @@ internal sealed class DocumentSelectionLayer : Control
     {
         if (_entries.Count == 0) return;
         _anchor = 0;
-        _focus  = _entries[^1].AbsEnd;   // up to (not including) trailing separator
+        _focus = _entries[^1].AbsEnd;   // up to (not including) trailing separator
         InvalidateVisual();
     }
 
@@ -62,7 +62,7 @@ internal sealed class DocumentSelectionLayer : Control
     public void ClearSelection()
     {
         _anchor = null;
-        _focus  = null;
+        _focus = null;
         InvalidateVisual();
     }
 
@@ -71,7 +71,7 @@ internal sealed class DocumentSelectionLayer : Control
     {
         if (_anchor is null || _focus is null) return string.Empty;
         int selStart = Math.Min(_anchor.Value, _focus.Value);
-        int selEnd   = Math.Max(_anchor.Value, _focus.Value);
+        int selEnd = Math.Max(_anchor.Value, _focus.Value);
         if (selStart == selEnd) return string.Empty;
 
         var sb = new System.Text.StringBuilder();
@@ -81,7 +81,7 @@ internal sealed class DocumentSelectionLayer : Control
             if (entry.AbsStart >= selEnd) break;              // entirely after selection
 
             int localStart = Math.Max(0, selStart - entry.AbsStart);
-            int localEnd   = Math.Min(entry.PlainText.Length, selEnd - entry.AbsStart);
+            int localEnd = Math.Min(entry.PlainText.Length, selEnd - entry.AbsStart);
             if (localEnd > localStart)
                 sb.Append(entry.PlainText.AsSpan(localStart, localEnd - localStart));
 
@@ -113,7 +113,7 @@ internal sealed class DocumentSelectionLayer : Control
         var offset = HitTestOffset(posInLayer);
         if (offset is null) return;
         _anchor = offset;
-        _focus  = offset;
+        _focus = offset;
     }
 
     /// <summary>
@@ -170,7 +170,7 @@ internal sealed class DocumentSelectionLayer : Control
     {
         if (_anchor is null || _focus is null) return;
         int selStart = Math.Min(_anchor.Value, _focus.Value);
-        int selEnd   = Math.Max(_anchor.Value, _focus.Value);
+        int selEnd = Math.Max(_anchor.Value, _focus.Value);
         if (selStart == selEnd) return;
 
         foreach (var entry in _entries)
@@ -181,11 +181,11 @@ internal sealed class DocumentSelectionLayer : Control
             var origin = entry.TextBlock.TranslatePoint(new Point(0, 0), this);
             if (origin is null) continue;
 
-            var textOrigin  = origin.Value + new Vector(entry.TextBlock.Padding.Left,
+            var textOrigin = origin.Value + new Vector(entry.TextBlock.Padding.Left,
                                                          entry.TextBlock.Padding.Top);
             int localStart = Math.Max(0, selStart - entry.AbsStart);
-            int localEnd   = Math.Min(entry.PlainText.Length, selEnd - entry.AbsStart);
-            int length     = localEnd - localStart;
+            int localEnd = Math.Min(entry.PlainText.Length, selEnd - entry.AbsStart);
+            int length = localEnd - localStart;
             if (length <= 0) continue;
 
             foreach (var rect in entry.TextBlock.TextLayout.HitTestTextRange(localStart, length))
@@ -199,7 +199,7 @@ internal sealed class DocumentSelectionLayer : Control
     internal void SetSelectionForTest(int start, int end)
     {
         _anchor = start;
-        _focus  = end;
+        _focus = end;
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────

--- a/src/MarkView.Avalonia/Rendering/Inlines/AbbreviationInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/AbbreviationInlineRenderer.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+
+using Markdig.Extensions.Abbreviations;
+
+namespace MarkView.Avalonia.Rendering.Inlines;
+
+/// <summary>
+/// Renders a Markdig <see cref="AbbreviationInline"/> as a <see cref="TextBlock"/>
+/// inside an <see cref="InlineUIContainer"/> with a tooltip showing the full definition.
+/// </summary>
+public class AbbreviationInlineRenderer : AvaloniaObjectRenderer<AbbreviationInline>
+{
+    protected override void Write(AvaloniaRenderer renderer, AbbreviationInline obj)
+    {
+        var abbr = obj.Abbreviation;
+        // Abbreviation.Label is the matched word; Abbreviation.Text (a field) is the definition.
+        var labelText = abbr?.Label ?? string.Empty;
+        var tooltipText = abbr?.Text.ToString() ?? string.Empty;
+
+        var tb = new TextBlock { Text = labelText };
+        tb.Classes.Add("markdown-abbr");
+        if (!string.IsNullOrEmpty(tooltipText))
+            ToolTip.SetTip(tb, tooltipText);
+
+        renderer.WriteInline(new InlineUIContainer { Child = tb });
+    }
+}

--- a/src/MarkView.Avalonia/Rendering/Inlines/FootnoteLinkRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/FootnoteLinkRenderer.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Controls.Documents;
+
+using Markdig.Extensions.Footnotes;
+
+namespace MarkView.Avalonia.Rendering.Inlines;
+
+/// <summary>
+/// Renders a Markdig <see cref="FootnoteLink"/> inline as a clickable superscript reference.
+/// Clicking navigates to the footnote definition anchor (fn-N). Back-links are skipped.
+/// </summary>
+public class FootnoteLinkRenderer : AvaloniaObjectRenderer<FootnoteLink>
+{
+    protected override void Write(AvaloniaRenderer renderer, FootnoteLink obj)
+    {
+        if (obj.IsBackLink) return;
+
+        var hyperlink = new MarkdownHyperlink
+        {
+            NavigateUri = new Uri($"#fn-{obj.Footnote.Order}", UriKind.Relative),
+        };
+        hyperlink.Inlines.Add(new Run { Text = $"[{obj.Footnote.Order}]" });
+        hyperlink.Classes.Add("markdown-footnote-ref");
+        renderer.WriteInline(hyperlink);
+    }
+}

--- a/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
@@ -196,7 +196,7 @@ public partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
         };
         playOverlay.Classes.Add("markdown-youtube-play");
 
-        var overlayGrid = new Grid(); 
+        var overlayGrid = new Grid();
         overlayGrid.Classes.Add("markdown-youtube-overlay");
 
         var button = new Button { Content = overlayGrid };

--- a/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
@@ -4,6 +4,7 @@
 using System.Text.RegularExpressions;
 
 using Avalonia.Controls;
+using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
@@ -15,6 +16,7 @@ namespace MarkView.Avalonia.Rendering.Inlines;
 
 /// <summary>
 /// Renders a Markdig <see cref="LinkInline"/> as a <see cref="MarkdownHyperlink"/> span or image.
+/// YouTube video links (produced by UseMediaLinks) are rendered as clickable thumbnails.
 /// </summary>
 public partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
 {
@@ -24,10 +26,19 @@ public partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
     [GeneratedRegex(@"^=(\d+)x(\d+)$", RegexOptions.Compiled)]
     private static partial Regex DimensionTitleRegex();
 
+    [GeneratedRegex(@"(?:youtu\.be/|[?&]v=)([A-Za-z0-9_\-]{11})", RegexOptions.Compiled)]
+    private static partial Regex YoutubeIdRegex();
+
     protected override void Write(AvaloniaRenderer renderer, LinkInline obj)
     {
         if (obj.IsImage)
         {
+            var videoId = ExtractYoutubeId(obj.Url);
+            if (videoId is not null)
+            {
+                WriteYoutubeEmbed(renderer, obj, videoId);
+                return;
+            }
             WriteImage(renderer, obj);
             return;
         }
@@ -83,12 +94,15 @@ public partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
         CancellationTokenSource? cts = null;
         image.AttachedToVisualTree += (_, _) =>
         {
-            if (image.Source != null) return; // already loaded, no need to reload
-            cts?.Cancel();
+            // Guard against both "already loaded" and "load already in flight".
+            // AttachedToVisualTree can fire multiple times during layout passes; without
+            // the second guard the first in-flight task would be cancelled and a new one
+            // started, causing the image to never load.
+            if (image.Source != null || cts != null) return;
             cts = new CancellationTokenSource();
             _ = LoadImageAsync(renderer, image, url, cts.Token);
         };
-        image.DetachedFromVisualTree += (_, _) => cts?.Cancel();
+        image.DetachedFromLogicalTree += (_, _) => cts?.Cancel();
 
         renderer.WriteInline(image);
     }
@@ -132,9 +146,87 @@ public partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
             var httpBitmap = new Bitmap(responseStream);
             await Dispatcher.UIThread.InvokeAsync(() => image.Source = httpBitmap);
         }
-        catch (OperationCanceledException) { }
-        catch (HttpRequestException) { }
-        catch (IOException) { }
+        catch (OperationCanceledException e)
+        {
+
+        }
+        catch (HttpRequestException e)
+        {
+
+        }
+        catch (IOException e)
+        {
+            
+        }
+    }
+
+    private static string? ExtractYoutubeId(string? url)
+    {
+        if (string.IsNullOrEmpty(url)) return null;
+        var match = YoutubeIdRegex().Match(url);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    private static void WriteYoutubeEmbed(AvaloniaRenderer renderer, LinkInline obj, string videoId)
+    {
+        if (!Uri.TryCreate(obj.Url, UriKind.Absolute, out var videoUri)) return;
+
+        var thumbnailUrl = $"https://img.youtube.com/vi/{videoId}/hqdefault.jpg";
+
+        var thumbnail = new Image();
+        thumbnail.Classes.Add("markdown-youtube-thumbnail");
+
+        // Honour =WxH title syntax (same as regular images); falls back to theme dimensions.
+        if (!string.IsNullOrEmpty(obj.Title))
+        {
+            var dim = DimensionTitleRegex().Match(obj.Title);
+            if (dim.Success)
+            {
+                thumbnail.Width = int.Parse(dim.Groups[1].Value);
+                thumbnail.Height = int.Parse(dim.Groups[2].Value);
+                thumbnail.Stretch = Stretch.Uniform;
+            }
+        }
+
+        var playOverlay = new TextBlock
+        {
+            Text = "▶",
+            HorizontalAlignment = HorizontalAlignment.Center,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        playOverlay.Classes.Add("markdown-youtube-play");
+
+        var overlayGrid = new Grid(); 
+        overlayGrid.Classes.Add("markdown-youtube-overlay");
+
+        var button = new Button { Content = overlayGrid };
+        button.Classes.Add("markdown-youtube");
+
+        button.Click += async (_, _) =>
+        {
+            var launcher = TopLevel.GetTopLevel(button)?.Launcher;
+            if (launcher is not null)
+                await launcher.LaunchUriAsync(videoUri);
+        };
+
+        CancellationTokenSource? cts = null;
+        thumbnail.AttachedToVisualTree += (_, _) =>
+        {
+            // Guard against both "already loaded" and "load already in flight".
+            // AttachedToVisualTree fires multiple times during Avalonia's layout passes
+            // (Button > Grid > Image nesting amplifies this). Without the second guard
+            // each re-attach would cancel the previous in-flight fetch and restart it.
+            if (thumbnail.Source != null || cts != null) return;
+            cts = new CancellationTokenSource();
+            _ = LoadImageAsync(renderer, thumbnail, thumbnailUrl, cts.Token);
+        };
+        // DetachedFromLogicalTree fires on genuine content replacement (e.g. Markdown property
+        // change), unlike DetachedFromVisualTree which also fires during layout passes.
+        thumbnail.DetachedFromLogicalTree += (_, _) => cts?.Cancel();
+
+        overlayGrid.Children.Add(thumbnail);
+        overlayGrid.Children.Add(playOverlay);
+        renderer.WriteInline(button);
     }
 
 }

--- a/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
@@ -6,8 +6,6 @@ using System.Text.RegularExpressions;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
-using Avalonia.Media.Imaging;
-using Avalonia.Platform;
 using Avalonia.Threading;
 
 using Markdig.Syntax.Inlines;
@@ -129,35 +127,12 @@ public partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
                 }
             }
 
-            if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
-                return;
-
-            // avares:// — Avalonia embedded resource
-            if (uri.Scheme == "avares")
-            {
-                using var stream = AssetLoader.Open(uri);
-                var bitmap = new Bitmap(stream);
-                await Dispatcher.UIThread.InvokeAsync(() => image.Source = bitmap);
-                return;
-            }
-
-            // HTTP/HTTPS fallback
-            using var responseStream = await HttpClient.GetStreamAsync(uri, cancellationToken);
-            var httpBitmap = new Bitmap(responseStream);
-            await Dispatcher.UIThread.InvokeAsync(() => image.Source = httpBitmap);
+            // No loader claimed the URL — nothing to do.
+            // (BitmapImageLoader is always registered last as the catch-all.)
         }
-        catch (OperationCanceledException e)
-        {
-
-        }
-        catch (HttpRequestException e)
-        {
-
-        }
-        catch (IOException e)
-        {
-            
-        }
+        catch (OperationCanceledException) { }
+        catch (HttpRequestException) { }
+        catch (IOException) { }
     }
 
     private static string? ExtractYoutubeId(string? url)

--- a/src/MarkView.Avalonia/Themes/MarkdownTheme.axaml
+++ b/src/MarkView.Avalonia/Themes/MarkdownTheme.axaml
@@ -11,12 +11,34 @@
           <SolidColorBrush x:Key="MarkdownCodeBlockForeground">#D4D4D4</SolidColorBrush>
           <SolidColorBrush x:Key="MarkdownCodeInlineBackground">#1A000000</SolidColorBrush>
           <SolidColorBrush x:Key="MarkdownCodeInlineForeground">#CE9178</SolidColorBrush>
+          <!-- Alert accent colours — dark theme -->
+          <SolidColorBrush x:Key="MarkdownAlertNoteBorder">#3B82F6</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertNoteBackground">#1A3B82F6</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertTipBorder">#22C55E</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertTipBackground">#1A22C55E</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertImportantBorder">#A855F7</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertImportantBackground">#1AA855F7</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertWarningBorder">#EAB308</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertWarningBackground">#1AEAB308</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertCautionBorder">#EF4444</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertCautionBackground">#1AEF4444</SolidColorBrush>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
           <SolidColorBrush x:Key="MarkdownCodeBlockBackground">#F3F3F3</SolidColorBrush>
           <SolidColorBrush x:Key="MarkdownCodeBlockForeground">#1E1E1E</SolidColorBrush>
           <SolidColorBrush x:Key="MarkdownCodeInlineBackground">#0A000000</SolidColorBrush>
           <SolidColorBrush x:Key="MarkdownCodeInlineForeground">#A31515</SolidColorBrush>
+          <!-- Alert accent colours — light theme -->
+          <SolidColorBrush x:Key="MarkdownAlertNoteBorder">#2563EB</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertNoteBackground">#EFF6FF</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertTipBorder">#16A34A</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertTipBackground">#F0FDF4</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertImportantBorder">#9333EA</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertImportantBackground">#FAF5FF</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertWarningBorder">#CA8A04</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertWarningBackground">#FEFCE8</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertCautionBorder">#DC2626</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownAlertCautionBackground">#FEF2F2</SolidColorBrush>
         </ResourceDictionary>
       </ResourceDictionary.ThemeDictionaries>
     </ResourceDictionary>
@@ -135,6 +157,114 @@
   </Style>
   <Style Selector="Border.markdown-table-header > StackPanel > TextBlock">
     <Setter Property="FontWeight" Value="Bold" />
+  </Style>
+
+  <!-- Footnotes -->
+  <Style Selector="StackPanel.markdown-footnote-group">
+    <Setter Property="Margin" Value="0,8,0,0" />
+    <Setter Property="Opacity" Value="0.85" />
+  </Style>
+  <Style Selector="Grid.markdown-footnote-item">
+    <Setter Property="Margin" Value="0,2" />
+  </Style>
+  <Style Selector="mri|MarkdownHyperlink.markdown-footnote-ref">
+    <Setter Property="Foreground" Value="{DynamicResource SystemAccentColor}" />
+    <Setter Property="TextDecorations" Value="Underline" />
+    <Setter Property="FontSize" Value="11" />
+    <Setter Property="BaselineAlignment" Value="Superscript" />
+  </Style>
+
+  <!-- Alert blocks — shared layout -->
+  <Style Selector="Border.markdown-alert">
+    <Setter Property="BorderThickness" Value="4,0,0,0" />
+    <Setter Property="CornerRadius" Value="0,4,4,0" />
+    <Setter Property="Padding" Value="12,8" />
+    <Setter Property="Margin" Value="0,4" />
+  </Style>
+  <Style Selector="TextBlock.markdown-alert-header">
+    <Setter Property="FontWeight" Value="SemiBold" />
+    <Setter Property="FontSize" Value="13" />
+    <Setter Property="Margin" Value="0,0,0,4" />
+  </Style>
+  <!-- Alert variants — border + background per kind -->
+  <Style Selector="Border.markdown-alert-note">
+    <Setter Property="BorderBrush" Value="{DynamicResource MarkdownAlertNoteBorder}" />
+    <Setter Property="Background" Value="{DynamicResource MarkdownAlertNoteBackground}" />
+  </Style>
+  <Style Selector="Border.markdown-alert-note TextBlock.markdown-alert-header">
+    <Setter Property="Foreground" Value="{DynamicResource MarkdownAlertNoteBorder}" />
+  </Style>
+  <Style Selector="Border.markdown-alert-tip">
+    <Setter Property="BorderBrush" Value="{DynamicResource MarkdownAlertTipBorder}" />
+    <Setter Property="Background" Value="{DynamicResource MarkdownAlertTipBackground}" />
+  </Style>
+  <Style Selector="Border.markdown-alert-tip TextBlock.markdown-alert-header">
+    <Setter Property="Foreground" Value="{DynamicResource MarkdownAlertTipBorder}" />
+  </Style>
+  <Style Selector="Border.markdown-alert-important">
+    <Setter Property="BorderBrush" Value="{DynamicResource MarkdownAlertImportantBorder}" />
+    <Setter Property="Background" Value="{DynamicResource MarkdownAlertImportantBackground}" />
+  </Style>
+  <Style Selector="Border.markdown-alert-important TextBlock.markdown-alert-header">
+    <Setter Property="Foreground" Value="{DynamicResource MarkdownAlertImportantBorder}" />
+  </Style>
+  <Style Selector="Border.markdown-alert-warning">
+    <Setter Property="BorderBrush" Value="{DynamicResource MarkdownAlertWarningBorder}" />
+    <Setter Property="Background" Value="{DynamicResource MarkdownAlertWarningBackground}" />
+  </Style>
+  <Style Selector="Border.markdown-alert-warning TextBlock.markdown-alert-header">
+    <Setter Property="Foreground" Value="{DynamicResource MarkdownAlertWarningBorder}" />
+  </Style>
+  <Style Selector="Border.markdown-alert-caution">
+    <Setter Property="BorderBrush" Value="{DynamicResource MarkdownAlertCautionBorder}" />
+    <Setter Property="Background" Value="{DynamicResource MarkdownAlertCautionBackground}" />
+  </Style>
+  <Style Selector="Border.markdown-alert-caution TextBlock.markdown-alert-header">
+    <Setter Property="Foreground" Value="{DynamicResource MarkdownAlertCautionBorder}" />
+  </Style>
+
+  <!-- Abbreviations -->
+  <Style Selector="TextBlock.markdown-abbr">
+    <Setter Property="TextDecorations" Value="Underline" />
+    <Setter Property="Cursor" Value="Help" />
+  </Style>
+
+  <!-- Figures -->
+  <Style Selector="Border.markdown-figure">
+    <Setter Property="BorderBrush" Value="#40808080" />
+    <Setter Property="BorderThickness" Value="1" />
+    <Setter Property="CornerRadius" Value="4" />
+    <Setter Property="Padding" Value="12,8" />
+    <Setter Property="Margin" Value="0,8" />
+  </Style>
+  <Style Selector=":is(TextBlock).markdown-figure-caption">
+    <Setter Property="FontStyle" Value="Italic" />
+    <Setter Property="TextAlignment" Value="Center" />
+    <Setter Property="Opacity" Value="0.75" />
+    <Setter Property="Margin" Value="0,4,0,0" />
+  </Style>
+
+  <!-- YouTube thumbnail embeds -->
+  <Style Selector="Button.markdown-youtube">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="BorderThickness" Value="0" />
+    <Setter Property="Padding" Value="0" />
+    <Setter Property="Margin" Value="0,4" />
+    <Setter Property="Cursor" Value="Hand" />
+  </Style>
+  <!-- Explicit dimensions ensure the button has a visible area before the thumbnail loads -->
+  <Style Selector="Image.markdown-youtube-thumbnail">
+    <Setter Property="Width" Value="480" />
+    <Setter Property="Height" Value="270" />
+    <Setter Property="Stretch" Value="UniformToFill" />
+  </Style>
+  <Style Selector="Grid.markdown-youtube-overlay">
+    <Setter Property="Background" Value="#FF1A1A1A" />
+  </Style>
+  <Style Selector="TextBlock.markdown-youtube-play">
+    <Setter Property="FontSize" Value="64" />
+    <Setter Property="Foreground" Value="White" />
+    <Setter Property="Opacity" Value="0.85" />
   </Style>
 
 </Styles>

--- a/tests/MarkView.Avalonia.Mermaid.Tests/MarkdownViewerDefaultsExtensionsTests.cs
+++ b/tests/MarkView.Avalonia.Mermaid.Tests/MarkdownViewerDefaultsExtensionsTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace MarkView.Avalonia.Mermaid.Tests;
+
+public class MarkdownViewerDefaultsExtensionsTests
+{
+    [AvaloniaFact]
+    public void AddMermaid_adds_MermaidExtension_to_defaults()
+    {
+        using var _ = new MarkdownViewerDefaultsMermaidScope();
+
+        MarkdownViewerDefaults.Extensions.AddMermaid();
+
+        Assert.Single(MarkdownViewerDefaults.Extensions.OfType<MermaidExtension>());
+    }
+}
+
+// Save/restore scope for this test project (self-contained, no dependency on MarkView.Avalonia.Tests)
+internal sealed class MarkdownViewerDefaultsMermaidScope : IDisposable
+{
+    private readonly Markdig.MarkdownPipeline? _savedPipeline;
+    private readonly MarkView.Avalonia.Extensions.IMarkViewExtension[] _savedExtensions;
+
+    public MarkdownViewerDefaultsMermaidScope()
+    {
+        _savedPipeline = MarkdownViewerDefaults.Pipeline;
+        _savedExtensions = MarkdownViewerDefaults.Extensions.ToArray();
+    }
+
+    public void Dispose()
+    {
+        MarkdownViewerDefaults.Pipeline = _savedPipeline;
+        MarkdownViewerDefaults.Extensions.Clear();
+        foreach (var e in _savedExtensions)
+            MarkdownViewerDefaults.Extensions.Add(e);
+    }
+}

--- a/tests/MarkView.Avalonia.Svg.Tests/MarkdownViewerDefaultsExtensionsTests.cs
+++ b/tests/MarkView.Avalonia.Svg.Tests/MarkdownViewerDefaultsExtensionsTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Headless.XUnit;
+using Xunit;
+
+namespace MarkView.Avalonia.Svg.Tests;
+
+public class MarkdownViewerDefaultsExtensionsTests
+{
+    [AvaloniaFact]
+    public void AddSvg_adds_SvgExtension_to_defaults()
+    {
+        using var _ = new MarkdownViewerDefaultsSvgScope();
+
+        MarkdownViewerDefaults.Extensions.AddSvg();
+
+        Assert.Single(MarkdownViewerDefaults.Extensions.OfType<SvgExtension>());
+    }
+}
+
+internal sealed class MarkdownViewerDefaultsSvgScope : IDisposable
+{
+    private readonly Markdig.MarkdownPipeline? _savedPipeline;
+    private readonly MarkView.Avalonia.Extensions.IMarkViewExtension[] _savedExtensions;
+
+    public MarkdownViewerDefaultsSvgScope()
+    {
+        _savedPipeline = MarkdownViewerDefaults.Pipeline;
+        _savedExtensions = MarkdownViewerDefaults.Extensions.ToArray();
+    }
+
+    public void Dispose()
+    {
+        MarkdownViewerDefaults.Pipeline = _savedPipeline;
+        MarkdownViewerDefaults.Extensions.Clear();
+        foreach (var e in _savedExtensions)
+            MarkdownViewerDefaults.Extensions.Add(e);
+    }
+}

--- a/tests/MarkView.Avalonia.Svg.Tests/SvgImageLoaderTests.cs
+++ b/tests/MarkView.Avalonia.Svg.Tests/SvgImageLoaderTests.cs
@@ -31,7 +31,8 @@ public class SvgImageLoaderTests
         var renderer = new AvaloniaRenderer();
         var extension = new SvgExtension();
         extension.Register(renderer);
-        Assert.Single(renderer.ImageLoaders);
+        // AvaloniaRenderer starts with BitmapImageLoader at index 0; SvgExtension inserts at 0, pushing it to index 1
+        Assert.Equal(2, renderer.ImageLoaders.Count);
         Assert.IsType<SvgImageLoader>(renderer.ImageLoaders[0]);
     }
 
@@ -45,9 +46,11 @@ public class SvgImageLoaderTests
         var extension = new SvgExtension();
         extension.Register(renderer);
 
-        Assert.Equal(2, renderer.ImageLoaders.Count);
+        // AvaloniaRenderer starts with BitmapImageLoader at index 0; after Add(existing) it's at index 1;
+        // SvgExtension inserts at 0, pushing both to indices 1 and 2
+        Assert.Equal(3, renderer.ImageLoaders.Count);
         Assert.IsType<SvgImageLoader>(renderer.ImageLoaders[0]);
-        Assert.Same(existing, renderer.ImageLoaders[1]);
+        Assert.Same(existing, renderer.ImageLoaders[2]);
     }
 
     [AvaloniaFact]

--- a/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/MarkdownViewerDefaultsExtensionsTests.cs
+++ b/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/MarkdownViewerDefaultsExtensionsTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Headless.XUnit;
+using TextMateSharp.Grammars;
+using Xunit;
+
+namespace MarkView.Avalonia.SyntaxHighlighting.Tests;
+
+public class MarkdownViewerDefaultsExtensionsTests
+{
+    [AvaloniaFact]
+    public void AddTextMateHighlighting_adds_TextMateExtension_to_defaults()
+    {
+        using var _ = new MarkdownViewerDefaultsSyntaxScope();
+
+        MarkdownViewerDefaults.Extensions.AddTextMateHighlighting();
+
+        Assert.Single(MarkdownViewerDefaults.Extensions.OfType<TextMateExtension>());
+    }
+
+    [AvaloniaFact]
+    public void AddTextMateHighlighting_with_custom_themes_adds_TextMateExtension()
+    {
+        using var _ = new MarkdownViewerDefaultsSyntaxScope();
+
+        MarkdownViewerDefaults.Extensions.AddTextMateHighlighting(
+            ThemeName.DimmedMonokai, ThemeName.QuietLight);
+
+        Assert.Single(MarkdownViewerDefaults.Extensions.OfType<TextMateExtension>());
+    }
+}
+
+// Save/restore scope for this test project (self-contained, no dependency on MarkView.Avalonia.Tests)
+internal sealed class MarkdownViewerDefaultsSyntaxScope : IDisposable
+{
+    private readonly Markdig.MarkdownPipeline? _savedPipeline;
+    private readonly MarkView.Avalonia.Extensions.IMarkViewExtension[] _savedExtensions;
+
+    public MarkdownViewerDefaultsSyntaxScope()
+    {
+        _savedPipeline = MarkdownViewerDefaults.Pipeline;
+        _savedExtensions = MarkdownViewerDefaults.Extensions.ToArray();
+    }
+
+    public void Dispose()
+    {
+        MarkdownViewerDefaults.Pipeline = _savedPipeline;
+        MarkdownViewerDefaults.Extensions.Clear();
+        foreach (var e in _savedExtensions)
+            MarkdownViewerDefaults.Extensions.Add(e);
+    }
+}

--- a/tests/MarkView.Avalonia.Tests/Blocks/AlertBlockTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Blocks/AlertBlockTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Markdig;
+using Xunit;
+
+namespace MarkView.Avalonia.Tests.Blocks;
+
+public class AlertBlockTests : RenderTestBase
+{
+    private static MarkdownPipeline AlertPipeline() =>
+        new MarkdownPipelineBuilder().UseAlertBlocks().Build();
+
+    [AvaloniaTheory]
+    [InlineData("> [!NOTE]\n> Content", "note")]
+    [InlineData("> [!WARNING]\n> Content", "warning")]
+    [InlineData("> [!TIP]\n> Content", "tip")]
+    [InlineData("> [!IMPORTANT]\n> Content", "important")]
+    [InlineData("> [!CAUTION]\n> Content", "caution")]
+    public void Alert_renders_Border_with_variant_class(string markdown, string kind)
+    {
+        var result = Render(markdown, AlertPipeline());
+        var border = Assert.IsType<Border>(Assert.Single(result.Children));
+        Assert.Contains("markdown-alert", border.Classes);
+        Assert.Contains($"markdown-alert-{kind}", border.Classes);
+    }
+
+    [AvaloniaFact]
+    public void Alert_renders_header_and_content()
+    {
+        var result = Render("> [!NOTE]\n> Hello world", AlertPipeline());
+        var border = Assert.IsType<Border>(result.Children[0]);
+        var outer = Assert.IsType<StackPanel>(border.Child);
+        // outer has header TextBlock + content StackPanel
+        Assert.True(outer.Children.Count >= 2);
+        var header = Assert.IsType<TextBlock>(outer.Children[0]);
+        Assert.Equal("NOTE", header.Text);
+    }
+
+    [AvaloniaFact]
+    public void Alert_content_panel_has_children()
+    {
+        var result = Render("> [!WARNING]\n> Watch out", AlertPipeline());
+        var border = Assert.IsType<Border>(result.Children[0]);
+        var outer = Assert.IsType<StackPanel>(border.Child);
+        var content = Assert.IsType<StackPanel>(outer.Children[1]);
+        Assert.Contains("markdown-alert-content", content.Classes);
+        Assert.NotEmpty(content.Children);
+    }
+}

--- a/tests/MarkView.Avalonia.Tests/Blocks/FigureTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Blocks/FigureTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Headless.XUnit;
+using Markdig;
+using MarkView.Avalonia.Rendering;
+using Xunit;
+
+namespace MarkView.Avalonia.Tests.Blocks;
+
+public class FigureTests : RenderTestBase
+{
+    private static MarkdownPipeline FigurePipeline() =>
+        new MarkdownPipelineBuilder().UseFigures().Build();
+
+    [AvaloniaFact]
+    public void Figure_renders_as_Border_with_figure_class()
+    {
+        // ^^^ opens a figure, ^^^ Caption closes it with a caption line
+        var result = Render("^^^\nContent\n\n^^^ My Caption", FigurePipeline());
+        var border = Assert.IsType<Border>(Assert.Single(result.Children));
+        Assert.Contains("markdown-figure", border.Classes);
+    }
+
+    [AvaloniaFact]
+    public void Figure_contains_StackPanel_with_content_and_caption()
+    {
+        var result = Render("^^^\nContent\n\n^^^ My Caption", FigurePipeline());
+        var border = Assert.IsType<Border>(Assert.Single(result.Children));
+        var panel = Assert.IsType<StackPanel>(border.Child);
+        // Panel should have at least one content child and one caption
+        Assert.True(panel.Children.Count >= 2,
+            $"Expected at least 2 children (content + caption), got {panel.Children.Count}");
+    }
+
+    [AvaloniaFact]
+    public void Figure_caption_has_caption_class()
+    {
+        var result = Render("^^^\nContent\n\n^^^ My Caption", FigurePipeline());
+        var border = Assert.IsType<Border>(Assert.Single(result.Children));
+        var panel = Assert.IsType<StackPanel>(border.Child);
+        // Last child is the caption TextBlock
+        var caption = panel.Children[^1];
+        Assert.IsType<MarkdownSelectableTextBlock>(caption);
+        Assert.Contains("markdown-figure-caption", caption.Classes);
+    }
+
+    [AvaloniaFact]
+    public void Figure_without_caption_renders_single_border()
+    {
+        // A figure with no caption line still renders
+        var result = Render("^^^\nContent\n^^^", FigurePipeline());
+        var border = Assert.IsType<Border>(Assert.Single(result.Children));
+        Assert.Contains("markdown-figure", border.Classes);
+    }
+}

--- a/tests/MarkView.Avalonia.Tests/Blocks/FootnoteTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Blocks/FootnoteTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Headless.XUnit;
+using Markdig;
+using MarkView.Avalonia.Rendering;
+using Xunit;
+
+namespace MarkView.Avalonia.Tests.Blocks;
+
+public class FootnoteTests : RenderTestBase
+{
+    private static MarkdownPipeline FootnotePipeline() =>
+        new MarkdownPipelineBuilder().UseFootnotes().Build();
+
+    [AvaloniaFact]
+    public void Footnote_ref_inline_renders_with_class()
+    {
+        var result = Render("Text[^1]\n\n[^1]: Definition", FootnotePipeline());
+        // First child is a paragraph
+        var para = Assert.IsType<MarkdownSelectableTextBlock>(result.Children[0]);
+        // There should be an inline with markdown-footnote-ref class somewhere in the inlines
+        bool found = ContainsFootnoteRef(para.Inlines!);
+        Assert.True(found, "Expected a markdown-footnote-ref inline but found none");
+    }
+
+    [AvaloniaFact]
+    public void Footnote_group_renders_at_bottom()
+    {
+        var result = Render("Text[^1]\n\n[^1]: Definition", FootnotePipeline());
+        // Last block should be the footnote group panel
+        var last = result.Children[^1];
+        bool isGroup = (last is StackPanel sp && sp.Classes.Contains("markdown-footnote-group"));
+        Assert.True(isGroup, $"Expected StackPanel.markdown-footnote-group at bottom, got {last?.GetType().Name}");
+    }
+
+    [AvaloniaFact]
+    public void Footnote_anchor_is_registered()
+    {
+        var pipeline = FootnotePipeline();
+        var document = Markdig.Markdown.Parse("Text[^1]\n\n[^1]: Definition", pipeline);
+        var renderer = new AvaloniaRenderer();
+        pipeline.Setup(renderer);
+        renderer.Render(document);
+        Assert.True(renderer.Anchors.Count > 0, "Expected at least one anchor to be registered for footnote");
+    }
+
+    [AvaloniaFact]
+    public void Footnote_group_contains_definition_text()
+    {
+        var result = Render("Text[^1]\n\n[^1]: My footnote text", FootnotePipeline());
+        var group = (StackPanel)result.Children[^1];
+        // Group should have at least one child (the footnote item row)
+        Assert.NotEmpty(group.Children);
+    }
+
+    private static bool ContainsFootnoteRef(InlineCollection inlines)
+    {
+        foreach (var inline in inlines)
+        {
+            if (inline.Classes.Contains("markdown-footnote-ref"))
+                return true;
+            if (inline is Span s && s.Inlines != null && ContainsFootnoteRef(s.Inlines))
+                return true;
+        }
+        return false;
+    }
+}

--- a/tests/MarkView.Avalonia.Tests/Extensions/ExtensibilityTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Extensions/ExtensibilityTests.cs
@@ -83,7 +83,8 @@ public class ExtensibilityTests
     {
         var renderer = new AvaloniaRenderer();
         Assert.NotNull(renderer.ImageLoaders);
-        Assert.Empty(renderer.ImageLoaders);
+        Assert.Single(renderer.ImageLoaders);
+        Assert.IsType<BitmapImageLoader>(renderer.ImageLoaders[0]);
     }
 
     [AvaloniaFact]

--- a/tests/MarkView.Avalonia.Tests/Inlines/AbbreviationTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Inlines/AbbreviationTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Headless.XUnit;
+using Markdig;
+using MarkView.Avalonia.Rendering;
+using Xunit;
+
+namespace MarkView.Avalonia.Tests.Inlines;
+
+public class AbbreviationTests : RenderTestBase
+{
+    private static MarkdownPipeline AbbrPipeline() =>
+        new MarkdownPipelineBuilder().UseAbbreviations().Build();
+
+    [AvaloniaFact]
+    public void Abbreviation_renders_with_class_and_tooltip()
+    {
+        var result = Render("HTML is great\n\n*[HTML]: HyperText Markup Language", AbbrPipeline());
+        var para = Assert.IsType<MarkdownSelectableTextBlock>(result.Children[0]);
+        var abbr = FindAbbrTextBlock(para.Inlines!);
+        Assert.NotNull(abbr);
+        Assert.Equal("HTML", abbr!.Text);
+        Assert.Equal("HyperText Markup Language", ToolTip.GetTip(abbr) as string);
+    }
+
+    [AvaloniaFact]
+    public void Abbreviation_has_markdown_abbr_class()
+    {
+        var result = Render("HTML is great\n\n*[HTML]: HyperText Markup Language", AbbrPipeline());
+        var para = Assert.IsType<MarkdownSelectableTextBlock>(result.Children[0]);
+        var abbr = FindAbbrTextBlock(para.Inlines!);
+        Assert.NotNull(abbr);
+        Assert.Contains("markdown-abbr", abbr!.Classes);
+    }
+
+    [AvaloniaFact]
+    public void Non_abbreviated_word_has_no_abbr_inline()
+    {
+        var result = Render("CSS is great\n\n*[HTML]: HyperText Markup Language", AbbrPipeline());
+        var para = Assert.IsType<MarkdownSelectableTextBlock>(result.Children[0]);
+        Assert.Null(FindAbbrTextBlock(para.Inlines!));
+    }
+
+    private static TextBlock? FindAbbrTextBlock(InlineCollection inlines)
+    {
+        foreach (var inline in inlines)
+        {
+            if (inline is InlineUIContainer c && c.Child is TextBlock tb && tb.Classes.Contains("markdown-abbr"))
+                return tb;
+            if (inline is Span s && s.Inlines != null)
+            {
+                var found = FindAbbrTextBlock(s.Inlines);
+                if (found is not null) return found;
+            }
+        }
+        return null;
+    }
+}

--- a/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
@@ -64,7 +64,9 @@ public class ImageTests : RenderTestBase
         var pipeline = new Markdig.MarkdownPipelineBuilder().Build();
         var document = Markdig.Markdown.Parse("![alt](https://example.com/image.png)", pipeline);
         var renderer = new AvaloniaRenderer();
-        renderer.ImageLoaders.Add(loader);
+        // Insert at index 0 so the spy takes priority over the default BitmapImageLoader
+        // and its CanLoad is called synchronously (before the first await in the loader chain).
+        renderer.ImageLoaders.Insert(0, loader);
         pipeline.Setup(renderer);
         renderer.Render(document);
 

--- a/tests/MarkView.Avalonia.Tests/Inlines/YoutubeTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Inlines/YoutubeTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Headless.XUnit;
+using Markdig;
+using Xunit;
+
+namespace MarkView.Avalonia.Tests.Inlines;
+
+public class YoutubeTests : RenderTestBase
+{
+    private const string YoutubeUrl = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+    private const string YoutubeShortUrl = "https://youtu.be/dQw4w9WgXcQ";
+
+    private static MarkdownPipeline MediaPipeline() =>
+        new MarkdownPipelineBuilder().UseMediaLinks().Build();
+
+    [AvaloniaFact]
+    public void Youtube_image_renders_as_Button()
+    {
+        var result = Render($"![video]({YoutubeUrl})", MediaPipeline());
+        var btn = FindFirst<Button>(result);
+        Assert.NotNull(btn);
+        Assert.Contains("markdown-youtube", btn!.Classes);
+    }
+
+    [AvaloniaFact]
+    public void Youtube_short_url_renders_as_Button()
+    {
+        var result = Render($"![video]({YoutubeShortUrl})", MediaPipeline());
+        var btn = FindFirst<Button>(result);
+        Assert.NotNull(btn);
+        Assert.Contains("markdown-youtube", btn!.Classes);
+    }
+
+    [AvaloniaFact]
+    public void Youtube_button_contains_grid_with_image_and_play_overlay()
+    {
+        var result = Render($"![video]({YoutubeUrl})", MediaPipeline());
+        var btn = FindFirst<Button>(result);
+        Assert.NotNull(btn);
+        var grid = Assert.IsType<Grid>(btn!.Content);
+        Assert.True(grid.Children.Count >= 2, "Grid should have thumbnail Image and play overlay");
+        Assert.Contains(grid.Children, c => c is Image);
+        Assert.Contains(grid.Children, c => c is TextBlock tb && tb.Classes.Contains("markdown-youtube-play"));
+    }
+
+    [AvaloniaFact]
+    public void Non_youtube_image_renders_without_button()
+    {
+        var result = Render("![img](https://example.com/image.png)", MediaPipeline());
+        var btn = FindFirst<Button>(result);
+        Assert.Null(btn);
+    }
+
+    private static T? FindFirst<T>(Control root) where T : Control
+    {
+        if (root is T match) return match;
+        if (root is Panel panel)
+        {
+            foreach (var child in panel.Children)
+            {
+                var found = FindFirst<T>(child);
+                if (found != null) return found;
+            }
+        }
+        if (root is ContentControl cc && cc.Content is Control content)
+            return FindFirst<T>(content);
+        if (root is Decorator dec && dec.Child is Control decChild)
+            return FindFirst<T>(decChild);
+        if (root is TextBlock tb && tb.Inlines != null)
+        {
+            foreach (var inline in tb.Inlines)
+            {
+                if (inline is InlineUIContainer iuc && iuc.Child is Control inlineChild)
+                {
+                    var found = FindFirst<T>(inlineChild);
+                    if (found != null) return found;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/tests/MarkView.Avalonia.Tests/MarkdownViewerDefaultsScope.cs
+++ b/tests/MarkView.Avalonia.Tests/MarkdownViewerDefaultsScope.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace MarkView.Avalonia.Tests;
+
+/// <summary>
+/// Saves and restores <see cref="MarkdownViewerDefaults"/> state around a test,
+/// preventing cross-test pollution from the global mutable statics.
+/// Usage: <c>using var _ = new MarkdownViewerDefaultsScope();</c>
+/// </summary>
+internal sealed class MarkdownViewerDefaultsScope : IDisposable
+{
+    private readonly Markdig.MarkdownPipeline? _savedPipeline;
+    private readonly MarkView.Avalonia.Extensions.IMarkViewExtension[] _savedExtensions;
+
+    public MarkdownViewerDefaultsScope()
+    {
+        _savedPipeline = MarkdownViewerDefaults.Pipeline;
+        _savedExtensions = MarkdownViewerDefaults.Extensions.ToArray();
+    }
+
+    public void Dispose()
+    {
+        MarkdownViewerDefaults.Pipeline = _savedPipeline;
+        MarkdownViewerDefaults.Extensions.Clear();
+        foreach (var e in _savedExtensions)
+            MarkdownViewerDefaults.Extensions.Add(e);
+    }
+}

--- a/tests/MarkView.Avalonia.Tests/MarkdownViewerDefaultsTests.cs
+++ b/tests/MarkView.Avalonia.Tests/MarkdownViewerDefaultsTests.cs
@@ -1,0 +1,138 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Headless.XUnit;
+using Markdig;
+using MarkView.Avalonia.Extensions;
+using MarkView.Avalonia.Rendering;
+using Xunit;
+
+namespace MarkView.Avalonia.Tests;
+
+public class MarkdownViewerDefaultsTests
+{
+    // ── Pipeline resolution ───────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void No_globals_uses_built_in_default_pipeline()
+    {
+        using var _ = new MarkdownViewerDefaultsScope();
+
+        MarkdownViewerDefaults.Pipeline = null;
+
+        var viewer = new MarkdownViewer { Markdown = "hello" };
+
+        // No exception = built-in default pipeline was used
+        Assert.NotNull(viewer.Content);
+    }
+
+    [AvaloniaFact]
+    public void Global_pipeline_used_when_instance_pipeline_is_null()
+    {
+        using var _ = new MarkdownViewerDefaultsScope();
+
+        var globalPipeline = new MarkdownPipelineBuilder().UseSupportedExtensions().Build();
+        MarkdownViewerDefaults.Pipeline = globalPipeline;
+
+        var viewer = new MarkdownViewer { Markdown = "hello" };
+
+        // Pipeline property is null (not set on instance) — global should have been used.
+        // We can only verify indirectly: render should succeed without error.
+        Assert.Null(viewer.Pipeline);
+        Assert.NotNull(viewer.Content);
+    }
+
+    [AvaloniaFact]
+    public void Instance_pipeline_wins_over_global_pipeline()
+    {
+        using var _ = new MarkdownViewerDefaultsScope();
+
+        var globalPipeline = new MarkdownPipelineBuilder().UseSupportedExtensions().Build();
+        var instancePipeline = new MarkdownPipelineBuilder().UseSupportedExtensions().UseFootnotes().Build();
+        MarkdownViewerDefaults.Pipeline = globalPipeline;
+
+        var viewer = new MarkdownViewer
+        {
+            Pipeline = instancePipeline,
+            Markdown = "hello"
+        };
+
+        Assert.Same(instancePipeline, viewer.Pipeline);
+        Assert.NotNull(viewer.Content);
+    }
+
+    // ── Extension composition ─────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void Global_extension_is_registered_once()
+    {
+        using var _ = new MarkdownViewerDefaultsScope();
+
+        var tracker = new TrackingExtension();
+        MarkdownViewerDefaults.Extensions.Add(tracker);
+
+        var viewer = new MarkdownViewer { Markdown = "hello" };
+
+        Assert.Equal(1, tracker.RegisterCallCount);
+    }
+
+    [AvaloniaFact]
+    public void Instance_extension_is_registered_once()
+    {
+        using var _ = new MarkdownViewerDefaultsScope();
+
+        var tracker = new TrackingExtension();
+
+        var viewer = new MarkdownViewer { Markdown = "# hi" };
+        viewer.Extensions.Add(tracker);
+        viewer.Markdown = "# hello"; // trigger re-render
+
+        Assert.Equal(1, tracker.RegisterCallCount);
+    }
+
+    [AvaloniaFact]
+    public void Same_extension_object_in_both_lists_is_registered_exactly_once()
+    {
+        using var _ = new MarkdownViewerDefaultsScope();
+
+        var tracker = new TrackingExtension();
+        MarkdownViewerDefaults.Extensions.Add(tracker);
+
+        var viewer = new MarkdownViewer();
+        viewer.Extensions.Add(tracker); // same object reference
+        viewer.Markdown = "hello";
+
+        Assert.Equal(1, tracker.RegisterCallCount);
+    }
+
+    [AvaloniaFact]
+    public void Global_and_instance_extensions_both_run_global_first()
+    {
+        using var _ = new MarkdownViewerDefaultsScope();
+
+        var order = new List<string>();
+        var globalExt = new OrderTrackingExtension("global", order);
+        var instanceExt = new OrderTrackingExtension("instance", order);
+
+        MarkdownViewerDefaults.Extensions.Add(globalExt);
+
+        var viewer = new MarkdownViewer();
+        viewer.Extensions.Add(instanceExt);
+        viewer.Markdown = "hello";
+
+        Assert.Equal(new[] { "global", "instance" }, order);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private sealed class TrackingExtension : IMarkViewExtension
+    {
+        public int RegisterCallCount { get; private set; }
+        public void Register(AvaloniaRenderer renderer) => RegisterCallCount++;
+    }
+
+    private sealed class OrderTrackingExtension(string name, List<string> log) : IMarkViewExtension
+    {
+        public void Register(AvaloniaRenderer renderer) => log.Add(name);
+    }
+}

--- a/tests/MarkView.Avalonia.Tests/MarkdownViewerDefaultsTests.cs
+++ b/tests/MarkView.Avalonia.Tests/MarkdownViewerDefaultsTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Nicolas Musset
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Markdig;
 using MarkView.Avalonia.Extensions;
@@ -20,10 +21,15 @@ public class MarkdownViewerDefaultsTests
 
         MarkdownViewerDefaults.Pipeline = null;
 
-        var viewer = new MarkdownViewer { Markdown = "hello" };
+        var viewer = new MarkdownViewer { Markdown = "- [ ] item" };
 
-        // No exception = built-in default pipeline was used
-        Assert.NotNull(viewer.Content);
+        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
+        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var rootPanel = contentGrid.Children.OfType<StackPanel>().First();
+
+        // Built-in default uses UseSupportedExtensions which includes UseTaskLists.
+        // A task list item renders a TextBlock with class "markdown-task-list" when the extension is active.
+        Assert.NotNull(FindTaskMarker(rootPanel));
     }
 
     [AvaloniaFact]
@@ -31,15 +37,17 @@ public class MarkdownViewerDefaultsTests
     {
         using var _ = new MarkdownViewerDefaultsScope();
 
-        var globalPipeline = new MarkdownPipelineBuilder().UseSupportedExtensions().Build();
-        MarkdownViewerDefaults.Pipeline = globalPipeline;
+        // A pipeline without UseTaskLists
+        MarkdownViewerDefaults.Pipeline = new MarkdownPipelineBuilder().Build();
 
-        var viewer = new MarkdownViewer { Markdown = "hello" };
+        var viewer = new MarkdownViewer { Markdown = "- [ ] item" };
 
-        // Pipeline property is null (not set on instance) — global should have been used.
-        // We can only verify indirectly: render should succeed without error.
-        Assert.Null(viewer.Pipeline);
-        Assert.NotNull(viewer.Content);
+        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
+        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var rootPanel = contentGrid.Children.OfType<StackPanel>().First();
+
+        // Without UseTaskLists, no task marker is rendered — task list item renders as plain text.
+        Assert.Null(FindTaskMarker(rootPanel));
     }
 
     [AvaloniaFact]
@@ -47,18 +55,22 @@ public class MarkdownViewerDefaultsTests
     {
         using var _ = new MarkdownViewerDefaultsScope();
 
-        var globalPipeline = new MarkdownPipelineBuilder().UseSupportedExtensions().Build();
-        var instancePipeline = new MarkdownPipelineBuilder().UseSupportedExtensions().UseFootnotes().Build();
-        MarkdownViewerDefaults.Pipeline = globalPipeline;
+        // Global has task lists; instance does not
+        MarkdownViewerDefaults.Pipeline = new MarkdownPipelineBuilder().UseSupportedExtensions().Build();
+        var instancePipeline = new MarkdownPipelineBuilder().Build(); // no task lists
 
         var viewer = new MarkdownViewer
         {
             Pipeline = instancePipeline,
-            Markdown = "hello"
+            Markdown = "- [ ] item"
         };
 
-        Assert.Same(instancePipeline, viewer.Pipeline);
-        Assert.NotNull(viewer.Content);
+        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
+        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var rootPanel = contentGrid.Children.OfType<StackPanel>().First();
+
+        // Instance pipeline (no task lists) wins over global — no task marker rendered.
+        Assert.Null(FindTaskMarker(rootPanel));
     }
 
     // ── Extension composition ─────────────────────────────────────────────────
@@ -83,9 +95,9 @@ public class MarkdownViewerDefaultsTests
 
         var tracker = new TrackingExtension();
 
-        var viewer = new MarkdownViewer { Markdown = "# hi" };
+        var viewer = new MarkdownViewer();
         viewer.Extensions.Add(tracker);
-        viewer.Markdown = "# hello"; // trigger re-render
+        viewer.Markdown = "# hello";
 
         Assert.Equal(1, tracker.RegisterCallCount);
     }
@@ -134,5 +146,24 @@ public class MarkdownViewerDefaultsTests
     private sealed class OrderTrackingExtension(string name, List<string> log) : IMarkViewExtension
     {
         public void Register(AvaloniaRenderer renderer) => log.Add(name);
+    }
+
+    private static TextBlock? FindTaskMarker(Control root)
+    {
+        if (root is TextBlock tb && tb.Classes.Contains("markdown-task-list"))
+            return tb;
+        if (root is Panel panel)
+        {
+            foreach (var child in panel.Children)
+            {
+                var found = FindTaskMarker(child);
+                if (found != null) return found;
+            }
+        }
+        if (root is ContentControl cc && cc.Content is Control content)
+            return FindTaskMarker(content);
+        if (root is Decorator dec && dec.Child is Control decChild)
+            return FindTaskMarker(decChild);
+        return null;
     }
 }

--- a/tests/MarkView.Avalonia.Tests/MarkdownViewerExtensionsTests.cs
+++ b/tests/MarkView.Avalonia.Tests/MarkdownViewerExtensionsTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Markdig;
+using Xunit;
+
+namespace MarkView.Avalonia.Tests;
+
+public class MarkdownViewerExtensionsTests
+{
+    [AvaloniaFact]
+    public void UseFootnotes_sets_pipeline_on_viewer()
+    {
+        var viewer = new MarkdownViewer();
+        var result = viewer.UseFootnotes();
+        Assert.Same(viewer, result);
+        Assert.NotNull(viewer.Pipeline);
+    }
+
+    [AvaloniaFact]
+    public void UseAlertBlocks_sets_pipeline_on_viewer()
+    {
+        var viewer = new MarkdownViewer();
+        var result = viewer.UseAlertBlocks();
+        Assert.Same(viewer, result);
+        Assert.NotNull(viewer.Pipeline);
+    }
+
+    [AvaloniaFact]
+    public void UseAbbreviations_sets_pipeline_on_viewer()
+    {
+        var viewer = new MarkdownViewer();
+        var result = viewer.UseAbbreviations();
+        Assert.Same(viewer, result);
+        Assert.NotNull(viewer.Pipeline);
+    }
+
+    [AvaloniaFact]
+    public void UseFigures_sets_pipeline_on_viewer()
+    {
+        var viewer = new MarkdownViewer();
+        var result = viewer.UseFigures();
+        Assert.Same(viewer, result);
+        Assert.NotNull(viewer.Pipeline);
+    }
+
+    [AvaloniaFact]
+    public void UseMediaLinks_sets_pipeline_on_viewer()
+    {
+        var viewer = new MarkdownViewer();
+        var result = viewer.UseMediaLinks();
+        Assert.Same(viewer, result);
+        Assert.NotNull(viewer.Pipeline);
+    }
+
+    [AvaloniaFact]
+    public void UseFootnotes_renders_footnote_when_markdown_set()
+    {
+        var viewer = new MarkdownViewer();
+        viewer.UseFootnotes();
+        viewer.Markdown = "Text[^1]\n\n[^1]: Definition";
+
+        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
+        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var panel = Assert.IsType<StackPanel>(contentGrid.Children[0]);
+        // Footnote group should be the last child
+        Assert.True(panel.Children.Count >= 2, "Expected content + footnote group");
+    }
+
+    [AvaloniaFact]
+    public void UseAlertBlocks_renders_alert_border_when_markdown_set()
+    {
+        var viewer = new MarkdownViewer();
+        viewer.UseAlertBlocks();
+        viewer.Markdown = "> [!NOTE]\n> Hello";
+
+        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
+        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var panel = Assert.IsType<StackPanel>(contentGrid.Children[0]);
+        var border = Assert.IsType<Border>(Assert.Single(panel.Children));
+        Assert.Contains("markdown-alert", border.Classes);
+    }
+}


### PR DESCRIPTION
## Summary

- `MarkdownViewerDefaults`: new static class with `Pipeline?` and `Extensions` — set once at app startup to configure every `MarkdownViewer` instance globally; per-instance `Pipeline` and `Extensions` still take priority (pipeline: last-writer-wins; extensions: globals first, then per-instance, exact-reference duplicates skipped via a `HashSet<ReferenceEqualityComparer>`)
- `MarkdownViewer.RenderMarkdown()`: pipeline resolution changed to `instance.Pipeline ?? MarkdownViewerDefaults.Pipeline ?? DefaultPipeline`; extension loop updated to run globals then instance extensions with deduplication
- `LinkClicked` promoted to a bubbling `RoutedEvent<LinkClickedEventArgs>` — enables app-level class handlers (`MarkdownViewer.LinkClickedEvent.AddClassHandler<MarkdownViewer>(...)`) and window-level handlers (`window.AddHandler(MarkdownViewer.LinkClickedEvent, ...)`); `LinkClickedEventArgs` now extends `RoutedEventArgs`; CLR event wrapper unchanged (existing `+=` subscriptions compile without modification)
- `IList<IMarkViewExtension>` extension methods: `AddTextMateHighlighting()` (SyntaxHighlighting), `AddMermaid()` (Mermaid), `AddSvg()` (Svg) — unifies per-instance and global API: `viewer.Extensions.AddMermaid()` and `MarkdownViewerDefaults.Extensions.AddMermaid()` are the same call
- `BitmapImageLoader` added as default image loader in `AvaloniaRenderer` (pre-populated at index 0; extensions insert before it as higher-priority loaders)
- Opt-in Markdig block renderers: Footnotes, AlertBlocks, Abbreviations, Figures, MediaLinks (YouTube embeds) — each with `MarkdownViewer.UseXxx()` convenience method and matching theme styles
- Demo updated to use `MarkdownViewerDefaults` and a class-level link handler; `MainWindow` reduced to 10 lines

## Type of change

- [x] New feature
- [x] Refactoring (no behaviour change)

## Test plan

- [x] `dotnet test` — all tests pass (204/204, 2 pre-existing SVG isolation failures also fixed)
- [x] `MarkdownViewerDefaultsTests` — 7 behavioural tests covering pipeline resolution and extension composition
- [x] Manual smoke-test in the demo app
