### PR TITLE
demo: load from file, in-app navigation, history + fix slug and fragment

### DIFF
--- a/samples/MarkView.Avalonia.Demo/App.axaml.cs
+++ b/samples/MarkView.Avalonia.Demo/App.axaml.cs
@@ -33,8 +33,32 @@ public class App : Application
         MarkdownViewerDefaults.Extensions.AddMermaid();
 
         // Global link handler — handles external links for every MarkdownViewer in the app
-        MarkdownViewer.LinkClickedEvent.AddClassHandler<MarkdownViewer>((_, e) =>
+        MarkdownViewer.LinkClickedEvent.AddClassHandler<MarkdownViewer>(OnLinkClicked);
+
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
+            desktop.MainWindow = new MainWindow();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+        return;
+
+        static void OnLinkClicked(MarkdownViewer sender, Rendering.LinkClickedEventArgs e)
+        {
+            // If the link resolves to a local .md file, open it in the viewer instead of the browser.
+            if (Uri.TryCreate(e.Url, UriKind.Absolute, out var uri)
+                && uri.IsFile
+                && (uri.LocalPath.EndsWith(".md", StringComparison.OrdinalIgnoreCase)
+                    || uri.LocalPath.EndsWith(".markdown", StringComparison.OrdinalIgnoreCase)))
+            {
+                var path = uri.LocalPath;
+                if (File.Exists(path))
+                {
+                    ((MainViewModel)sender.DataContext!).LoadFile(path);
+                    return;
+                }
+            }
+
             try
             {
                 Process.Start(new ProcessStartInfo(e.Url) { UseShellExecute = true });
@@ -43,13 +67,6 @@ public class App : Application
             {
                 // Ignore failures to open browser
             }
-        });
-
-        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
-        {
-            desktop.MainWindow = new MainWindow();
         }
-
-        base.OnFrameworkInitializationCompleted();
     }
 }

--- a/samples/MarkView.Avalonia.Demo/App.axaml.cs
+++ b/samples/MarkView.Avalonia.Demo/App.axaml.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
 
 using Markdig;
 
@@ -55,6 +56,9 @@ public class App : Application
                 if (File.Exists(path))
                 {
                     ((MainViewModel)sender.DataContext!).LoadFile(path);
+                    var fragment = uri.Fragment.TrimStart('#');
+                    if (!string.IsNullOrEmpty(fragment))
+                        Dispatcher.UIThread.Post(() => sender.ScrollToAnchor(fragment), DispatcherPriority.Loaded);
                     return;
                 }
             }

--- a/samples/MarkView.Avalonia.Demo/MainViewModel.cs
+++ b/samples/MarkView.Avalonia.Demo/MainViewModel.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.ComponentModel;
-using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
@@ -248,6 +247,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
         """;
 
     private string? _markdown;
+    private Uri? _baseUri;
     private int _selectedIndex;
     private bool _isLightTheme;
 
@@ -279,6 +279,12 @@ public sealed class MainViewModel : INotifyPropertyChanged
         private set => SetField(ref _markdown, value);
     }
 
+    public Uri? BaseUri
+    {
+        get => _baseUri;
+        private set => SetField(ref _baseUri, value);
+    }
+
     public MainViewModel()
     {
         LoadContent();
@@ -286,12 +292,20 @@ public sealed class MainViewModel : INotifyPropertyChanged
 
     private void LoadContent()
     {
+        BaseUri = null;
         Markdown = _selectedIndex switch
         {
             0 => ShowcaseMarkdown,
             1 => ExtensionsShowcaseMarkdown,
             _ => ReadmeMarkdown,
         };
+    }
+
+    public void LoadFile(string filePath)
+    {
+        var dir = Path.GetFullPath(Path.GetDirectoryName(filePath)!);
+        BaseUri = new Uri(dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar);
+        Markdown = File.ReadAllText(filePath);
     }
 
     private static string LoadReadme()

--- a/samples/MarkView.Avalonia.Demo/MainViewModel.cs
+++ b/samples/MarkView.Avalonia.Demo/MainViewModel.cs
@@ -246,6 +246,10 @@ public sealed class MainViewModel : INotifyPropertyChanged
         ![Big Buck Bunny trailer](https://youtu.be/aqz-KE-bpKQ)
         """;
 
+    private readonly List<(string? Markdown, Uri? BaseUri)> _history = [];
+    private int _historyIndex = -1;
+    private bool _navigating;
+
     private string? _markdown;
     private Uri? _baseUri;
     private int _selectedIndex;
@@ -285,6 +289,49 @@ public sealed class MainViewModel : INotifyPropertyChanged
         private set => SetField(ref _baseUri, value);
     }
 
+    public bool CanGoBack => _historyIndex > 0;
+    public bool CanGoForward => _historyIndex < _history.Count - 1;
+
+    public void GoBack()
+    {
+        if (!CanGoBack) return;
+        _historyIndex--;
+        RestoreEntry(_history[_historyIndex]);
+    }
+
+    public void GoForward()
+    {
+        if (!CanGoForward) return;
+        _historyIndex++;
+        RestoreEntry(_history[_historyIndex]);
+    }
+
+    private void RestoreEntry((string? Markdown, Uri? BaseUri) entry)
+    {
+        _navigating = true;
+        BaseUri = entry.BaseUri;
+        Markdown = entry.Markdown;
+        _navigating = false;
+        NotifyNavigation();
+    }
+
+    private void PushEntry(string? markdown, Uri? baseUri)
+    {
+        if (_navigating) return;
+        // Discard any forward entries
+        if (_historyIndex < _history.Count - 1)
+            _history.RemoveRange(_historyIndex + 1, _history.Count - _historyIndex - 1);
+        _history.Add((markdown, baseUri));
+        _historyIndex = _history.Count - 1;
+        NotifyNavigation();
+    }
+
+    private void NotifyNavigation()
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CanGoBack)));
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CanGoForward)));
+    }
+
     public MainViewModel()
     {
         LoadContent();
@@ -299,6 +346,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
             1 => ExtensionsShowcaseMarkdown,
             _ => ReadmeMarkdown,
         };
+        PushEntry(Markdown, null);
     }
 
     public void LoadFile(string filePath)
@@ -306,6 +354,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
         var dir = Path.GetFullPath(Path.GetDirectoryName(filePath)!);
         BaseUri = new Uri(dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar);
         Markdown = File.ReadAllText(filePath);
+        PushEntry(Markdown, BaseUri);
     }
 
     private static string LoadReadme()

--- a/samples/MarkView.Avalonia.Demo/MainWindow.axaml
+++ b/samples/MarkView.Avalonia.Demo/MainWindow.axaml
@@ -15,6 +15,16 @@
         <ComboBox ItemsSource="{Binding Views}"
                   SelectedIndex="{Binding SelectedIndex}"
                   MinWidth="120" />
+        <Button Content="←"
+                Click="OnGoBackClicked"
+                IsEnabled="{Binding CanGoBack}"
+                ToolTip.Tip="Go back"
+                VerticalAlignment="Center" />
+        <Button Content="→"
+                Click="OnGoForwardClicked"
+                IsEnabled="{Binding CanGoForward}"
+                ToolTip.Tip="Go forward"
+                VerticalAlignment="Center" />
         <Button Content="Open file…"
                 Click="OnOpenFileClicked"
                 VerticalAlignment="Center" />

--- a/samples/MarkView.Avalonia.Demo/MainWindow.axaml
+++ b/samples/MarkView.Avalonia.Demo/MainWindow.axaml
@@ -15,6 +15,9 @@
         <ComboBox ItemsSource="{Binding Views}"
                   SelectedIndex="{Binding SelectedIndex}"
                   MinWidth="120" />
+        <Button Content="Open file…"
+                Click="OnOpenFileClicked"
+                VerticalAlignment="Center" />
         <ToggleButton IsChecked="{Binding IsLightTheme}"
                       Content="Light theme"
                       VerticalAlignment="Center" />
@@ -23,7 +26,8 @@
 
     <!-- Markdown content -->
     <mv:MarkdownViewer x:Name="MarkdownView"
-                       Markdown="{Binding Markdown}" />
+                       Markdown="{Binding Markdown}"
+                       BaseUri="{Binding BaseUri}" />
   </DockPanel>
 
 </Window>

--- a/samples/MarkView.Avalonia.Demo/MainWindow.axaml.cs
+++ b/samples/MarkView.Avalonia.Demo/MainWindow.axaml.cs
@@ -12,6 +12,12 @@ public partial class MainWindow : Window
         DataContext = new MainViewModel();
     }
 
+    private void OnGoBackClicked(object? sender, RoutedEventArgs e) =>
+        ((MainViewModel)DataContext!).GoBack();
+
+    private void OnGoForwardClicked(object? sender, RoutedEventArgs e) =>
+        ((MainViewModel)DataContext!).GoForward();
+
     private async void OnOpenFileClicked(object? sender, RoutedEventArgs e)
     {
         var files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions

--- a/samples/MarkView.Avalonia.Demo/MainWindow.axaml.cs
+++ b/samples/MarkView.Avalonia.Demo/MainWindow.axaml.cs
@@ -1,4 +1,6 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
 
 namespace MarkView.Avalonia.Demo;
 
@@ -8,5 +10,26 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
         DataContext = new MainViewModel();
+    }
+
+    private async void OnOpenFileClicked(object? sender, RoutedEventArgs e)
+    {
+        var files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Open Markdown file",
+            AllowMultiple = false,
+            FileTypeFilter =
+            [
+                new FilePickerFileType("Markdown files") { Patterns = ["*.md", "*.markdown"] },
+                new FilePickerFileType("All files")      { Patterns = ["*"] },
+            ],
+        });
+
+        if (files is [var file])
+        {
+            var path = file.TryGetLocalPath();
+            if (path is not null)
+                ((MainViewModel)DataContext!).LoadFile(path);
+        }
     }
 }

--- a/src/MarkView.Avalonia/MarkdownViewer.cs
+++ b/src/MarkView.Avalonia/MarkdownViewer.cs
@@ -459,7 +459,7 @@ public partial class MarkdownViewer : ContentControl
         RaiseEvent(e);
     }
 
-    private void ScrollToAnchor(string anchorId)
+    public void ScrollToAnchor(string anchorId)
     {
         if (!_anchors.TryGetValue(anchorId, out var control))
             return;

--- a/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
@@ -224,11 +224,21 @@ public class AvaloniaRenderer : RendererBase
 
     /// <summary>
     /// Resolves a URL against the <see cref="BaseUri"/> if set and the URL is relative.
+    /// The fragment part (everything from <c>#</c> onward) is split off before combining
+    /// with the base URI so that <c>#</c> is never percent-encoded to <c>%23</c>.
     /// </summary>
     public string ResolveUrl(string url)
     {
         if (BaseUri != null && Uri.TryCreate(url, UriKind.Relative, out _))
         {
+            // Separate path from fragment before combining to prevent '#' → '%23' encoding.
+            var hashIdx = url.IndexOf('#');
+            if (hashIdx >= 0)
+            {
+                var path = url[..hashIdx];
+                var fragment = url[hashIdx..]; // includes the '#'
+                return new Uri(BaseUri, path) + fragment;
+            }
             return new Uri(BaseUri, url).ToString();
         }
         return url;

--- a/src/MarkView.Avalonia/Rendering/Blocks/HeadingRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/HeadingRenderer.cs
@@ -30,14 +30,35 @@ public class HeadingRenderer : AvaloniaObjectRenderer<HeadingBlock>
 
         // Generate anchor slug and register for fragment navigation
         var sb = new System.Text.StringBuilder();
-        if (obj.Inline is not null)
-            foreach (var c in obj.Inline)
-                if (c is LiteralInline lit) sb.Append(lit.Content.AsSpan());
-        var headingText = sb.ToString();
-        var slug = renderer.SlugGenerator.GenerateSlug(headingText);
+        ExtractText(obj.Inline, sb);
+        var slug = renderer.SlugGenerator.GenerateSlug(sb.ToString());
         textBlock.Tag = slug;
         renderer.RegisterAnchor(slug, textBlock);
 
         renderer.WriteBlock(textBlock);
+    }
+
+    /// <summary>
+    /// Recursively extracts plain text from an inline tree, matching GitHub's behaviour:
+    /// literal text and code-span content are included; container inlines are descended into.
+    /// </summary>
+    private static void ExtractText(Markdig.Syntax.Inlines.Inline? inline, System.Text.StringBuilder sb)
+    {
+        while (inline is not null)
+        {
+            switch (inline)
+            {
+                case LiteralInline lit:
+                    sb.Append(lit.Content.AsSpan());
+                    break;
+                case Markdig.Syntax.Inlines.CodeInline code:
+                    sb.Append(code.Content);
+                    break;
+                case ContainerInline container:
+                    ExtractText(container.FirstChild, sb);
+                    break;
+            }
+            inline = inline.NextSibling;
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **Demo — Open file from disk:** Added an "Open file" button (MainWindow) that lets the user load any .md file via the system file picker; App.axaml.cs wires up the storage provider and passes the path to the view-model.
- **Demo — In-app relative link navigation:** Clicking a relative .md link now opens the target file inside the viewer instead of launching the default browser; MainViewModel resolves the path relative to the current file.
- **Demo — Back/forward history:** MainViewModel maintains a navigation stack so the toolbar Back / Forward buttons move through previously viewed files.
- **Fix — URL fragment preservation:** AvaloniaRenderer.ResolveUrl and the cross-file link handler no longer strip the #fragment part of a URL when resolving relative paths.
- **Fix — Heading slug with nested inlines:** HeadingRenderer now walks the full inline tree (including \CodeSpan\ and other inline nodes) when computing the GitHub-style slug, so headings like \## Use \Foo\\ produce the correct anchor \#use-foo\.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [ ] Documentation
- [ ] CI / build

## Test plan

- [x] \dotnet test\ — all tests pass
- [x] Manual smoke-test in the demo app
