### PR TITLE
feat: implement all EmphasisExtras — subscript, superscript, inserted, marked

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,7 @@ dotnet add package MarkView.Avalonia.SyntaxHighlighting
 ```
 
 ```csharp
-using TextMateSharp.Grammars;
-
-viewer.UseTextMateHighlighting(ThemeName.DarkPlus); // default theme
+viewer.UseTextMateHighlighting(); // DarkPlus / LightPlus by default
 ```
 
 The extension replaces the built-in `CodeBlockRenderer` with `TextMateCodeBlockRenderer`, which tokenises each line and emits coloured `Run` elements. Unsupported languages fall back to the default monochrome rendering automatically.
@@ -105,14 +103,14 @@ The extension inserts `SvgImageLoader` at the front of the image loader chain. R
 
 ### Mermaid Diagrams (`MarkView.Avalonia.Mermaid`)
 
-Renders fenced `mermaid` code blocks as SVG diagrams using the [Mermaider](https://github.com/FoggyBalrog/Mermaider) library (pure .NET, no browser required). Works on all platforms including Linux. Diagrams re-render automatically when the user switches between light and dark themes.
+Renders fenced `mermaid` code blocks as SVG diagrams using the [Mermaider](https://github.com/nullean/mermaider) library (pure .NET, no browser required). Works on all platforms including Linux. Diagrams re-render automatically when the user switches between light and dark themes.
 
 ```bash
 dotnet add package MarkView.Avalonia.Mermaid
 ```
 
 ```csharp
-viewer.UseMermaid(initialHeight: 300); // height in device-independent pixels
+viewer.UseMermaid();
 ```
 
 Markdown syntax:

--- a/samples/MarkView.Avalonia.Demo/MainViewModel.cs
+++ b/samples/MarkView.Avalonia.Demo/MainViewModel.cs
@@ -25,6 +25,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
 
         - [Headings](#headings)
         - [Text Formatting](#text-formatting)
+        - [Emphasis Extras](#emphasis-extras)
         - [Blockquotes](#blockquotes)
         - [Task List](#task-list)
         - [Tables](#tables)
@@ -51,6 +52,19 @@ public sealed class MainViewModel : INotifyPropertyChanged
         Regular paragraph with **bold text**, *italic text*, ~~strikethrough~~, and `inline code`.
 
         You can also combine them: ***bold and italic***, **`bold code`**, *~~italic strikethrough~~*.
+
+        ---
+
+        ## Emphasis Extras
+
+        The `EmphasisExtras` Markdig extension unlocks four additional inline styles:
+
+        | Syntax | Result | Description |
+        |--------|--------|-----------|
+        | `~text~` | H~2~O | Subscript |
+        | `^text^` | x^2^ + y^2^ = r^2^ | Superscript |
+        | `++text++` | ++inserted++ | Underline (inserted) |
+        | `==text==` | ==marked== | Highlighted (marked) |
 
         ---
 

--- a/src/MarkView.Avalonia/Rendering/Inlines/EmphasisInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/EmphasisInlineRenderer.cs
@@ -14,9 +14,34 @@ public class EmphasisInlineRenderer : AvaloniaObjectRenderer<EmphasisInline>
     {
         Span span = obj.DelimiterChar switch
         {
+            // bold
             '*' or '_' when obj.DelimiterCount == 2 => new Bold(),
+            // italic
             '*' or '_' => new Italic(),
-            '~' when obj.DelimiterCount == 2 => CreateStrikethrough(),
+            // strikethrough
+            '~' when obj.DelimiterCount == 2 => new Span
+            {
+                TextDecorations = TextDecorations.Strikethrough
+            },
+            // subscript
+            '~' => new Span
+            {
+                BaselineAlignment = BaselineAlignment.Subscript,
+                FontFeatures = [FontFeature.Parse("subs")]
+            },
+            // superscript
+            '^' => new Span
+            {
+                BaselineAlignment = BaselineAlignment.Superscript,
+                FontFeatures = [FontFeature.Parse("sups")]
+            },
+            // underline
+            '+' when obj.DelimiterCount == 2 => new Underline(),
+            // marked
+            '=' when obj.DelimiterCount == 2 => new Span
+            {
+                Classes = { "markdown-marked" }
+            },
             _ => new Span(),
         };
 
@@ -25,12 +50,5 @@ public class EmphasisInlineRenderer : AvaloniaObjectRenderer<EmphasisInline>
         renderer.Pop();
 
         renderer.WriteInline(span);
-    }
-
-    private static Span CreateStrikethrough()
-    {
-        var span = new Span();
-        span.TextDecorations = TextDecorations.Strikethrough;
-        return span;
     }
 }

--- a/src/MarkView.Avalonia/Themes/MarkdownTheme.axaml
+++ b/src/MarkView.Avalonia/Themes/MarkdownTheme.axaml
@@ -22,6 +22,7 @@
           <SolidColorBrush x:Key="MarkdownAlertWarningBackground">#1AEAB308</SolidColorBrush>
           <SolidColorBrush x:Key="MarkdownAlertCautionBorder">#EF4444</SolidColorBrush>
           <SolidColorBrush x:Key="MarkdownAlertCautionBackground">#1AEF4444</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownMarkedBackground">#5C4B00</SolidColorBrush>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Light">
           <SolidColorBrush x:Key="MarkdownCodeBlockBackground">#F3F3F3</SolidColorBrush>
@@ -39,6 +40,7 @@
           <SolidColorBrush x:Key="MarkdownAlertWarningBackground">#FEFCE8</SolidColorBrush>
           <SolidColorBrush x:Key="MarkdownAlertCautionBorder">#DC2626</SolidColorBrush>
           <SolidColorBrush x:Key="MarkdownAlertCautionBackground">#FEF2F2</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownMarkedBackground">#FFFF00</SolidColorBrush>
         </ResourceDictionary>
       </ResourceDictionary.ThemeDictionaries>
     </ResourceDictionary>
@@ -99,6 +101,11 @@
     <Setter Property="FontFamily" Value="Cascadia Code, Consolas, Courier New, monospace"/>
     <Setter Property="Background" Value="{DynamicResource MarkdownCodeInlineBackground}"/>
     <Setter Property="Foreground" Value="{DynamicResource MarkdownCodeInlineForeground}"/>
+  </Style>
+
+  <!-- Marked / highlighted text -->
+  <Style Selector="Span.markdown-marked">
+    <Setter Property="Background" Value="{DynamicResource MarkdownMarkedBackground}"/>
   </Style>
 
   <!-- Blockquote -->

--- a/tests/MarkView.Avalonia.Tests/Inlines/EmphasisTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Inlines/EmphasisTests.cs
@@ -6,6 +6,7 @@ using Avalonia.Headless.XUnit;
 using Avalonia.Media;
 
 using Markdig;
+using Markdig.Syntax.Inlines;
 
 using MarkView.Avalonia.Rendering;
 
@@ -53,5 +54,81 @@ public class EmphasisTests : RenderTestBase
         var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(result.Children));
         var span = Assert.IsType<Span>(Assert.Single(textBlock.Inlines!));
         Assert.Equal(TextDecorations.Strikethrough, span.TextDecorations);
+    }
+
+    [AvaloniaFact]
+    public void Subscript_text_renders_with_subscript_baseline_alignment()
+    {
+        var pipeline = new MarkdownPipelineBuilder().UseEmphasisExtras().Build();
+        var result = Render("H~2~O", pipeline);
+
+        var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(result.Children));
+        var span = textBlock.Inlines!.OfType<Span>().Single();
+        Assert.Equal(BaselineAlignment.Subscript, span.BaselineAlignment);
+    }
+
+    [AvaloniaFact]
+    public void Superscript_text_renders_with_superscript_baseline_alignment()
+    {
+        var pipeline = new MarkdownPipelineBuilder().UseEmphasisExtras().Build();
+        var result = Render("E=mc^2^", pipeline);
+
+        var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(result.Children));
+        var span = textBlock.Inlines!.OfType<Span>().Single();
+        Assert.Equal(BaselineAlignment.Superscript, span.BaselineAlignment);
+    }
+
+    [AvaloniaFact]
+    public void Inserted_text_renders_with_underline_decoration()
+    {
+        var pipeline = new MarkdownPipelineBuilder().UseEmphasisExtras().Build();
+        var result = Render("++inserted++", pipeline);
+
+        var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(result.Children));
+        var span = Assert.IsType<Underline>(Assert.Single(textBlock.Inlines!));
+        Assert.Equal(TextDecorations.Underline, span.TextDecorations);
+    }
+
+    [AvaloniaFact]
+    public void Marked_text_renders_with_markdown_marked_class()
+    {
+        var pipeline = new MarkdownPipelineBuilder().UseEmphasisExtras().Build();
+        var result = Render("==highlighted==", pipeline);
+
+        var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(result.Children));
+        var span = Assert.IsType<Span>(Assert.Single(textBlock.Inlines!));
+        Assert.Contains("markdown-marked", span.Classes);
+    }
+
+    [AvaloniaFact]
+    public void Inserted_single_plus_falls_through_to_plain_span()
+    {
+        var span = RenderEmphasisInlineDirect('+', delimiterCount: 1);
+        Assert.IsNotType<Underline>(span);
+        Assert.Null(span.TextDecorations);
+    }
+
+    [AvaloniaFact]
+    public void Marked_single_equals_falls_through_to_plain_span()
+    {
+        var span = RenderEmphasisInlineDirect('=', delimiterCount: 1);
+        Assert.DoesNotContain("markdown-marked", span.Classes);
+    }
+
+    private static Span RenderEmphasisInlineDirect(char delimiterChar, int delimiterCount)
+    {
+        var renderer = new AvaloniaRenderer();
+        var pipeline = new MarkdownPipelineBuilder().Build();
+        pipeline.Setup(renderer);
+
+        var container = new Span();
+        renderer.Push(container.Inlines);
+
+        var inline = new EmphasisInline { DelimiterChar = delimiterChar, DelimiterCount = delimiterCount };
+        inline.AppendChild(new LiteralInline("text"));
+        renderer.Write(inline);
+
+        renderer.Pop();
+        return Assert.IsType<Span>(Assert.Single(container.Inlines));
     }
 }


### PR DESCRIPTION
## Summary

- **Subscript (`~text~`):** `EmphasisInlineRenderer` maps single-`~` delimiter to a `Span` with `BaselineAlignment.Subscript` and the `subs` OpenType font feature.
- **Superscript (`^text^`):** `^` delimiter maps to a `Span` with `BaselineAlignment.Superscript` and the `sups` OpenType font feature.
- **nserted / underline (`++text++`):** double-`+` delimiter maps to `new Underline()`.
- **Marked / highlight (`==text==`):** double-`=` delimiter maps to a `Span` with CSS class `markdown-marked`; `MarkdownMarkedBackground` added to both dark and light theme dictionaries.
- **fix delimiter-count guards:** `+` and `=` cases are guarded with `DelimiterCount == 2` so single `+` and `=` pass through as plain text.
- **Feature Showcase:** new *Emphasis Extras* section (with ToC entry) shows all four new inline styles in a live table.
- **README fixes:** removed non-existent `initialHeight` parameter from `UseMermaid()`, corrected `UseTextMateHighlighting()` call signature, and fixed Mermaider GitHub URL (`nullean/mermaider`).

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [x] Documentation
- [ ] CI / build

## Test plan

- [x] `dotnet test` — all tests pass (6 new tests covering all EmphasisExtras cases and delimiter-count guards)
- [x] Manual smoke-test in the demo app
