### PR TITLE
docs: update READMEs and add usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,14 @@ Include the default theme and add `MarkdownViewer` to your XAML:
 </Window>
 ```
 
-To handle link clicks in code-behind:
+### Setting a base URI for relative links and images
+
+```csharp
+viewer.BaseUri = new Uri("https://raw.githubusercontent.com/Kryptos-FR/MarkView.Avalonia/main/");
+viewer.Markdown = markdownText; // relative image paths resolved against BaseUri
+```
+
+### Handling link clicks
 
 ```csharp
 viewer.LinkClicked += (_, e) =>
@@ -40,36 +47,110 @@ viewer.LinkClicked += (_, e) =>
 };
 ```
 
-To use a custom Markdig pipeline:
+`LinkClickedEvent` is an Avalonia **routed event** (bubbles up) — subscribe globally once at app startup to handle all viewers:
+
+```csharp
+// App.axaml.cs — applies to every MarkdownViewer in the application
+MarkdownViewer.LinkClickedEvent.AddClassHandler<MarkdownViewer>((_, e) =>
+    Process.Start(new ProcessStartInfo(e.Url) { UseShellExecute = true }));
+```
+
+### Navigating to an anchor
+
+```csharp
+viewer.ScrollToAnchor("my-heading");  // scrolls to the heading's anchor position
+```
+
+### Using a custom Markdig pipeline
 
 ```csharp
 viewer.Pipeline = new MarkdownPipelineBuilder()
-    .UseAdvancedExtensions()
+    .UseSupportedExtensions()
+    .UseAlertBlocks()
+    .UseFootnotes()
     .Build();
 ```
 
+## Extension Methods
+
+Convenience methods configure a pipeline with a single opt-in feature:
+
+```csharp
+viewer.UseFootnotes();
+viewer.UseAlertBlocks();
+viewer.UseAbbreviations();
+viewer.UseFigures();
+viewer.UseMediaLinks();
+```
+
+To combine several opt-in features, build the pipeline explicitly (see above).
+
+## Application-Wide Defaults
+
+`MarkdownViewerDefaults` lets you set a pipeline and/or extensions once so that every `MarkdownViewer` in the application inherits them automatically — no need to configure each instance:
+
+```csharp
+// App.axaml.cs
+MarkdownViewerDefaults.Pipeline = new MarkdownPipelineBuilder()
+    .UseSupportedExtensions()
+    .UseFootnotes()
+    .UseAlertBlocks()
+    .Build();
+
+MarkdownViewerDefaults.Extensions.AddTextMateHighlighting();
+MarkdownViewerDefaults.Extensions.AddSvg();
+MarkdownViewerDefaults.Extensions.AddMermaid();
+```
+
+Per-instance `Pipeline` and `Extensions` take precedence over the defaults; an extension object shared between the defaults list and an instance list is only registered once per render.
+
 ## Supported Markdown Features
+
+### CommonMark baseline (always on)
 
 | Feature | Notes |
 |---------|-------|
 | Headings H1–H6 | CommonMark |
 | Bold, italic | CommonMark |
-| Strikethrough | Extension (`~~text~~`) |
 | Inline code | CommonMark |
 | Fenced code blocks | CommonMark |
 | Blockquotes | CommonMark |
 | Ordered and unordered lists | CommonMark, tight and loose |
-| Task lists | Extension (`- [x] item`) |
-| Pipe tables | Extension |
 | Links and autolinks | CommonMark + extension |
 | Images | CommonMark, remote URLs loaded async |
 | Thematic breaks | CommonMark |
 | Hard line breaks | CommonMark (`\` or two spaces) |
 | HTML `<br>` / `<br />` | Rendered as line break |
 
+### Extensions (enabled by `UseSupportedExtensions()`)
+
+| Feature | Syntax |
+|---------|--------|
+| Strikethrough | `~~text~~` |
+| Subscript | `~text~` |
+| Superscript | `^text^` |
+| Underline (inserted) | `++text++` |
+| Highlight (marked) | `==text==` |
+| Task lists | `- [x] item` |
+| Pipe tables | GFM-style `\| col \| col \|` |
+| Grid tables | RST-style grid tables |
+| Autolinks | bare `https://…` URLs |
+
+### Opt-in extensions
+
+These require adding `.UseXxx()` to the pipeline (see [Extension Methods](#extension-methods) below):
+
+| Feature | Activation | Syntax |
+|---------|-----------|--------|
+| Footnotes | `UseFootnotes()` | `[^1]` / `[^1]: …` |
+| GitHub alert blocks | `UseAlertBlocks()` | `> [!NOTE]` etc. |
+| Abbreviations | `UseAbbreviations()` | `*[HTML]: …` |
+| Figures | `UseFigures()` | `^^^` / `^^^ caption` |
+| YouTube embeds | `UseMediaLinks()` | `![title](https://youtu.be/…)` |
+
 ## Extension Packages
 
-MarkView.Avalonia ships optional NuGet packages that add richer rendering capabilities. Each package implements `IMarkViewExtension` and is activated via a convenience method on `MarkdownViewer`.
+MarkView.Avalonia ships optional NuGet packages that add richer rendering capabilities. Each package implements `IMarkViewExtension` and is activated via a convenience method on `MarkdownViewer`, or globally via `MarkdownViewerDefaults.Extensions.AddXxx()`.
 
 ### Syntax Highlighting (`MarkView.Avalonia.SyntaxHighlighting`)
 
@@ -81,15 +162,19 @@ dotnet add package MarkView.Avalonia.SyntaxHighlighting
 
 ```csharp
 viewer.UseTextMateHighlighting(); // DarkPlus / LightPlus by default
+// or with custom themes:
+viewer.UseTextMateHighlighting(darkTheme: ThemeName.Monokai, lightTheme: ThemeName.QuietLight);
 ```
 
 The extension replaces the built-in `CodeBlockRenderer` with `TextMateCodeBlockRenderer`, which tokenises each line and emits coloured `Run` elements. Unsupported languages fall back to the default monochrome rendering automatically.
+
+Colours update in-place when the user switches between light and dark themes — no document rebuild or scroll reset.
 
 Available `ThemeName` values are defined by TextMateSharp.Grammars: `DarkPlus`, `LightPlus`, `Monokai`, `SolarizedDark`, `SolarizedLight`, and more.
 
 ### SVG Images (`MarkView.Avalonia.Svg`)
 
-Renders SVG images embedded in markdown (`![desc](path/to/image.svg)`), including `data:image/svg+xml` data URIs.
+Renders SVG images embedded in markdown (`![desc](path/to/image.svg)`), including `data:image/svg+xml` data URIs and badge-service URLs that return SVG without a `.svg` extension.
 
 ```bash
 dotnet add package MarkView.Avalonia.Svg
@@ -150,7 +235,7 @@ public class MyExtension : IMarkViewExtension
     public void Register(AvaloniaRenderer renderer)
     {
         // swap a renderer, add an image loader, or set a code highlighter
-        renderer.ReplaceOrAdd<CodeBlockRenderer>(new MyCodeBlockRenderer());
+        renderer.ObjectRenderers.ReplaceOrAdd<CodeBlockRenderer>(new MyCodeBlockRenderer());
     }
 }
 
@@ -175,6 +260,16 @@ Include `MarkdownTheme.axaml` for default styles. Override any style class in yo
 | `markdown-table` | Tables | `Grid` |
 | `markdown-table-cell` | Table cells | `Border` |
 | `markdown-table-header` | Header cells | `Border` |
+| `markdown-marked` | Highlighted text (`==…==`) | `Span` |
+| `markdown-alert` | Alert block container | `Border` |
+| `markdown-alert-note` … `markdown-alert-caution` | Per-kind border colour | `Border` |
+| `markdown-alert-header` | Alert kind label | `TextBlock` |
+| `markdown-figure` | Figure container | `Border` |
+| `markdown-figure-caption` | Figure caption | `TextBlock` |
+| `markdown-abbr` | Abbreviation with tooltip | `TextBlock` |
+| `markdown-footnote-ref` | Footnote reference link | `HyperlinkButton` |
+| `markdown-footnote-group` | Footnote definition list | `StackPanel` |
+| `markdown-footnote-item` | Individual footnote row | `Grid` |
 
 Example — increase heading size and add a bottom border:
 
@@ -185,6 +280,25 @@ Example — increase heading size and add a bottom border:
   <Setter Property="Margin" Value="0,12,0,6" />
 </Style>
 ```
+
+## Text Selection
+
+`MarkdownViewer` supports full document-wide text selection:
+
+- **Click + drag** to select a range.
+- **`Ctrl+A`** to select all text.
+- **`Ctrl+C`** to copy the selection to the clipboard.
+
+Programmatic API:
+
+```csharp
+viewer.SelectAll();
+viewer.ClearSelection();
+string text = viewer.GetSelectedText();
+await viewer.CopyToClipboardAsync();
+```
+
+Images and task-list checkboxes are skipped during selection (same behaviour as all reference libraries).
 
 ## Known Limitations
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# MarkView.Avalonia Documentation
+
+This folder contains developer-facing documentation for the MarkView.Avalonia library and its extension packages.
+
+## Contents
+
+| Document | Description |
+|----------|-------------|
+| [getting-started.md](getting-started.md) | Installation, XAML setup, and first render |
+| [configuration.md](configuration.md) | Pipeline, global defaults, BaseUri, and opt-in extensions |
+| [extensions.md](extensions.md) | Extension packages: SyntaxHighlighting, Svg, Mermaid |
+| [text-selection.md](text-selection.md) | Text selection, clipboard, and programmatic API |
+| [theming.md](theming.md) | Style classes, theme switching, and customisation |
+| [custom-extensions.md](custom-extensions.md) | Writing your own `IMarkViewExtension`, image loaders, and renderers |
+
+For a quick overview, see the [root README](../README.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,117 @@
+# Configuration
+
+## MarkdownViewer properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Markdown` | `string?` | `null` | The markdown text to render. Setting this triggers a full re-render. |
+| `Pipeline` | `MarkdownPipeline?` | `null` | The Markdig pipeline. `null` falls back to `MarkdownViewerDefaults.Pipeline`, or the built-in default (`UseSupportedExtensions`). |
+| `BaseUri` | `Uri?` | `null` | Base URI for resolving relative links and image paths. |
+| `Extensions` | `IList<IMarkViewExtension>` | `[]` | Per-instance rendering extensions. Applied after global defaults. |
+
+## Markdig Pipeline
+
+The pipeline controls which Markdig extensions parse the input markdown. Build one with `MarkdownPipelineBuilder`:
+
+```csharp
+viewer.Pipeline = new MarkdownPipelineBuilder()
+    .UseSupportedExtensions()   // bold, italic, strikethrough, subscript, superscript,
+                                // underline, highlight, task lists, tables, autolinks
+    .UseFootnotes()             // [^1] footnotes
+    .UseAlertBlocks()           // > [!NOTE] / > [!WARNING] etc.
+    .UseAbbreviations()         // *[HTML]: HyperText Markup Language
+    .UseFigures()               // ^^^ figure blocks
+    .UseMediaLinks()            // YouTube thumbnail embeds
+    .Build();
+```
+
+`UseSupportedExtensions()` is a MarkView.Avalonia helper that enables the subset of Markdig extensions that have native renderers in the library:
+
+- `EmphasisExtras` — strikethrough `~~`, subscript `~`, superscript `^`, underline `++`, highlight `==`
+- `AutoLinks` — bare URL auto-linking
+- `GridTables` — RST-style grid tables
+- `PipeTables` — GFM pipe tables
+- `TaskLists` — `- [x]` checkboxes
+
+The five opt-in extensions above (`UseFootnotes()` etc.) are thin wrappers around the corresponding Markdig extension; they are defined in `MarkdownExtensions.cs` and re-exported as extension methods on `MarkdownPipelineBuilder`.
+
+### Convenience extension methods
+
+For simple use cases, call a single method instead of building the pipeline manually:
+
+```csharp
+viewer.UseFootnotes();     // pipeline + footnote rendering
+viewer.UseAlertBlocks();   // pipeline + alert block rendering
+viewer.UseAbbreviations(); // pipeline + abbreviation tooltips
+viewer.UseFigures();       // pipeline + figure blocks
+viewer.UseMediaLinks();    // pipeline + YouTube thumbnails
+```
+
+Each method calls `UseSupportedExtensions()` plus the requested feature. To combine several opt-in features, build the pipeline explicitly.
+
+## Application-wide defaults (`MarkdownViewerDefaults`)
+
+Set the pipeline and extensions once at application startup and they apply to **every** `MarkdownViewer` in the app:
+
+```csharp
+// App.axaml.cs  OnFrameworkInitializationCompleted()
+MarkdownViewerDefaults.Pipeline = new MarkdownPipelineBuilder()
+    .UseSupportedExtensions()
+    .UseAlertBlocks()
+    .Build();
+
+MarkdownViewerDefaults.Extensions.AddTextMateHighlighting();
+MarkdownViewerDefaults.Extensions.AddSvg();
+MarkdownViewerDefaults.Extensions.AddMermaid();
+```
+
+**Priority rules:**
+
+1. `viewer.Pipeline` is used if set; otherwise `MarkdownViewerDefaults.Pipeline`; otherwise the built-in default.
+2. `MarkdownViewerDefaults.Extensions` are registered first, then `viewer.Extensions`.
+3. If the same extension object appears in both lists it is registered only once (reference equality check).
+
+## BaseUri
+
+`BaseUri` is used to resolve relative links in markdown:
+
+```csharp
+// Load markdown from a GitHub URL — relative image paths resolve against this base
+viewer.BaseUri = new Uri("https://raw.githubusercontent.com/org/repo/main/docs/");
+viewer.Markdown = File.ReadAllText("README.md");
+```
+
+`BaseUri` is also passed to `IImageLoader.LoadAsync` for each image URL, allowing image loaders to convert relative paths to absolute ones.
+
+## LinkClicked event
+
+`LinkClicked` is an Avalonia **routed event** that bubbles up the visual tree. Subscribe on an individual viewer:
+
+```csharp
+viewer.LinkClicked += (_, e) =>
+    Process.Start(new ProcessStartInfo(e.Url) { UseShellExecute = true });
+```
+
+Or register a class-level handler once at startup to catch all viewers:
+
+```csharp
+MarkdownViewer.LinkClickedEvent.AddClassHandler<MarkdownViewer>((sender, e) =>
+{
+    // e.Url — the target URL (may be relative, e.g. "#section")
+    // sender — the MarkdownViewer that was clicked
+    Process.Start(new ProcessStartInfo(e.Url) { UseShellExecute = true });
+});
+```
+
+The event is raised for all hyperlinks, including anchor links (`#heading`). In-document anchor links are handled automatically by the viewer before raising the event — navigation happens regardless of whether you subscribe.
+
+## Anchor navigation
+
+Call `ScrollToAnchor` to programmatically scroll to any heading or footnote:
+
+```csharp
+viewer.ScrollToAnchor("installation");    // matches heading "## Installation"
+viewer.ScrollToAnchor("fn-1");            // matches footnote [^1]
+```
+
+Anchors are generated from heading text using GitHub-compatible slug rules (lowercase, spaces to hyphens, non-alphanumeric stripped). Headings with identical slugs are disambiguated with a numeric suffix (`-1`, `-2`, …).

--- a/docs/custom-extensions.md
+++ b/docs/custom-extensions.md
@@ -1,0 +1,183 @@
+# Writing Custom Extensions
+
+MarkView.Avalonia is designed to be extended. The three main extension points are:
+
+1. **Block / inline renderers** — replace or supplement how a Markdig AST node is rendered
+2. **Image loaders** — add support for new image URL schemes
+3. **Code highlighters** — replace the syntax-highlighting backend
+
+All extension points are accessed through `IMarkViewExtension`.
+
+## IMarkViewExtension
+
+```csharp
+using MarkView.Avalonia.Extensions;
+using MarkView.Avalonia.Rendering;
+
+public interface IMarkViewExtension
+{
+    void Register(AvaloniaRenderer renderer);
+}
+```
+
+`Register` is called once per render pass, **before** `pipeline.Setup(renderer)`, so extensions can install renderers that override the defaults.
+
+Register your extension on a viewer instance or globally:
+
+```csharp
+viewer.Extensions.Add(new MyExtension());
+// or globally:
+MarkdownViewerDefaults.Extensions.Add(new MyExtension());
+```
+
+## Replacing a block renderer
+
+Use `renderer.ObjectRenderers.ReplaceOrAdd<TExisting, TNew>()` to swap out a built-in renderer:
+
+```csharp
+public class MyCodeBlockExtension : IMarkViewExtension
+{
+    public void Register(AvaloniaRenderer renderer)
+    {
+        renderer.ObjectRenderers.ReplaceOrAdd<CodeBlockRenderer, MyCodeBlockRenderer>();
+    }
+}
+```
+
+To insert at a specific position (e.g. to intercept before the default):
+
+```csharp
+renderer.ObjectRenderers.Insert(0, new MyFencedCodeInterceptor());
+```
+
+### Writing a block renderer
+
+Extend `AvaloniaObjectRenderer<TBlock>`:
+
+```csharp
+using Markdig.Syntax;
+using MarkView.Avalonia.Rendering;
+
+public class MyCodeBlockRenderer : AvaloniaObjectRenderer<FencedCodeBlock>
+{
+    protected override void Write(AvaloniaRenderer renderer, FencedCodeBlock obj)
+    {
+        var language = obj.Info ?? string.Empty;
+        var source   = obj.Lines.ToString();
+
+        var tb = new TextBlock { Text = source };
+        tb.Classes.Add("markdown-code-block");
+        // ... add to renderer
+        renderer.WriteBlock(new Border { Child = tb });
+    }
+}
+```
+
+`renderer.WriteBlock(control)` adds the control to the current `Panel` container.  
+`renderer.WriteInline(inline)` adds an inline to the current `InlineCollection`.  
+`renderer.Push(container)` / `renderer.Pop()` manage the render stack.
+
+## Writing a custom image loader
+
+Implement `IImageLoader`:
+
+```csharp
+using MarkView.Avalonia.Extensions;
+
+public class MyImageLoader : IImageLoader
+{
+    public bool CanLoad(string url) => url.StartsWith("myapp://images/");
+
+    public async Task<IImage?> LoadAsync(string url, CancellationToken ct = default)
+    {
+        // Return null to fall through to the next loader in the chain
+        var stream = await MyApp.GetImageStreamAsync(url, ct);
+        if (stream is null) return null;
+        return new Bitmap(stream);
+    }
+}
+```
+
+Register it in a `IMarkViewExtension`:
+
+```csharp
+public class MyImageExtension : IMarkViewExtension
+{
+    public void Register(AvaloniaRenderer renderer)
+    {
+        // Insert at 0 to take priority over all built-in loaders
+        renderer.ImageLoaders.Insert(0, new MyImageLoader());
+    }
+}
+```
+
+The loader chain is tried in order. The first loader whose `CanLoad` returns `true` **and** whose `LoadAsync` returns a non-`null` result wins. Returning `null` from `LoadAsync` passes control to the next loader.
+
+## Writing a custom code highlighter
+
+Implement `ICodeHighlighter` (or `IThemeAwareCodeHighlighter` for live theme switching):
+
+```csharp
+using MarkView.Avalonia.Extensions;
+using Avalonia.Media;
+
+public class MyHighlighter : ICodeHighlighter
+{
+    public IReadOnlyList<(string Text, IBrush? Foreground)>? Highlight(
+        ReadOnlyMemory<char> line, string? language)
+    {
+        // Return null to signal the language is unsupported — falls back to monochrome.
+        // Return an empty list to signal supported but no tokens.
+        if (line.IsEmpty) return [];
+        return [(line.ToString(), Brushes.LimeGreen)];
+    }
+}
+```
+
+`IThemeAwareCodeHighlighter` adds `HighlightVariant(line, language, isDark)` — called in-place when the user switches themes, allowing code blocks to update colours without a full document re-render.
+
+Register on the renderer:
+
+```csharp
+public class MyHighlightExtension : IMarkViewExtension
+{
+    public void Register(AvaloniaRenderer renderer)
+    {
+        renderer.CodeHighlighter = new MyHighlighter();
+    }
+}
+```
+
+## Full example — custom admonition renderer
+
+```csharp
+/// <summary>Renders ::: note / ::: warning fences from a custom Markdig extension.</summary>
+public class AdmonitionExtension : IMarkViewExtension
+{
+    public void Register(AvaloniaRenderer renderer)
+    {
+        renderer.ObjectRenderers.Add(new AdmonitionBlockRenderer());
+    }
+}
+
+public class AdmonitionBlockRenderer : AvaloniaObjectRenderer<AdmonitionBlock>
+{
+    protected override void Write(AvaloniaRenderer renderer, AdmonitionBlock obj)
+    {
+        var panel = new StackPanel();
+        var border = new Border { Child = panel };
+        border.Classes.Add("my-admonition");
+        border.Classes.Add($"my-admonition-{obj.Kind.ToLowerInvariant()}");
+
+        var header = new TextBlock { Text = obj.Kind.ToUpperInvariant() };
+        header.Classes.Add("my-admonition-header");
+        panel.Children.Add(header);
+
+        renderer.Push(panel);
+        renderer.WriteChildren(obj);
+        renderer.Pop();
+
+        renderer.WriteBlock(border);
+    }
+}
+```

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,0 +1,119 @@
+# Extension Packages
+
+## SyntaxHighlighting
+
+**Package:** `MarkView.Avalonia.SyntaxHighlighting`  
+**[README](../src/MarkView.Avalonia.SyntaxHighlighting/README.md)**
+
+Replaces the built-in `CodeBlockRenderer` with `TextMateCodeBlockRenderer`, which tokenises each line via TextMate grammars and emits coloured `Run` elements.
+
+### Activation
+
+```csharp
+// DarkPlus / LightPlus defaults
+viewer.UseTextMateHighlighting();
+
+// Explicit themes
+viewer.UseTextMateHighlighting(
+    darkTheme:  ThemeName.Monokai,
+    lightTheme: ThemeName.QuietLight);
+```
+
+Or globally:
+
+```csharp
+MarkdownViewerDefaults.Extensions.AddTextMateHighlighting();
+MarkdownViewerDefaults.Extensions.AddTextMateHighlighting(ThemeName.Monokai, ThemeName.QuietLight);
+```
+
+### Theme switching
+
+When the Avalonia theme variant changes (light ↔ dark), `TextMateCodeBlockRenderer` rebuilds only the `TextBlock.Inlines` for each code block. The document structure, scroll position, and all other content are untouched.
+
+### Fallback
+
+Languages not in the grammar registry fall back to monochrome rendering automatically.
+
+---
+
+## Svg
+
+**Package:** `MarkView.Avalonia.Svg`  
+**[README](../src/MarkView.Avalonia.Svg/README.md)**
+
+Renders SVG images using [Svg.Skia](https://github.com/wieslawsoltes/Svg.Skia), the same vector backend Avalonia uses internally.
+
+### Activation
+
+```csharp
+viewer.UseSvg();
+// or globally:
+MarkdownViewerDefaults.Extensions.AddSvg();
+```
+
+### Supported URL formats
+
+| URL form | Notes |
+|----------|-------|
+| `https://example.com/icon.svg` | HTTP download |
+| Any `https://` URL | Attempted speculatively; falls back to bitmap if not SVG |
+| `data:image/svg+xml;base64,…` | Base64-decoded SVG |
+| `data:image/svg+xml,…` | URL-decoded SVG |
+
+Badge services (e.g. `shields.io`) that return SVG without a `.svg` extension are handled automatically via the speculative HTTP rule.
+
+---
+
+## Mermaid
+
+**Package:** `MarkView.Avalonia.Mermaid`  
+**[README](../src/MarkView.Avalonia.Mermaid/README.md)**
+
+Renders fenced `mermaid` code blocks as SVG diagrams using [Mermaider](https://github.com/nullean/mermaider) — a pure .NET implementation with no browser, WebView, or JavaScript runtime.
+
+### Activation
+
+```csharp
+viewer.UseMermaid();
+// or globally:
+MarkdownViewerDefaults.Extensions.AddMermaid();
+```
+
+### Markdown syntax
+
+````markdown
+```mermaid
+flowchart LR
+    A[Input] --> B[MarkdownViewer]
+    B --> C[Avalonia UI]
+```
+````
+
+### Supported diagram types
+
+Flowcharts, sequence diagrams, class diagrams, state diagrams, ER diagrams, Gantt charts, pie charts, git graphs, mind maps, timelines, and more — whatever Mermaider supports.
+
+### Theme awareness
+
+Diagrams are automatically re-rendered when the user switches between light and dark themes. The `Border` container stays in place so the scroll position is preserved.
+
+| Variant | Background | Foreground | Accent |
+|---------|-----------|-----------|--------|
+| Dark | `#18181B` | `#FAFAFA` | `#60a5fa` |
+| Light | `#FFFFFF` | `#27272A` | `#3b82f6` |
+
+### Fallback
+
+If rendering fails, the extension falls back to a plain-text block containing the original Mermaid source.
+
+---
+
+## Using all three together
+
+```csharp
+MarkdownViewerDefaults.Extensions.AddTextMateHighlighting();
+MarkdownViewerDefaults.Extensions.AddSvg();
+MarkdownViewerDefaults.Extensions.AddMermaid();
+```
+
+`MermaidBlockRenderer` is inserted at index 0 of `renderer.ObjectRenderers` and intercepts every `FencedCodeBlock`. Mermaid blocks are rendered as diagrams; all other fenced blocks pass through to `TextMateCodeBlockRenderer` (or the default `CodeBlockRenderer` if the SyntaxHighlighting extension is not active).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,92 @@
+# Getting Started
+
+## Installation
+
+Install the core package:
+
+```bash
+dotnet add package MarkView.Avalonia
+```
+
+Optionally add extension packages for richer rendering:
+
+```bash
+dotnet add package MarkView.Avalonia.SyntaxHighlighting  # TextMate code highlighting
+dotnet add package MarkView.Avalonia.Svg                 # SVG image rendering
+dotnet add package MarkView.Avalonia.Mermaid             # Mermaid diagram rendering
+```
+
+## 1. Include the default theme
+
+Add the built-in stylesheet to your application. The standard place is `App.axaml`:
+
+```xml
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="MyApp.App">
+  <Application.Styles>
+    <FluentTheme />
+    <StyleInclude Source="avares://MarkView.Avalonia/Themes/MarkdownTheme.axaml" />
+  </Application.Styles>
+</Application>
+```
+
+## 2. Add MarkdownViewer to a window
+
+```xml
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mv="using:MarkView.Avalonia"
+        x:Class="MyApp.MainWindow">
+
+  <mv:MarkdownViewer Markdown="# Hello, MarkView!" />
+</Window>
+```
+
+## 3. Bind to a view model
+
+```xml
+<mv:MarkdownViewer Markdown="{Binding DocumentText}" />
+```
+
+```csharp
+public class MainViewModel : INotifyPropertyChanged
+{
+    private string _documentText = "# My Document";
+
+    public string DocumentText
+    {
+        get => _documentText;
+        set { _documentText = value; OnPropertyChanged(); }
+    }
+}
+```
+
+## 4. Enable extension packages (optional)
+
+Configure globally at startup so all `MarkdownViewer` instances share the same settings:
+
+```csharp
+// App.axaml.cs
+public override void OnFrameworkInitializationCompleted()
+{
+    MarkdownViewerDefaults.Pipeline = new MarkdownPipelineBuilder()
+        .UseSupportedExtensions()
+        .UseAlertBlocks()
+        .UseFootnotes()
+        .Build();
+
+    MarkdownViewerDefaults.Extensions.AddTextMateHighlighting();
+    MarkdownViewerDefaults.Extensions.AddSvg();
+    MarkdownViewerDefaults.Extensions.AddMermaid();
+
+    // Open links in the system browser
+    MarkdownViewer.LinkClickedEvent.AddClassHandler<MarkdownViewer>((_, e) =>
+        Process.Start(new ProcessStartInfo(e.Url) { UseShellExecute = true }));
+
+    // ...
+    base.OnFrameworkInitializationCompleted();
+}
+```
+
+See [configuration.md](configuration.md) for the full set of options.

--- a/docs/text-selection.md
+++ b/docs/text-selection.md
@@ -1,0 +1,52 @@
+# Text Selection
+
+`MarkdownViewer` supports document-wide text selection via a transparent `DocumentSelectionLayer` overlay. The layer covers the entire rendered document and uses `TextBlock.TextLayout` hit-testing to map pointer positions to character offsets.
+
+## User interactions
+
+| Gesture / Key | Action |
+|---------------|--------|
+| Click + drag | Select a text range |
+| `Ctrl+A` | Select all text in the document |
+| `Ctrl+C` | Copy the current selection to the clipboard |
+
+## Programmatic API
+
+```csharp
+// Select all text
+viewer.SelectAll();
+
+// Clear the selection
+viewer.ClearSelection();
+
+// Read the current selection
+string text = viewer.GetSelectedText();
+
+// Copy to clipboard
+await viewer.CopyToClipboardAsync();
+```
+
+## What is selectable
+
+All text-bearing block types are registered with the selection layer:
+
+- Paragraphs
+- Headings
+- Code blocks (all text within the block)
+- Blockquotes
+- List items (including markers)
+- Table cells (tab-separated when copying)
+- Footnote definitions
+
+The following are **not selectable**:
+
+- Images (`InlineUIContainer` — same limitation as all reference libraries)
+- Task-list checkboxes (`InlineUIContainer`)
+
+## How it works
+
+`DocumentSelectionLayer` is a single transparent `Control` rendered in a single-cell `Grid` on top of the document. It tracks a start and end character offset across the entire flattened character index built by the renderer.
+
+On `PointerMoved`, the layer calls `TextBlock.TextLayout.HitTestPoint` + `TranslatePoint` for each registered text block to find the nearest character offset, then redraws the selection highlight rectangles using `HitTestTextRange`.
+
+On copy, `GetSelectedText()` extracts the substring from each text block's registered text and joins them with newlines (or tabs for table cells).

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,127 @@
+# Theming
+
+## Including the default theme
+
+`MarkdownTheme.axaml` is an embedded resource in the `MarkView.Avalonia` package. Include it in `App.axaml`:
+
+```xml
+<Application.Styles>
+  <FluentTheme />
+  <StyleInclude Source="avares://MarkView.Avalonia/Themes/MarkdownTheme.axaml" />
+</Application.Styles>
+```
+
+The theme uses `DynamicResource` throughout so it responds to Avalonia's `RequestedThemeVariant` changes automatically.
+
+## Style class reference
+
+Every element rendered by `MarkdownViewer` is tagged with a CSS-style class name. Override any selector in your own `Styles` block to customise appearance.
+
+### Core
+
+| Class | Control | Element |
+|-------|---------|---------|
+| `markdown-h1` … `markdown-h6` | `TextBlock` | Headings |
+| `markdown-paragraph` | `TextBlock` | Paragraphs |
+| `markdown-code-block` | `Border` | Fenced code block container |
+| `markdown-code-inline` | `Border` | Inline code container |
+| `markdown-blockquote` | `Border` | Blockquote container |
+| `markdown-list` | `StackPanel` | Ordered / unordered list |
+| `markdown-thematic-break` | `Separator` | Horizontal rule |
+| `markdown-image` | `Image` | Rendered image |
+| `markdown-link` | `HyperlinkButton` | Hyperlink |
+| `markdown-table` | `Grid` | Table |
+| `markdown-table-cell` | `Border` | Table body cell |
+| `markdown-table-header` | `Border` | Table header cell |
+
+### EmphasisExtras
+
+| Class | Control | Element |
+|-------|---------|---------|
+| `markdown-marked` | `Span` | Highlighted text (`==text==`) |
+
+Subscript, superscript, underline (inserted), bold, italic, and strikethrough use standard Avalonia inline properties (`BaselineAlignment`, `FontFeatures`, `TextDecorations`) and do not have dedicated style classes.
+
+### Alert blocks
+
+| Class | Control | Element |
+|-------|---------|---------|
+| `markdown-alert` | `Border` | Alert container |
+| `markdown-alert-note` | `Border` | NOTE variant |
+| `markdown-alert-tip` | `Border` | TIP variant |
+| `markdown-alert-important` | `Border` | IMPORTANT variant |
+| `markdown-alert-warning` | `Border` | WARNING variant |
+| `markdown-alert-caution` | `Border` | CAUTION variant |
+| `markdown-alert-header` | `TextBlock` | Alert kind label (e.g. "NOTE") |
+| `markdown-alert-content` | `StackPanel` | Alert body |
+
+Example — colour the NOTE variant:
+
+```xml
+<Style Selector="Border.markdown-alert-note">
+  <Setter Property="BorderBrush" Value="#3b82f6" />
+  <Setter Property="Background" Value="#eff6ff" />
+</Style>
+```
+
+### Figures
+
+| Class | Control | Element |
+|-------|---------|---------|
+| `markdown-figure` | `Border` | Figure container (centred) |
+| `markdown-figure-caption` | `TextBlock` | Caption text |
+
+### Abbreviations
+
+| Class | Control | Element |
+|-------|---------|---------|
+| `markdown-abbr` | `TextBlock` | Abbreviated term with tooltip |
+
+### Footnotes
+
+| Class | Control | Element |
+|-------|---------|---------|
+| `markdown-footnote-ref` | `HyperlinkButton` | Inline footnote reference `[1]` |
+| `markdown-footnote-group` | `StackPanel` | Definition list at end of document |
+| `markdown-footnote-item` | `Grid` | Individual footnote row |
+
+## Example customisations
+
+### Larger headings
+
+```xml
+<Style Selector="TextBlock.markdown-h1">
+  <Setter Property="FontSize" Value="36" />
+  <Setter Property="FontWeight" Value="Bold" />
+  <Setter Property="Margin" Value="0,16,0,8" />
+</Style>
+```
+
+### Custom code block style
+
+```xml
+<Style Selector="Border.markdown-code-block">
+  <Setter Property="Background" Value="#1e1e2e" />
+  <Setter Property="BorderBrush" Value="#313244" />
+  <Setter Property="BorderThickness" Value="1" />
+  <Setter Property="CornerRadius" Value="6" />
+  <Setter Property="Padding" Value="16" />
+</Style>
+```
+
+### Monospace font override
+
+```xml
+<Style Selector="Border.markdown-code-block TextBlock">
+  <Setter Property="FontFamily" Value="JetBrains Mono, Cascadia Code, Consolas, Courier New, monospace" />
+</Style>
+```
+
+## Live theme switching
+
+When the user switches between `Light` and `Dark` theme variants:
+
+- All `DynamicResource` references in `MarkdownTheme.axaml` update automatically.
+- `TextMateCodeBlockRenderer` rebuilds only the `TextBlock.Inlines` for each code block.
+- `MermaidBlockRenderer` re-renders diagrams with updated colour variables.
+- The document scroll position is preserved in both cases.

--- a/samples/MarkView.Avalonia.Demo/README.md
+++ b/samples/MarkView.Avalonia.Demo/README.md
@@ -1,0 +1,71 @@
+# MarkView.Avalonia Demo
+
+An interactive showcase application for the [MarkView.Avalonia](../../README.md) library. The demo renders markdown content using every feature available in the library and its extension packages, and serves as a reference for how to configure the library in a real Avalonia application.
+
+## Running the Demo
+
+```bash
+cd samples/MarkView.Avalonia.Demo
+dotnet run
+```
+
+## What the Demo Shows
+
+The demo window contains a top toolbar and a full-screen `MarkdownViewer`. Use the **View** dropdown to switch between three built-in documents; use **Open file…** to load any local `.md` file.
+
+### Built-in Views
+
+| View | Content |
+|------|---------|
+| **Feature Showcase** | Core markdown: headings, text formatting, EmphasisExtras, blockquotes, task lists, tables, code blocks (multi-language), bitmap image, SVG image, Mermaid diagram |
+| **Extensions Showcase** | Opt-in extensions: footnotes, GitHub alert blocks, abbreviations with tooltips, figures with captions, YouTube thumbnail embeds |
+| **README** | The project's own `README.md` loaded from disk (relative to the solution root) |
+
+### Navigation and History
+
+- **← / →** buttons navigate backward and forward through the history stack (loaded files and in-app anchor jumps).
+- **Open file…** opens a file picker to load any local Markdown file. Once loaded, in-document relative links (`[text](./other.md)`) open further files in the same viewer.
+- **In-document anchor links** (e.g. the Table of Contents) scroll immediately to the target heading via `ScrollToAnchor()`.
+
+### Theme Toggle
+
+The **Light theme** toggle button switches the entire application between Avalonia's `Light` and `Dark` theme variants. Syntax-highlighted code blocks and Mermaid diagrams update in-place — no document rebuild or scroll reset.
+
+## How the Demo Is Configured
+
+All configuration is done once in `App.axaml.cs` and applies globally to every `MarkdownViewer` instance:
+
+```csharp
+// Global pipeline — includes all opt-in extensions for the full showcase
+MarkdownViewerDefaults.Pipeline = new MarkdownPipelineBuilder()
+    .UseSupportedExtensions()
+    .UseFootnotes()
+    .UseAlertBlocks()
+    .UseAbbreviations()
+    .UseFigures()
+    .UseMediaLinks()
+    .Build();
+
+// Global rendering extensions
+MarkdownViewerDefaults.Extensions.AddTextMateHighlighting();
+MarkdownViewerDefaults.Extensions.AddSvg();
+MarkdownViewerDefaults.Extensions.AddMermaid();
+
+// Global link handler
+MarkdownViewer.LinkClickedEvent.AddClassHandler<MarkdownViewer>(OnLinkClicked);
+```
+
+The `OnLinkClicked` handler intercepts absolute `file://` links to `.md` / `.markdown` files and opens them in the viewer instead of the system browser. All other URLs are opened with `Process.Start`.
+
+## Project Structure
+
+```
+MarkView.Avalonia.Demo/
+├── App.axaml            — Application XAML (styles, resources)
+├── App.axaml.cs         — Startup: global pipeline, extensions, link handler
+├── MainWindow.axaml     — Single-window layout (toolbar + MarkdownViewer)
+├── MainWindow.axaml.cs  — Back/forward buttons, file picker
+├── MainViewModel.cs     — MVVM view model: history stack, built-in content, LoadFile()
+└── Assets/
+    └── avalonia-logo.png
+```

--- a/src/MarkView.Avalonia.Mermaid/README.md
+++ b/src/MarkView.Avalonia.Mermaid/README.md
@@ -24,6 +24,13 @@ viewer.UseMermaid();
 viewer.Markdown = markdownText;
 ```
 
+Or activate globally at application startup:
+
+```csharp
+// App.axaml.cs
+MarkdownViewerDefaults.Extensions.AddMermaid();
+```
+
 Diagrams are written in standard [Mermaid](https://mermaid.js.org) syntax inside a fenced code block:
 
 ````markdown
@@ -68,9 +75,14 @@ When the user switches between light and dark, the diagram is automatically re-r
 When `MarkView.Avalonia.SyntaxHighlighting` is also registered, non-mermaid fenced code blocks in the same document get full syntax highlighting. Registration order does not matter:
 
 ```csharp
+// Per-instance
 viewer
     .UseTextMateHighlighting()
     .UseMermaid();
+
+// Or globally
+MarkdownViewerDefaults.Extensions.AddTextMateHighlighting();
+MarkdownViewerDefaults.Extensions.AddMermaid();
 ```
 
 `MermaidBlockRenderer` handles all `FencedCodeBlock` nodes. Mermaid blocks are rendered as diagrams; all other fenced blocks are rendered as styled code blocks using any `ICodeHighlighter` registered by the SyntaxHighlighting extension.

--- a/src/MarkView.Avalonia.Svg/README.md
+++ b/src/MarkView.Avalonia.Svg/README.md
@@ -24,6 +24,13 @@ viewer.UseSvg();
 viewer.Markdown = markdownText;
 ```
 
+Or activate globally at application startup:
+
+```csharp
+// App.axaml.cs
+MarkdownViewerDefaults.Extensions.AddSvg();
+```
+
 Markdown syntax is unchanged — standard image syntax with an `.svg` URL:
 
 ```markdown

--- a/src/MarkView.Avalonia.SyntaxHighlighting/README.md
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/README.md
@@ -24,6 +24,13 @@ viewer.UseTextMateHighlighting();
 viewer.Markdown = markdownText;
 ```
 
+Or activate globally at application startup so every `MarkdownViewer` in the app gets highlighting automatically:
+
+```csharp
+// App.axaml.cs
+MarkdownViewerDefaults.Extensions.AddTextMateHighlighting();
+```
+
 By default, `DarkPlus` is used for dark themes and `LightPlus` for light themes. Both highlighters are created lazily — only the one matching the active variant is loaded at startup.
 
 ## Theme Selection
@@ -92,7 +99,8 @@ using MarkView.Avalonia.Extensions;
 
 public class MyHighlighter : ICodeHighlighter
 {
-    public IReadOnlyList<(string Text, IBrush? Foreground)>? Highlight(string line, string? language)
+    public IReadOnlyList<(string Text, IBrush? Foreground)>? Highlight(
+        ReadOnlyMemory<char> line, string? language)
     {
         // return null to fall back to monochrome rendering
         return null;
@@ -107,11 +115,12 @@ For automatic dark/light updates without a document rebuild, implement `IThemeAw
 ```csharp
 public class MyHighlighter : IThemeAwareCodeHighlighter
 {
-    public IReadOnlyList<(string Text, IBrush? Foreground)>? Highlight(string line, string? language)
+    public IReadOnlyList<(string Text, IBrush? Foreground)>? Highlight(
+        ReadOnlyMemory<char> line, string? language)
         => HighlightVariant(line, language, isDark: false);
 
     public IReadOnlyList<(string Text, IBrush? Foreground)>? HighlightVariant(
-        string line, string? language, bool isDark)
+        ReadOnlyMemory<char> line, string? language, bool isDark)
     {
         // return coloured tokens for the requested variant
         return null;


### PR DESCRIPTION
## Summary

- **Root `README.md`**: substantially expanded — full feature list, installation steps, XAML setup, all extension packages, badges, and links to the new docs folder.
- **`docs/` folder**: new developer documentation site with six pages: `getting-started.md`, `configuration.md`, `extensions.md`, `text-selection.md`, `theming.md`, and `custom-extensions.md`, plus a `README.md` index.
- **`docs/getting-started.md`**: installation, XAML setup, first render, and `StyleInclude` instructions.
- **`docs/configuration.md`**: Markdig pipeline options, `MarkdownViewerDefaults`, `BaseUri`, and opt-in extension helpers.
- **`docs/extensions.md`**: per-package guides for `SyntaxHighlighting`, `Svg`, and `Mermaid` — installation, `UseXxx()` activation, and key options.
- **`docs/text-selection.md`**: `SelectAll()`, `ClearSelection()`, `GetSelectedText()`, `CopyToClipboardAsync()`, `LinkClicked`, and keyboard shortcuts.
- **`docs/theming.md`**: `markdown-*` CSS class reference, dark/light theme switching, `DynamicResource` customisation, and monospace font stack.
- **`docs/custom-extensions.md`**: full walkthrough of `IMarkViewExtension`, custom image loaders, custom block/inline renderers, and `ICodeHighlighter`.
- **`samples/MarkView.Avalonia.Demo/README.md`**: demo app guide — build, run, keyboard shortcuts, and architecture notes.
- **Extension package READMEs** (`SyntaxHighlighting`, `Svg`, `Mermaid`): updated/extended with accurate wording and cross-links to the new docs.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [x] Documentation
- [ ] CI / build

## Test plan

- [x] `dotnet test` — all tests pass
- [x] Manual smoke-test in the demo app

## Related issues

N/A
