### PR TITLE
perf: reduce allocations and fix event-handler lifecycle in rendering pipeline

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,12 +13,12 @@
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.*" />
     <PackageVersion Include="Markdig" Version="1.1.*" />
     <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.*" />
-    <PackageVersion Include="TextMateSharp" Version="1.*" />
-    <PackageVersion Include="TextMateSharp.Grammars" Version="1.*" />
+    <PackageVersion Include="TextMateSharp" Version="2.*" />
+    <PackageVersion Include="TextMateSharp.Grammars" Version="2.*" />
     <!-- Test dependencies -->
     <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.*" />
-    <PackageVersion Include="coverlet.collector" Version="6.*" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageVersion Include="coverlet.collector" Version="8.*" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.*" />
     <PackageVersion Include="xunit.v3" Version="3.*" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.*" />
   </ItemGroup>

--- a/src/MarkView.Avalonia.Mermaid/MermaidBlockRenderer.cs
+++ b/src/MarkView.Avalonia.Mermaid/MermaidBlockRenderer.cs
@@ -64,7 +64,7 @@ public class MermaidBlockRenderer : AvaloniaObjectRenderer<FencedCodeBlock>
                 if (sv is null) return;
 
                 sv.SizeChanged += OnSizeChanged;
-                image.DetachedFromVisualTree += (_, _) =>
+                image.DetachedFromLogicalTree += (_, _) =>
                 {
                     sv.SizeChanged -= OnSizeChanged;
                     Application.Current?.PropertyChanged -= OnThemeChanged;
@@ -249,7 +249,7 @@ public class MermaidBlockRenderer : AvaloniaObjectRenderer<FencedCodeBlock>
                 BuildInlines(textBlock, themeAware, language, newIsDark, lineTexts);
             }
             Application.Current!.PropertyChanged += OnThemeChanged;
-            border.DetachedFromVisualTree += (_, _) => Application.Current?.PropertyChanged -= OnThemeChanged;
+            border.DetachedFromLogicalTree += (_, _) => Application.Current?.PropertyChanged -= OnThemeChanged;
         }
 
         renderer.WriteBlock(border);

--- a/src/MarkView.Avalonia.Mermaid/MermaidBlockRenderer.cs
+++ b/src/MarkView.Avalonia.Mermaid/MermaidBlockRenderer.cs
@@ -230,9 +230,13 @@ public class MermaidBlockRenderer : AvaloniaObjectRenderer<FencedCodeBlock>
         }
 
         // Materialise source lines once so they can be reused on theme change.
-        var lineTexts = new List<string>(obj.Lines.Count);
+        // AsMemory() references the Markdig source buffer directly — no per-line allocation.
+        var lineTexts = new List<ReadOnlyMemory<char>>(obj.Lines.Count);
         for (int i = 0; i < obj.Lines.Count; i++)
-            lineTexts.Add(obj.Lines.Lines[i].Slice.ToString());
+        {
+            var slice = obj.Lines.Lines[i].Slice;
+            lineTexts.Add(slice.Text.AsMemory(slice.Start, slice.Length));
+        }
 
         var isDark = Application.Current?.ActualThemeVariant == ThemeVariant.Dark;
         BuildInlines(textBlock, renderer.CodeHighlighter, language, isDark, lineTexts);
@@ -260,7 +264,7 @@ public class MermaidBlockRenderer : AvaloniaObjectRenderer<FencedCodeBlock>
         ICodeHighlighter? highlighter,
         string? language,
         bool isDark,
-        IReadOnlyList<string> lineTexts)
+        IReadOnlyList<ReadOnlyMemory<char>> lineTexts)
     {
         for (int i = 0; i < lineTexts.Count; i++)
         {
@@ -283,7 +287,7 @@ public class MermaidBlockRenderer : AvaloniaObjectRenderer<FencedCodeBlock>
             }
             else
             {
-                textBlock.Inlines!.Add(new Run(lineText));
+                textBlock.Inlines!.Add(new Run(lineText.ToString()));
             }
         }
     }

--- a/src/MarkView.Avalonia.SyntaxHighlighting/DualThemeTextMateHighlighter.cs
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/DualThemeTextMateHighlighter.cs
@@ -17,9 +17,9 @@ namespace MarkView.Avalonia.SyntaxHighlighting;
 internal sealed class DualThemeTextMateHighlighter(TextMateHighlighter dark, TextMateHighlighter light)
     : IThemeAwareCodeHighlighter
 {
-    public IReadOnlyList<(string Text, IBrush? Foreground)>? Highlight(string line, string? language)
+    public IReadOnlyList<(string Text, IBrush? Foreground)>? Highlight(ReadOnlyMemory<char> line, string? language)
         => HighlightVariant(line, language, Application.Current?.ActualThemeVariant == ThemeVariant.Dark);
 
-    public IReadOnlyList<(string Text, IBrush? Foreground)>? HighlightVariant(string line, string? language, bool isDark)
+    public IReadOnlyList<(string Text, IBrush? Foreground)>? HighlightVariant(ReadOnlyMemory<char> line, string? language, bool isDark)
         => isDark ? dark.Highlight(line, language) : light.Highlight(line, language);
 }

--- a/src/MarkView.Avalonia.SyntaxHighlighting/TextMateCodeBlockRenderer.cs
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/TextMateCodeBlockRenderer.cs
@@ -60,7 +60,7 @@ public class TextMateCodeBlockRenderer : AvaloniaObjectRenderer<CodeBlock>
                 BuildInlines(textBlock, themeAware, language, newIsDark, lineTexts);
             }
             Application.Current!.PropertyChanged += OnThemeChanged;
-            border.DetachedFromVisualTree += (_, _) => Application.Current?.PropertyChanged -= OnThemeChanged;
+            border.DetachedFromLogicalTree += (_, _) => Application.Current?.PropertyChanged -= OnThemeChanged;
         }
 
         renderer.WriteBlock(border);

--- a/src/MarkView.Avalonia.SyntaxHighlighting/TextMateCodeBlockRenderer.cs
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/TextMateCodeBlockRenderer.cs
@@ -41,9 +41,13 @@ public class TextMateCodeBlockRenderer : AvaloniaObjectRenderer<CodeBlock>
         }
 
         // Materialise source lines once so they can be reused on theme change.
-        var lineTexts = new List<string>(obj.Lines.Count);
+        // AsMemory() references the Markdig source buffer directly — no per-line allocation.
+        var lineTexts = new List<ReadOnlyMemory<char>>(obj.Lines.Count);
         for (int i = 0; i < obj.Lines.Count; i++)
-            lineTexts.Add(obj.Lines.Lines[i].Slice.ToString());
+        {
+            var slice = obj.Lines.Lines[i].Slice;
+            lineTexts.Add(slice.Text.AsMemory(slice.Start, slice.Length));
+        }
 
         var isDark = Application.Current?.ActualThemeVariant == ThemeVariant.Dark;
         BuildInlines(textBlock, renderer.CodeHighlighter, language, isDark, lineTexts);
@@ -71,7 +75,7 @@ public class TextMateCodeBlockRenderer : AvaloniaObjectRenderer<CodeBlock>
         ICodeHighlighter? highlighter,
         string? language,
         bool isDark,
-        IReadOnlyList<string> lineTexts)
+        IReadOnlyList<ReadOnlyMemory<char>> lineTexts)
     {
         for (int i = 0; i < lineTexts.Count; i++)
         {
@@ -94,7 +98,7 @@ public class TextMateCodeBlockRenderer : AvaloniaObjectRenderer<CodeBlock>
             }
             else
             {
-                textBlock.Inlines!.Add(new Run(lineText));
+                textBlock.Inlines!.Add(new Run(lineText.ToString()));
             }
         }
     }

--- a/src/MarkView.Avalonia.SyntaxHighlighting/TextMateHighlighter.cs
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/TextMateHighlighter.cs
@@ -34,7 +34,7 @@ public class TextMateHighlighter : ICodeHighlighter
     }
 
     /// <inheritdoc/>
-    public IReadOnlyList<(string Text, IBrush? Foreground)>? Highlight(string line, string? language)
+    public IReadOnlyList<(string Text, IBrush? Foreground)>? Highlight(ReadOnlyMemory<char> line, string? language)
     {
         if (string.IsNullOrEmpty(language))
             return null;
@@ -63,8 +63,10 @@ public class TextMateHighlighter : ICodeHighlighter
         return grammar;
     }
 
-    private IReadOnlyList<(string Text, IBrush? Foreground)> TokenizeLine(IGrammar grammar, string line)
+    private IReadOnlyList<(string Text, IBrush? Foreground)> TokenizeLine(IGrammar grammar, ReadOnlyMemory<char> line)
     {
+        // Implicit ReadOnlyMemory<char> → LineText conversion; TextMateSharp 2.x uses
+        // ArrayPool internally for the required trailing '\n', avoiding a string allocation.
         var result = grammar.TokenizeLine(line, null, TimeSpan.MaxValue);
         var tokens = new List<(string Text, IBrush? Foreground)>(result.Tokens.Length);
 
@@ -80,7 +82,7 @@ public class TextMateHighlighter : ICodeHighlighter
             if (start >= end)
                 continue;
 
-            var text = line[start..end];
+            var text = line.Span[start..end].ToString();
             IBrush? brush = null;
 
             var rules = _theme.Match(token.Scopes);

--- a/src/MarkView.Avalonia/Extensions/ICodeHighlighter.cs
+++ b/src/MarkView.Avalonia/Extensions/ICodeHighlighter.cs
@@ -13,7 +13,7 @@ namespace MarkView.Avalonia.Extensions;
 /// </summary>
 public interface ICodeHighlighter
 {
-    IReadOnlyList<(string Text, IBrush? Foreground)>? Highlight(string line, string? language);
+    IReadOnlyList<(string Text, IBrush? Foreground)>? Highlight(ReadOnlyMemory<char> line, string? language);
 }
 
 /// <summary>
@@ -23,5 +23,5 @@ public interface ICodeHighlighter
 /// </summary>
 public interface IThemeAwareCodeHighlighter : ICodeHighlighter
 {
-    IReadOnlyList<(string Text, IBrush? Foreground)>? HighlightVariant(string line, string? language, bool isDark);
+    IReadOnlyList<(string Text, IBrush? Foreground)>? HighlightVariant(ReadOnlyMemory<char> line, string? language, bool isDark);
 }

--- a/src/MarkView.Avalonia/MarkdownViewer.cs
+++ b/src/MarkView.Avalonia/MarkdownViewer.cs
@@ -134,17 +134,21 @@ public partial class MarkdownViewer : ContentControl
 
         // Extensions register before pipeline.Setup() so they can swap renderers.
         // Globals first, then per-instance; skip exact-reference duplicates.
-        var seen = new HashSet<IMarkViewExtension>(ReferenceEqualityComparer.Instance);
+        // Allocate the dedup HashSet only when at least one list is non-empty.
+        if (MarkdownViewerDefaults.Extensions.Count > 0 || Extensions.Count > 0)
+        {
+            var seen = new HashSet<IMarkViewExtension>(ReferenceEqualityComparer.Instance);
 
-        foreach (var ext in MarkdownViewerDefaults.Extensions)
-        {
-            if (seen.Add(ext))
-                ext.Register(renderer);
-        }
-        foreach (var ext in Extensions)
-        {
-            if (seen.Add(ext))
-                ext.Register(renderer);
+            foreach (var ext in MarkdownViewerDefaults.Extensions)
+            {
+                if (seen.Add(ext))
+                    ext.Register(renderer);
+            }
+            foreach (var ext in Extensions)
+            {
+                if (seen.Add(ext))
+                    ext.Register(renderer);
+            }
         }
 
         pipeline.Setup(renderer);

--- a/src/MarkView.Avalonia/MarkdownViewer.cs
+++ b/src/MarkView.Avalonia/MarkdownViewer.cs
@@ -265,34 +265,24 @@ public partial class MarkdownViewer : ContentControl
 
     private void RegisterTableRows(DocumentSelectionLayer layer, Grid tableGrid)
     {
-        // Collect cells (Border elements) grouped by row then column
-        var rowMap = new SortedDictionary<int, SortedDictionary<int, Border>>();
+        // TableRenderer adds cells in row-major order (rowIndex / colIndex ascending),
+        // so iterating Children directly avoids the O(N log N) SortedDictionary sort.
+        // Collect borders first, then emit each with "\t" or "\n" based on row boundary.
+        var cells = new List<Border>(tableGrid.Children.Count);
         foreach (var child in tableGrid.Children)
-        {
-            if (child is not Border cell) continue;
-            int row = Grid.GetRow(cell);
-            int col = Grid.GetColumn(cell);
-            if (!rowMap.TryGetValue(row, out var cols))
-                rowMap[row] = cols = [];
-            cols[col] = cell;
-        }
+            if (child is Border b) cells.Add(b);
 
-        foreach (var (_, colMap) in rowMap)
+        for (int i = 0; i < cells.Count; i++)
         {
-            int cellCount = colMap.Count;
-            int i = 0;
-            foreach (var cell in colMap.Values)
-            {
-                var tb = FindFirstTextBlock(cell);
-                if (tb is not null)
-                {
-                    var text = cell.Child is Panel p ? ExtractPanelText(p) : string.Empty;
-                    // Last cell in row separates with newline; others with tab
-                    var separator = (i == cellCount - 1) ? "\n" : "\t";
-                    layer.Register(new IndexEntry(tb, text, separator));
-                }
-                i++;
-            }
+            var cell = cells[i];
+            var tb = FindFirstTextBlock(cell);
+            if (tb is null) continue;
+
+            var text = cell.Child is Panel p ? ExtractPanelText(p) : string.Empty;
+            // Separator: "\n" if this is the last cell in its row, "\t" otherwise.
+            bool isLastInRow = i == cells.Count - 1
+                || Grid.GetRow(cells[i + 1]) != Grid.GetRow(cell);
+            layer.Register(new IndexEntry(tb, text, isLastInRow ? "\n" : "\t"));
         }
     }
 

--- a/src/MarkView.Avalonia/Rendering/Blocks/AlertBlockRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/AlertBlockRenderer.cs
@@ -16,9 +16,20 @@ public class AlertBlockRenderer : AvaloniaObjectRenderer<AlertBlock>
 {
     protected override void Write(AvaloniaRenderer renderer, AlertBlock obj)
     {
-        var kind = obj.Kind.ToString().ToLowerInvariant();
+        // obj.Kind is a StringSlice — call ToString() once, then use a lookup
+        // to avoid two further allocations (ToLowerInvariant + ToUpperInvariant).
+        var kindRaw = obj.Kind.ToString();
+        var (kindLower, kindUpper) = kindRaw.ToUpperInvariant() switch
+        {
+            "NOTE"      => ("note",      "NOTE"),
+            "TIP"       => ("tip",       "TIP"),
+            "WARNING"   => ("warning",   "WARNING"),
+            "IMPORTANT" => ("important", "IMPORTANT"),
+            "CAUTION"   => ("caution",   "CAUTION"),
+            var upper   => (kindRaw.ToLowerInvariant(), upper),
+        };
 
-        var header = new TextBlock { Text = kind.ToUpperInvariant() };
+        var header = new TextBlock { Text = kindUpper };
         header.Classes.Add("markdown-alert-header");
 
         var contentPanel = new StackPanel { Spacing = 4 };
@@ -30,7 +41,7 @@ public class AlertBlockRenderer : AvaloniaObjectRenderer<AlertBlock>
 
         var border = new Border { Child = outer };
         border.Classes.Add("markdown-alert");
-        border.Classes.Add($"markdown-alert-{kind}");
+        border.Classes.Add($"markdown-alert-{kindLower}");
 
         renderer.Push(contentPanel);
         renderer.WriteChildren(obj);

--- a/src/MarkView.Avalonia/Rendering/DocumentBlock.cs
+++ b/src/MarkView.Avalonia/Rendering/DocumentBlock.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Nicolas Musset
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Avalonia;
 using Avalonia.Controls;
 
 namespace MarkView.Avalonia.Rendering;
@@ -25,6 +26,12 @@ internal sealed class IndexEntry
 
     public int AbsEnd => AbsStart + PlainText.Length;
     public int AbsEndWithSep => AbsEnd + Separator.Length;
+
+    /// <summary>
+    /// Bounding rect in the <see cref="DocumentSelectionLayer"/>'s coordinate space.
+    /// Populated by <c>DocumentSelectionLayer.EnsureBounds()</c> and invalidated on layout.
+    /// </summary>
+    public Rect? CachedBounds { get; internal set; }
 
     public IndexEntry(TextBlock textBlock, string plainText, string separator = "\n")
     {

--- a/src/MarkView.Avalonia/Rendering/DocumentSelectionLayer.cs
+++ b/src/MarkView.Avalonia/Rendering/DocumentSelectionLayer.cs
@@ -33,6 +33,25 @@ internal sealed class DocumentSelectionLayer : Control
         IsHitTestVisible = false;
     }
 
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        LayoutUpdated += OnLayoutUpdated;
+    }
+
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+        LayoutUpdated -= OnLayoutUpdated;
+    }
+
+    private void OnLayoutUpdated(object? sender, EventArgs e)
+    {
+        // Invalidate cached bounds so they're recomputed on the next pointer event.
+        foreach (var entry in _entries)
+            entry.CachedBounds = null;
+    }
+
     // ── Registration ─────────────────────────────────────────────────────────
 
     /// <summary>
@@ -139,7 +158,12 @@ internal sealed class DocumentSelectionLayer : Control
     {
         foreach (var entry in _entries)
         {
-            var localPos = ToLocalPos(entry.TextBlock, posInLayer);
+            // Entries are in document order (top to bottom). Once cached bounds show
+            // we've passed the pointer's Y, no further entry can match.
+            if (entry.CachedBounds is { } b && b.Top > posInLayer.Y)
+                break;
+
+            var localPos = ToLocalPos(entry, posInLayer);
             if (localPos is null) continue;
 
             var textPos = new Point(localPos.Value.X - entry.TextBlock.Padding.Left,
@@ -158,7 +182,10 @@ internal sealed class DocumentSelectionLayer : Control
     {
         foreach (var entry in _entries)
         {
-            if (ToLocalPos(entry.TextBlock, posInLayer) is not null)
+            if (entry.CachedBounds is { } b && b.Top > posInLayer.Y)
+                break;
+
+            if (ToLocalPos(entry, posInLayer) is not null)
                 return entry;
         }
         return null;
@@ -178,7 +205,9 @@ internal sealed class DocumentSelectionLayer : Control
             if (entry.AbsEnd <= selStart) continue;
             if (entry.AbsStart >= selEnd) break;
 
-            var origin = entry.TextBlock.TranslatePoint(new Point(0, 0), this);
+            var origin = entry.CachedBounds is { } b
+                ? b.TopLeft
+                : entry.TextBlock.TranslatePoint(new Point(0, 0), this);
             if (origin is null) continue;
 
             var textOrigin = origin.Value + new Vector(entry.TextBlock.Padding.Left,
@@ -205,19 +234,27 @@ internal sealed class DocumentSelectionLayer : Control
     // ── Private helpers ───────────────────────────────────────────────────────
 
     /// <summary>
-    /// Returns <paramref name="posInLayer"/> in the TextBlock's local coordinate space,
+    /// Returns <paramref name="posInLayer"/> in the entry's TextBlock local coordinate space,
     /// or null if the point is outside the TextBlock's bounds.
+    /// Caches the bounding <see cref="Rect"/> on <see cref="IndexEntry.CachedBounds"/> so
+    /// subsequent calls avoid a full visual-tree <c>TranslatePoint</c> walk.
     /// </summary>
-    private Point? ToLocalPos(TextBlock tb, Point posInLayer)
+    private Point? ToLocalPos(IndexEntry entry, Point posInLayer)
     {
-        var origin = tb.TranslatePoint(new Point(0, 0), this);
-        if (origin is null) return null;
+        Rect bounds;
+        if (entry.CachedBounds is { } cached)
+        {
+            bounds = cached;
+        }
+        else
+        {
+            var origin = entry.TextBlock.TranslatePoint(new Point(0, 0), this);
+            if (origin is null) return null;
+            bounds = new Rect(origin.Value, entry.TextBlock.Bounds.Size);
+            entry.CachedBounds = bounds;
+        }
 
-        var local = posInLayer - origin.Value;
-        if (local.X < 0 || local.Y < 0 ||
-            local.X > tb.Bounds.Width || local.Y > tb.Bounds.Height)
-            return null;
-
-        return local;
+        if (!bounds.Contains(posInLayer)) return null;
+        return posInLayer - bounds.TopLeft;
     }
 }

--- a/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/TextMateCodeBlockRendererTests.cs
+++ b/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/TextMateCodeBlockRendererTests.cs
@@ -94,8 +94,8 @@ public class TextMateCodeBlockRendererTests
         new TextMateExtension().Register(renderer);
         var themeAware = (IThemeAwareCodeHighlighter)renderer.CodeHighlighter!;
 
-        var darkTokens = themeAware.HighlightVariant("var x = 1;", "csharp", isDark: true);
-        var lightTokens = themeAware.HighlightVariant("var x = 1;", "csharp", isDark: false);
+        var darkTokens = themeAware.HighlightVariant("var x = 1;".AsMemory(), "csharp", isDark: true);
+        var lightTokens = themeAware.HighlightVariant("var x = 1;".AsMemory(), "csharp", isDark: false);
 
         Assert.NotNull(darkTokens);
         Assert.NotNull(lightTokens);
@@ -110,8 +110,8 @@ public class TextMateCodeBlockRendererTests
         new TextMateExtension().Register(renderer);
         var themeAware = (IThemeAwareCodeHighlighter)renderer.CodeHighlighter!;
 
-        var dark = themeAware.HighlightVariant("var x = 1;", "csharp", isDark: true)!;
-        var light = themeAware.HighlightVariant("var x = 1;", "csharp", isDark: false)!;
+        var dark = themeAware.HighlightVariant("var x = 1;".AsMemory(), "csharp", isDark: true)!;
+        var light = themeAware.HighlightVariant("var x = 1;".AsMemory(), "csharp", isDark: false)!;
 
         // At least one token should differ in colour between dark and light themes.
         var darkColours = dark.Select(t => t.Foreground?.ToString()).ToList();

--- a/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/TextMateHighlighterTests.cs
+++ b/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/TextMateHighlighterTests.cs
@@ -12,7 +12,7 @@ public class TextMateHighlighterTests
     public void Highlight_returns_null_for_unknown_language()
     {
         var highlighter = new TextMateHighlighter();
-        var result = highlighter.Highlight("var x = 1;", "notareallanguage");
+        var result = highlighter.Highlight("var x = 1;".AsMemory(), "notareallanguage");
         Assert.Null(result);
     }
 
@@ -20,7 +20,7 @@ public class TextMateHighlighterTests
     public void Highlight_returns_tokens_for_csharp()
     {
         var highlighter = new TextMateHighlighter();
-        var result = highlighter.Highlight("var x = 1;", "csharp");
+        var result = highlighter.Highlight("var x = 1;".AsMemory(), "csharp");
         Assert.NotNull(result);
         var tokens = result!.ToList();
         Assert.NotEmpty(tokens);
@@ -32,7 +32,7 @@ public class TextMateHighlighterTests
     public void Highlight_returns_tokens_for_json()
     {
         var highlighter = new TextMateHighlighter();
-        var result = highlighter.Highlight("{\"key\": 42}", "json");
+        var result = highlighter.Highlight("{\"key\": 42}".AsMemory(), "json");
         Assert.NotNull(result);
         Assert.Equal("{\"key\": 42}", string.Concat(result!.Select(t => t.Text)));
     }
@@ -41,7 +41,7 @@ public class TextMateHighlighterTests
     public void Highlight_accepts_null_language_and_returns_null()
     {
         var highlighter = new TextMateHighlighter();
-        var result = highlighter.Highlight("anything", null);
+        var result = highlighter.Highlight("anything".AsMemory(), null);
         Assert.Null(result);
     }
 
@@ -49,7 +49,7 @@ public class TextMateHighlighterTests
     public void Highlight_with_DarkPlus_theme_produces_colored_tokens()
     {
         var highlighter = new TextMateHighlighter(ThemeName.DarkPlus);
-        var result = highlighter.Highlight("var x = 1;", "csharp");
+        var result = highlighter.Highlight("var x = 1;".AsMemory(), "csharp");
         Assert.NotNull(result);
         // At least one token should have a non-null brush
         Assert.Contains(result!, t => t.Foreground != null);

--- a/tests/MarkView.Avalonia.Tests/Extensions/ExtensibilityTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Extensions/ExtensibilityTests.cs
@@ -19,7 +19,7 @@ public class ExtensibilityTests
     public void ICodeHighlighter_returns_null_for_unsupported_language()
     {
         ICodeHighlighter highlighter = new StubHighlighter();
-        var result = highlighter.Highlight("var x = 1;", "unsupported");
+        var result = highlighter.Highlight("var x = 1;".AsMemory(), "unsupported");
         Assert.Null(result);
     }
 
@@ -27,7 +27,7 @@ public class ExtensibilityTests
     public void ICodeHighlighter_returns_tokens_for_supported_language()
     {
         ICodeHighlighter highlighter = new StubHighlighter();
-        var result = highlighter.Highlight("hello", "stub");
+        var result = highlighter.Highlight("hello".AsMemory(), "stub");
         Assert.NotNull(result);
         Assert.Single(result);
         Assert.Equal("hello", result[0].Text);
@@ -38,7 +38,7 @@ public class ExtensibilityTests
     public void ICodeHighlighter_returns_empty_list_for_blank_line()
     {
         ICodeHighlighter highlighter = new StubHighlighter();
-        var result = highlighter.Highlight("", "stub");
+        var result = highlighter.Highlight("".AsMemory(), "stub");
         Assert.NotNull(result);
         Assert.Empty(result);
     }
@@ -117,11 +117,11 @@ public class ExtensibilityTests
 
     private sealed class StubHighlighter : ICodeHighlighter
     {
-        public IReadOnlyList<(string Text, IBrush? Foreground)>? Highlight(string line, string? language)
+        public IReadOnlyList<(string Text, IBrush? Foreground)>? Highlight(ReadOnlyMemory<char> line, string? language)
         {
             if (language != "stub") return null;
-            if (string.IsNullOrEmpty(line)) return [];
-            return [(line, null)];
+            if (line.IsEmpty) return [];
+            return [(line.ToString(), null)];
         }
     }
 


### PR DESCRIPTION
## Summary

- **`DocumentSelectionLayer`**: cache each `IndexEntry`'s bounding `Rect` in the layer's coordinate space after layout (`LayoutUpdated` invalidates on each layout pass). `HitTestOffset`, `HitTestEntry`, and `Render` now skip entries whose cached Y-range is above the pointer, and avoid `TranslatePoint` visual-tree walks on every pointer-move event (was O(N) tree traversals at 60 fps during selection drags).
- **`DetachedFromLogicalTree` cleanup**: `TextMateCodeBlockRenderer` and `MermaidBlockRenderer` were unsubscribing from `Application.Current.PropertyChanged` on `DetachedFromVisualTree`, which fires during layout passes and silently dropped theme-change subscriptions. Changed to `DetachedFromLogicalTree` to match `LinkInlineRenderer`.
- **`RegisterTableRows`**: replaced `SortedDictionary<int, SortedDictionary<int, Border>>` with a direct linear pass over `Grid.Children` — `TableRenderer` already adds cells in row/column order so the O(N log N) sort and nested allocations were unnecessary.
- **`RenderMarkdown`**: skip `HashSet<IMarkViewExtension>` allocation when both `MarkdownViewerDefaults.Extensions` and instance `Extensions` are empty (the common case with no custom extensions).
- **`AlertBlockRenderer`**: replace `StringSlice.ToString().ToLowerInvariant()` + `.ToUpperInvariant()` with a switch lookup on the five known `AlertKind` values, eliminating two string allocations per alert block render.
- **`ICodeHighlighter`** (breaking): `Highlight` and `HighlightVariant` now accept `ReadOnlyMemory<char>` instead of `string`. Callers (`TextMateCodeBlockRenderer`, `MermaidBlockRenderer.WriteStandardCodeBlock`) slice the Markdig `StringSlice` source buffer directly via `AsMemory(slice.Start, slice.Length)` — no per-line `ToString()` allocation. `TextMateHighlighter` passes the `ReadOnlyMemory<char>` as a `LineText` (implicit conversion) directly to `IGrammar.TokenizeLine`, letting TextMateSharp 2.x use its internal `ArrayPool` for the required trailing `'\n'`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactoring (no behaviour change)
- [ ] Documentation
- [ ] CI / build

## Test plan

- [x] `dotnet test` — all 211 tests pass
- [x] Manual smoke-test in the demo app

## Related issues

Ref TextMateSharp v2.0.0 — "Add ReadOnlyMemory support" (danipen/TextMateSharp#100)
