### PR TITLE
perf: performance improvements

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
 ## Summary
 
 <!--
-One bullet per logical change (•). Be specific: class/method names, packages
+One item per logical change. Be specific: class/method names, packages
 affected, behaviour before → after.
 -->
 
-•
+- 
 
 ## Type of change
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -93,7 +93,7 @@ Plain `[Fact]` / `[Theory]` is only safe when a test constructs **zero Avalonia 
 
 **Do not** assume that "no visual tree / no layout" makes a test safe for `[Fact]`. The rule is: **no Avalonia object construction at all**.
 
-> **Known upstream issue:** `Avalonia/Avalonia#20664` — `HeadlessUnitTestSession` cleanup can resume on a different thread in xUnit v3's async lifecycle, causing sporadic `Dispatcher.VerifyAccess()` failures in `[AvaloniaFact]` tests. Mitigation: convert to `[Fact]` only where truly safe (see above); otherwise accept the occasional flake until the upstream fix lands.
+> **Known upstream issue:** `AvaloniaUI/Avalonia#20664` — `HeadlessUnitTestSession` cleanup can resume on a different thread in xUnit v3's async lifecycle, causing sporadic `Dispatcher.VerifyAccess()` failures in `[AvaloniaFact]` tests. Mitigation: convert to `[Fact]` only where truly safe (see above); otherwise accept the occasional flake until the upstream fix lands.
 
 ## Known Limitations / Open TODOs
 

--- a/src/MarkView.Avalonia.Mermaid/MermaidBlockRenderer.cs
+++ b/src/MarkView.Avalonia.Mermaid/MermaidBlockRenderer.cs
@@ -27,7 +27,7 @@ namespace MarkView.Avalonia.Mermaid;
 /// non-mermaid fenced blocks are rendered as styled code blocks and respect any
 /// <see cref="AvaloniaRenderer.CodeHighlighter"/> registered by the SyntaxHighlighting extension.
 /// </summary>
-public class MermaidBlockRenderer : AvaloniaObjectRenderer<FencedCodeBlock>
+public sealed class MermaidBlockRenderer : AvaloniaObjectRenderer<FencedCodeBlock>
 {
     protected override void Write(AvaloniaRenderer renderer, FencedCodeBlock obj)
     {

--- a/src/MarkView.Avalonia.Mermaid/MermaidBlockRenderer.cs
+++ b/src/MarkView.Avalonia.Mermaid/MermaidBlockRenderer.cs
@@ -40,67 +40,100 @@ public class MermaidBlockRenderer : AvaloniaObjectRenderer<FencedCodeBlock>
     private static void WriteMermaid(AvaloniaRenderer renderer, FencedCodeBlock obj)
     {
         var source = ExtractSource(obj);
-        try
+
+        var image = new Image
         {
-            var image = new Image
-            {
-                Stretch = Stretch.Uniform,
-                HorizontalAlignment = HorizontalAlignment.Left,
-            };
+            Stretch = Stretch.Uniform,
+            HorizontalAlignment = HorizontalAlignment.Left,
+        };
 
-            ApplyTheme();
+        var border = new Border { Child = image };
+        border.Classes.Add("markdown-mermaid");
 
-            // Re-render when the user switches light/dark theme.
-            // Standard Avalonia controls update automatically via DynamicResource, but
-            // the Mermaid SVG has colours baked in at render time so it must be rebuilt.
-            void OnThemeChanged(object? s, AvaloniaPropertyChangedEventArgs e) => ApplyTheme();
-            Application.Current!.PropertyChanged += OnThemeChanged;
+        CancellationTokenSource? cts = null;
 
-            // A ScrollViewer passes infinite available width to its children.
-            // Constrain MaxWidth to the viewport width, updating on resize.
-            image.AttachedToVisualTree += (_, _) =>
-            {
-                var sv = image.FindAncestorOfType<ScrollViewer>();
-                if (sv is null) return;
-
-                sv.SizeChanged += OnSizeChanged;
-                image.DetachedFromLogicalTree += (_, _) =>
-                {
-                    sv.SizeChanged -= OnSizeChanged;
-                    Application.Current?.PropertyChanged -= OnThemeChanged;
-                };
-                Update();
-
-                void Update()
-                {
-                    var w = sv.Viewport.Width;
-                    if (w > 0) image.MaxWidth = Math.Min(w, 800);
-                }
-
-                void OnSizeChanged(object? s, SizeChangedEventArgs e) => Update();
-            };
-
-            var border = new Border { Child = image };
-            border.Classes.Add("markdown-mermaid");
-            renderer.WriteBlock(border);
-
-            void ApplyTheme()
-            {
-                var opts = GetRenderOptions();
-                var prevCulture = Thread.CurrentThread.CurrentCulture;
-                Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
-                string svg;
-                try { svg = MermaidRenderer.RenderSvg(source, opts); }
-                finally { Thread.CurrentThread.CurrentCulture = prevCulture; }
-
-                svg = InlineCssVariables(svg, opts);
-                using var stream = new MemoryStream(Encoding.UTF8.GetBytes(svg));
-                image.Source = new SvgImage { Source = SvgSource.LoadFromStream(stream) };
-            }
+        // Re-render when the user switches light/dark theme.
+        // Standard Avalonia controls update automatically via DynamicResource, but
+        // the Mermaid SVG has colours baked in at render time so it must be rebuilt.
+        void OnThemeChanged(object? s, AvaloniaPropertyChangedEventArgs e)
+        {
+            if (e.Property.Name != nameof(Application.ActualThemeVariant)) return;
+            _ = ApplyThemeAsync();
         }
-        catch (Exception ex)
+        Application.Current!.PropertyChanged += OnThemeChanged;
+
+        // A ScrollViewer passes infinite available width to its children.
+        // Constrain MaxWidth to the viewport width, updating on resize.
+        image.AttachedToVisualTree += (_, _) =>
         {
-            WriteFallback(renderer, source, ex.Message);
+            var sv = image.FindAncestorOfType<ScrollViewer>();
+            if (sv is null) return;
+
+            sv.SizeChanged += OnSizeChanged;
+            image.DetachedFromLogicalTree += (_, _) =>
+            {
+                sv.SizeChanged -= OnSizeChanged;
+                Application.Current?.PropertyChanged -= OnThemeChanged;
+                cts?.Cancel();
+                cts?.Dispose();
+            };
+            Update();
+
+            void Update()
+            {
+                var w = sv.Viewport.Width;
+                if (w > 0) image.MaxWidth = Math.Min(w, 800);
+            }
+
+            void OnSizeChanged(object? s, SizeChangedEventArgs e) => Update();
+        };
+
+        renderer.WriteBlock(border);
+        _ = ApplyThemeAsync();
+
+        // Heavy work (MermaidRenderer.RenderSvg + SvgSource.LoadFromStream via SkiaSharp)
+        // is offloaded to a background thread so the UI thread is never blocked.
+        // A CancellationTokenSource allows rapid theme switches to cancel in-flight renders.
+        async Task ApplyThemeAsync()
+        {
+            cts?.Cancel();
+            cts?.Dispose();
+            var localCts = cts = new CancellationTokenSource();
+            var token = localCts.Token;
+
+            var opts = GetRenderOptions();
+
+            try
+            {
+                var svgSource = await Task.Run(() =>
+                {
+                    var prevCulture = Thread.CurrentThread.CurrentCulture;
+                    Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+                    string svg;
+                    try { svg = MermaidRenderer.RenderSvg(source, opts); }
+                    finally { Thread.CurrentThread.CurrentCulture = prevCulture; }
+
+                    svg = InlineCssVariables(svg, opts);
+                    using var stream = new MemoryStream(Encoding.UTF8.GetBytes(svg));
+                    return SvgSource.LoadFromStream(stream);
+                }, token);
+
+                if (!token.IsCancellationRequested)
+                    image.Source = new SvgImage { Source = svgSource };
+            }
+            catch (OperationCanceledException) { }
+            catch (Exception ex)
+            {
+                if (!token.IsCancellationRequested)
+                {
+                    var panel = new StackPanel { Spacing = 4 };
+                    panel.Children.Add(new TextBlock { Text = $"Mermaid render error: {ex.Message}" });
+                    panel.Children.Add(new TextBlock { Text = source });
+                    border.Child = panel;
+                    border.Classes.Clear();
+                    border.Classes.Add("markdown-mermaid-fallback");
+                }
+            }
         }
     }
 
@@ -198,19 +231,6 @@ public class MermaidBlockRenderer : AvaloniaObjectRenderer<FencedCodeBlock>
             sb.Append(lines.Lines[i].Slice.AsSpan());
         }
         return sb.ToString();
-    }
-
-    private static void WriteFallback(AvaloniaRenderer renderer, string source, string? errorMessage = null)
-    {
-        var panel = new StackPanel { Spacing = 4 };
-        if (errorMessage != null)
-            panel.Children.Add(new TextBlock { Text = $"Mermaid render error: {errorMessage}" });
-        panel.Children.Add(new TextBlock { Text = source });
-
-        var border = new Border { Child = panel };
-        border.Classes.Add("markdown-mermaid-fallback");
-
-        renderer.WriteBlock(border);
     }
 
     private static void WriteStandardCodeBlock(AvaloniaRenderer renderer, FencedCodeBlock obj)

--- a/src/MarkView.Avalonia.Svg/SvgImageLoader.cs
+++ b/src/MarkView.Avalonia.Svg/SvgImageLoader.cs
@@ -5,7 +5,6 @@ using System.Xml;
 
 using Avalonia.Media;
 using Avalonia.Svg.Skia;
-using Avalonia.Threading;
 
 using MarkView.Avalonia.Extensions;
 
@@ -50,19 +49,27 @@ public sealed class SvgImageLoader : IImageLoader
             if (url.StartsWith("data:", StringComparison.OrdinalIgnoreCase))
             {
                 var bytes = DecodeDataUri(url);
-                using var ms = new MemoryStream(bytes);
-                source = SvgSource.LoadFromStream(ms);
+                source = await Task.Run(() =>
+                {
+                    using var ms = new MemoryStream(bytes);
+                    return SvgSource.LoadFromStream(ms);
+                }, cancellationToken);
             }
             else
             {
                 if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
                     return null;
                 using var responseStream = await HttpClient.GetStreamAsync(uri, cancellationToken);
-                source = SvgSource.LoadFromStream(responseStream);
+                using var buffer = new MemoryStream();
+                await responseStream.CopyToAsync(buffer, cancellationToken);
+                buffer.Position = 0;
+                source = await Task.Run(() => SvgSource.LoadFromStream(buffer), cancellationToken);
             }
 
             // SvgImage is an AvaloniaObject — must be created on the UI thread.
-            return await Dispatcher.UIThread.InvokeAsync(() => new SvgImage { Source = source });
+            // LoadAsync is always awaited from LoadImageAsync which starts on the Avalonia UI
+            // thread, so the SynchronizationContext is captured and continuations resume there.
+            return new SvgImage { Source = source };
         }
         catch (OperationCanceledException)
         {

--- a/src/MarkView.Avalonia.Svg/SvgImageLoader.cs
+++ b/src/MarkView.Avalonia.Svg/SvgImageLoader.cs
@@ -16,7 +16,6 @@ namespace MarkView.Avalonia.Svg;
 /// </summary>
 public sealed class SvgImageLoader : IImageLoader
 {
-    private static readonly HttpClient HttpClient = new();
 
     public bool CanLoad(string url)
     {
@@ -59,7 +58,7 @@ public sealed class SvgImageLoader : IImageLoader
             {
                 if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
                     return null;
-                using var responseStream = await HttpClient.GetStreamAsync(uri, cancellationToken);
+                using var responseStream = await SharedHttpClient.Instance.GetStreamAsync(uri, cancellationToken);
                 using var buffer = new MemoryStream();
                 await responseStream.CopyToAsync(buffer, cancellationToken);
                 buffer.Position = 0;

--- a/src/MarkView.Avalonia.SyntaxHighlighting/TextMateCodeBlockRenderer.cs
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/TextMateCodeBlockRenderer.cs
@@ -21,7 +21,7 @@ namespace MarkView.Avalonia.SyntaxHighlighting;
 /// and subscribes to theme changes so token colours update in-place when the user switches
 /// between light and dark themes — without rebuilding the surrounding document tree.
 /// </summary>
-public class TextMateCodeBlockRenderer : AvaloniaObjectRenderer<CodeBlock>
+public sealed class TextMateCodeBlockRenderer : AvaloniaObjectRenderer<CodeBlock>
 {
     protected override void Write(AvaloniaRenderer renderer, CodeBlock obj)
     {

--- a/src/MarkView.Avalonia.SyntaxHighlighting/TextMateHighlighter.cs
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/TextMateHighlighter.cs
@@ -14,7 +14,7 @@ namespace MarkView.Avalonia.SyntaxHighlighting;
 /// Tokenises source-code lines using TextMate grammars and maps token
 /// scopes to <see cref="IBrush"/> colours via the chosen theme.
 /// </summary>
-public class TextMateHighlighter : ICodeHighlighter
+public sealed class TextMateHighlighter : ICodeHighlighter
 {
     private readonly RegistryOptions _options;
     private readonly Registry _registry;

--- a/src/MarkView.Avalonia/AssemblyInfo.cs
+++ b/src/MarkView.Avalonia/AssemblyInfo.cs
@@ -1,3 +1,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("MarkView.Avalonia.Tests")]
+[assembly: InternalsVisibleTo("MarkView.Avalonia.Svg")]

--- a/src/MarkView.Avalonia/Extensions/BitmapImageLoader.cs
+++ b/src/MarkView.Avalonia/Extensions/BitmapImageLoader.cs
@@ -16,7 +16,6 @@ namespace MarkView.Avalonia.Extensions;
 /// </summary>
 internal sealed class BitmapImageLoader : IImageLoader
 {
-    private static readonly HttpClient HttpClient = new();
 
     public bool CanLoad(string url)
     {
@@ -52,7 +51,7 @@ internal sealed class BitmapImageLoader : IImageLoader
                 return new Bitmap(stream);
             }
 
-            using var responseStream = await HttpClient.GetStreamAsync(uri, cancellationToken);
+            using var responseStream = await SharedHttpClient.Instance.GetStreamAsync(uri, cancellationToken);
             using var buffer = new MemoryStream();
             await responseStream.CopyToAsync(buffer, cancellationToken);
             buffer.Position = 0;

--- a/src/MarkView.Avalonia/Extensions/SharedHttpClient.cs
+++ b/src/MarkView.Avalonia/Extensions/SharedHttpClient.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace MarkView.Avalonia.Extensions;
+
+/// <summary>
+/// Shared <see cref="HttpClient"/> instance for all image loaders.
+/// A single static instance is sufficient — and recommended — to allow connection pooling
+/// across <see cref="BitmapImageLoader"/>, <c>SvgImageLoader</c>, and <see cref="Rendering.Inlines.LinkInlineRenderer"/>.
+/// </summary>
+internal static class SharedHttpClient
+{
+    internal static readonly HttpClient Instance = new();
+}

--- a/src/MarkView.Avalonia/MarkdownViewer.cs
+++ b/src/MarkView.Avalonia/MarkdownViewer.cs
@@ -27,6 +27,8 @@ public partial class MarkdownViewer : ContentControl
     [GeneratedRegex(@"(\!\[[^\]]*\]\()([^\s\)]+)\s+=(\d+x\d+)(\))", RegexOptions.Compiled)]
     private static partial Regex ImageSizePreprocessorRegex();
 
+    private static readonly Cursor HandCursor = new(StandardCursorType.Hand);
+
     private Dictionary<string, Control> _anchors = new(StringComparer.OrdinalIgnoreCase);
     private DocumentSelectionLayer? _selectionLayer;
     private bool _isDragging;
@@ -387,7 +389,7 @@ public partial class MarkdownViewer : ContentControl
     {
         if (_selectionLayer is null) return;
         Cursor = FindHyperlinkAt(posInLayer) != null
-            ? new Cursor(StandardCursorType.Hand)
+            ? HandCursor
             : Cursor.Default;
     }
 

--- a/src/MarkView.Avalonia/MarkdownViewer.cs
+++ b/src/MarkView.Avalonia/MarkdownViewer.cs
@@ -24,7 +24,7 @@ public partial class MarkdownViewer : ContentControl
 {
     // Converts the non-standard "![alt](url =WxH)" size hint to the title slot so Markdig
     // can parse it: "![alt](url "=WxH")". CommonMark has no image-size syntax.
-    [GeneratedRegex(@"(\!\[[^\]]*\]\()([^\s\)]+)\s+=(\d+x\d+)(\))", RegexOptions.Compiled)]
+    [GeneratedRegex(@"(\!\[[^\]]*\]\()([^\s\)]+)\s+=(\d+x\d+)(\))")]
     private static partial Regex ImageSizePreprocessorRegex();
 
     private static readonly Cursor HandCursor = new(StandardCursorType.Hand);

--- a/src/MarkView.Avalonia/Rendering/Blocks/AlertBlockRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/AlertBlockRenderer.cs
@@ -12,7 +12,7 @@ namespace MarkView.Avalonia.Rendering.Blocks;
 /// Supports GitHub GFM variants: NOTE, TIP, WARNING, IMPORTANT, CAUTION.
 /// BorderBrush per variant is provided by AXAML theme styles (markdown-alert-note, etc.).
 /// </summary>
-public class AlertBlockRenderer : AvaloniaObjectRenderer<AlertBlock>
+public sealed class AlertBlockRenderer : AvaloniaObjectRenderer<AlertBlock>
 {
     protected override void Write(AvaloniaRenderer renderer, AlertBlock obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Blocks/CodeBlockRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/CodeBlockRenderer.cs
@@ -8,7 +8,7 @@ using Markdig.Syntax;
 
 namespace MarkView.Avalonia.Rendering.Blocks;
 
-public class CodeBlockRenderer : AvaloniaObjectRenderer<CodeBlock>
+public sealed class CodeBlockRenderer : AvaloniaObjectRenderer<CodeBlock>
 {
     protected override void Write(AvaloniaRenderer renderer, CodeBlock obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Blocks/FigureRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/FigureRenderer.cs
@@ -13,7 +13,7 @@ namespace MarkView.Avalonia.Rendering.Blocks;
 /// Renders Markdig <see cref="Figure"/> blocks. <see cref="FigureCaption"/> children
 /// are rendered as an italic centred caption below the figure content.
 /// </summary>
-public class FigureRenderer : AvaloniaObjectRenderer<Figure>
+public sealed class FigureRenderer : AvaloniaObjectRenderer<Figure>
 {
     protected override void Write(AvaloniaRenderer renderer, Figure obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Blocks/FootnoteGroupRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/FootnoteGroupRenderer.cs
@@ -13,7 +13,7 @@ namespace MarkView.Avalonia.Rendering.Blocks;
 /// Renders a Markdig <see cref="FootnoteGroup"/> block as a numbered definition list below a separator.
 /// Each footnote definition is registered as an anchor for back-navigation.
 /// </summary>
-public class FootnoteGroupRenderer : AvaloniaObjectRenderer<FootnoteGroup>
+public sealed class FootnoteGroupRenderer : AvaloniaObjectRenderer<FootnoteGroup>
 {
     protected override void Write(AvaloniaRenderer renderer, FootnoteGroup obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Blocks/HeadingRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/HeadingRenderer.cs
@@ -12,7 +12,7 @@ namespace MarkView.Avalonia.Rendering.Blocks;
 /// Renders a Markdig <see cref="HeadingBlock"/> as a <see cref="MarkdownSelectableTextBlock"/>
 /// and registers it as an anchor target for in-document navigation.
 /// </summary>
-public class HeadingRenderer : AvaloniaObjectRenderer<HeadingBlock>
+public sealed class HeadingRenderer : AvaloniaObjectRenderer<HeadingBlock>
 {
     protected override void Write(AvaloniaRenderer renderer, HeadingBlock obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Blocks/HtmlBlockRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/HtmlBlockRenderer.cs
@@ -9,7 +9,7 @@ namespace MarkView.Avalonia.Rendering.Blocks;
 /// Renders a Markdig <see cref="HtmlBlock"/> as raw text.
 /// Full HTML rendering is out of scope; this provides a visible fallback.
 /// </summary>
-public class HtmlBlockRenderer : AvaloniaObjectRenderer<HtmlBlock>
+public sealed class HtmlBlockRenderer : AvaloniaObjectRenderer<HtmlBlock>
 {
     protected override void Write(AvaloniaRenderer renderer, HtmlBlock obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Blocks/ListRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/ListRenderer.cs
@@ -10,7 +10,7 @@ using Markdig.Syntax;
 
 namespace MarkView.Avalonia.Rendering.Blocks;
 
-public class ListRenderer : AvaloniaObjectRenderer<ListBlock>
+public sealed class ListRenderer : AvaloniaObjectRenderer<ListBlock>
 {
     protected override void Write(AvaloniaRenderer renderer, ListBlock obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Blocks/ParagraphRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/ParagraphRenderer.cs
@@ -10,7 +10,7 @@ namespace MarkView.Avalonia.Rendering.Blocks;
 /// <summary>
 /// Renders a Markdig <see cref="ParagraphBlock"/> as a <see cref="MarkdownSelectableTextBlock"/>.
 /// </summary>
-public class ParagraphRenderer : AvaloniaObjectRenderer<ParagraphBlock>
+public sealed class ParagraphRenderer : AvaloniaObjectRenderer<ParagraphBlock>
 {
     protected override void Write(AvaloniaRenderer renderer, ParagraphBlock obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Blocks/QuoteBlockRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/QuoteBlockRenderer.cs
@@ -7,7 +7,7 @@ using Markdig.Syntax;
 
 namespace MarkView.Avalonia.Rendering.Blocks;
 
-public class QuoteBlockRenderer : AvaloniaObjectRenderer<QuoteBlock>
+public sealed class QuoteBlockRenderer : AvaloniaObjectRenderer<QuoteBlock>
 {
     protected override void Write(AvaloniaRenderer renderer, QuoteBlock obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Blocks/TableRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/TableRenderer.cs
@@ -12,7 +12,7 @@ namespace MarkView.Avalonia.Rendering.Blocks;
 /// Renders a Markdig <see cref="Table"/> as an Avalonia <see cref="Grid"/>.
 /// Supports pipe tables and grid tables (both share the same AST).
 /// </summary>
-public class TableRenderer : AvaloniaObjectRenderer<Table>
+public sealed class TableRenderer : AvaloniaObjectRenderer<Table>
 {
     protected override void Write(AvaloniaRenderer renderer, Table obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Blocks/ThematicBreakRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/ThematicBreakRenderer.cs
@@ -7,7 +7,7 @@ using Markdig.Syntax;
 
 namespace MarkView.Avalonia.Rendering.Blocks;
 
-public class ThematicBreakRenderer : AvaloniaObjectRenderer<ThematicBreakBlock>
+public sealed class ThematicBreakRenderer : AvaloniaObjectRenderer<ThematicBreakBlock>
 {
     protected override void Write(AvaloniaRenderer renderer, ThematicBreakBlock obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Inlines/AbbreviationInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/AbbreviationInlineRenderer.cs
@@ -12,7 +12,7 @@ namespace MarkView.Avalonia.Rendering.Inlines;
 /// Renders a Markdig <see cref="AbbreviationInline"/> as a <see cref="TextBlock"/>
 /// inside an <see cref="InlineUIContainer"/> with a tooltip showing the full definition.
 /// </summary>
-public class AbbreviationInlineRenderer : AvaloniaObjectRenderer<AbbreviationInline>
+public sealed class AbbreviationInlineRenderer : AvaloniaObjectRenderer<AbbreviationInline>
 {
     protected override void Write(AvaloniaRenderer renderer, AbbreviationInline obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Inlines/AutolinkInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/AutolinkInlineRenderer.cs
@@ -11,7 +11,7 @@ namespace MarkView.Avalonia.Rendering.Inlines;
 /// <summary>
 /// Renders a Markdig <see cref="AutolinkInline"/> as an Avalonia <see cref="HyperlinkButton"/>.
 /// </summary>
-public class AutolinkInlineRenderer : AvaloniaObjectRenderer<AutolinkInline>
+public sealed class AutolinkInlineRenderer : AvaloniaObjectRenderer<AutolinkInline>
 {
     protected override void Write(AvaloniaRenderer renderer, AutolinkInline obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Inlines/CodeInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/CodeInlineRenderer.cs
@@ -11,7 +11,7 @@ namespace MarkView.Avalonia.Rendering.Inlines;
 /// Renders a Markdig <see cref="CodeInline"/> as a styled <see cref="Run"/>.
 /// Using Run (instead of Border+InlineUIContainer) keeps the text selectable.
 /// </summary>
-public class CodeInlineRenderer : AvaloniaObjectRenderer<CodeInline>
+public sealed class CodeInlineRenderer : AvaloniaObjectRenderer<CodeInline>
 {
     protected override void Write(AvaloniaRenderer renderer, CodeInline obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Inlines/DelimiterInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/DelimiterInlineRenderer.cs
@@ -7,7 +7,7 @@ using Markdig.Syntax.Inlines;
 
 namespace MarkView.Avalonia.Rendering.Inlines;
 
-public class DelimiterInlineRenderer : AvaloniaObjectRenderer<DelimiterInline>
+public sealed class DelimiterInlineRenderer : AvaloniaObjectRenderer<DelimiterInline>
 {
     protected override void Write(AvaloniaRenderer renderer, DelimiterInline obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Inlines/EmphasisInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/EmphasisInlineRenderer.cs
@@ -8,7 +8,7 @@ using Markdig.Syntax.Inlines;
 
 namespace MarkView.Avalonia.Rendering.Inlines;
 
-public class EmphasisInlineRenderer : AvaloniaObjectRenderer<EmphasisInline>
+public sealed class EmphasisInlineRenderer : AvaloniaObjectRenderer<EmphasisInline>
 {
     protected override void Write(AvaloniaRenderer renderer, EmphasisInline obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Inlines/FootnoteLinkRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/FootnoteLinkRenderer.cs
@@ -11,7 +11,7 @@ namespace MarkView.Avalonia.Rendering.Inlines;
 /// Renders a Markdig <see cref="FootnoteLink"/> inline as a clickable superscript reference.
 /// Clicking navigates to the footnote definition anchor (fn-N). Back-links are skipped.
 /// </summary>
-public class FootnoteLinkRenderer : AvaloniaObjectRenderer<FootnoteLink>
+public sealed class FootnoteLinkRenderer : AvaloniaObjectRenderer<FootnoteLink>
 {
     protected override void Write(AvaloniaRenderer renderer, FootnoteLink obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Inlines/HtmlEntityInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/HtmlEntityInlineRenderer.cs
@@ -7,7 +7,7 @@ using Markdig.Syntax.Inlines;
 
 namespace MarkView.Avalonia.Rendering.Inlines;
 
-public class HtmlEntityInlineRenderer : AvaloniaObjectRenderer<HtmlEntityInline>
+public sealed class HtmlEntityInlineRenderer : AvaloniaObjectRenderer<HtmlEntityInline>
 {
     protected override void Write(AvaloniaRenderer renderer, HtmlEntityInline obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Inlines/HtmlInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/HtmlInlineRenderer.cs
@@ -14,7 +14,7 @@ namespace MarkView.Avalonia.Rendering.Inlines;
 /// Recognizes common self-closing tags (e.g. &lt;br&gt;, &lt;br/&gt;) and renders them
 /// as their visual equivalent. Other HTML tags are silently ignored.
 /// </summary>
-public partial class HtmlInlineRenderer : AvaloniaObjectRenderer<HtmlInline>
+public sealed partial class HtmlInlineRenderer : AvaloniaObjectRenderer<HtmlInline>
 {
     [GeneratedRegex(@"^<br\s*/?\s*>$", RegexOptions.IgnoreCase)]
     private static partial Regex BrTagRegex();

--- a/src/MarkView.Avalonia/Rendering/Inlines/LineBreakInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LineBreakInlineRenderer.cs
@@ -7,7 +7,7 @@ using Markdig.Syntax.Inlines;
 
 namespace MarkView.Avalonia.Rendering.Inlines;
 
-public class LineBreakInlineRenderer : AvaloniaObjectRenderer<LineBreakInline>
+public sealed class LineBreakInlineRenderer : AvaloniaObjectRenderer<LineBreakInline>
 {
     protected override void Write(AvaloniaRenderer renderer, LineBreakInline obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
@@ -6,7 +6,6 @@ using System.Text.RegularExpressions;
 using Avalonia.Controls;
 using Avalonia.Layout;
 using Avalonia.Media;
-using Avalonia.Threading;
 
 using Markdig.Syntax.Inlines;
 
@@ -122,7 +121,7 @@ public partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
                 var loaded = await loader.LoadAsync(url, cancellationToken);
                 if (loaded != null)
                 {
-                    await Dispatcher.UIThread.InvokeAsync(() => image.Source = loaded);
+                    image.Source = loaded;
                     return;
                 }
             }

--- a/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
@@ -15,7 +15,7 @@ namespace MarkView.Avalonia.Rendering.Inlines;
 /// Renders a Markdig <see cref="LinkInline"/> as a <see cref="MarkdownHyperlink"/> span or image.
 /// YouTube video links (produced by UseMediaLinks) are rendered as clickable thumbnails.
 /// </summary>
-public partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
+public sealed partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
 {
     private static readonly HttpClient HttpClient = new();
 

--- a/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
@@ -20,10 +20,10 @@ public partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
     private static readonly HttpClient HttpClient = new();
 
     // Matches the "=WxH" title produced by MarkdownViewer's preprocessor.
-    [GeneratedRegex(@"^=(\d+)x(\d+)$", RegexOptions.Compiled)]
+    [GeneratedRegex(@"^=(\d+)x(\d+)$")]
     private static partial Regex DimensionTitleRegex();
 
-    [GeneratedRegex(@"(?:youtu\.be/|[?&]v=)([A-Za-z0-9_\-]{11})", RegexOptions.Compiled)]
+    [GeneratedRegex(@"(?:youtu\.be/|[?&]v=)([A-Za-z0-9_\-]{11})")]
     private static partial Regex YoutubeIdRegex();
 
     protected override void Write(AvaloniaRenderer renderer, LinkInline obj)

--- a/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
@@ -17,7 +17,6 @@ namespace MarkView.Avalonia.Rendering.Inlines;
 /// </summary>
 public sealed partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInline>
 {
-    private static readonly HttpClient HttpClient = new();
 
     // Matches the "=WxH" title produced by MarkdownViewer's preprocessor.
     [GeneratedRegex(@"^=(\d+)x(\d+)$")]

--- a/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Nicolas Musset
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 using Avalonia.Controls;
@@ -76,8 +77,8 @@ public sealed partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInli
             var dim = DimensionTitleRegex().Match(obj.Title);
             if (dim.Success)
             {
-                image.Width = int.Parse(dim.Groups[1].Value);
-                image.Height = int.Parse(dim.Groups[2].Value);
+                image.Width = int.Parse(dim.Groups[1].Value, CultureInfo.InvariantCulture);
+                image.Height = int.Parse(dim.Groups[2].Value, CultureInfo.InvariantCulture);
                 image.Stretch = Stretch.Uniform;
             }
         }
@@ -155,8 +156,8 @@ public sealed partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInli
             var dim = DimensionTitleRegex().Match(obj.Title);
             if (dim.Success)
             {
-                thumbnail.Width = int.Parse(dim.Groups[1].Value);
-                thumbnail.Height = int.Parse(dim.Groups[2].Value);
+                thumbnail.Width = int.Parse(dim.Groups[1].Value, CultureInfo.InvariantCulture);
+                thumbnail.Height = int.Parse(dim.Groups[2].Value, CultureInfo.InvariantCulture);
                 thumbnail.Stretch = Stretch.Uniform;
             }
         }

--- a/src/MarkView.Avalonia/Rendering/Inlines/LiteralInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LiteralInlineRenderer.cs
@@ -10,7 +10,7 @@ namespace MarkView.Avalonia.Rendering.Inlines;
 /// <summary>
 /// Renders a Markdig <see cref="LiteralInline"/> as an Avalonia <see cref="Run"/>.
 /// </summary>
-public class LiteralInlineRenderer : AvaloniaObjectRenderer<LiteralInline>
+public sealed class LiteralInlineRenderer : AvaloniaObjectRenderer<LiteralInline>
 {
     protected override void Write(AvaloniaRenderer renderer, LiteralInline obj)
     {

--- a/src/MarkView.Avalonia/Rendering/Inlines/TaskListRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/TaskListRenderer.cs
@@ -11,7 +11,7 @@ namespace MarkView.Avalonia.Rendering.Inlines;
 /// <summary>
 /// Renders a Markdig <see cref="TaskList"/> as a disabled <see cref="CheckBox"/>.
 /// </summary>
-public class TaskListRenderer : AvaloniaObjectRenderer<TaskList>
+public sealed class TaskListRenderer : AvaloniaObjectRenderer<TaskList>
 {
     protected override void Write(AvaloniaRenderer renderer, TaskList obj)
     {


### PR DESCRIPTION
## Summary

- Offload Mermaid SVG render to background thread; fix spurious re-renders on theme change
- Offload `SvgSource.LoadFromStream` to background thread; remove redundant dispatcher dispatch
- Cache `Hand` cursor as `static readonly` to avoid per-`PointerMoved` allocation
- Remove redundant `RegexOptions.Compiled` from `[GeneratedRegex]` attributes (SYSLIB1044)
- Seal all concrete renderer and highlighter classes to enable JIT devirtualization
- Consolidate three separate `HttpClient` instances into a single shared instance
- Use `CultureInfo.InvariantCulture` in `int.Parse` for image dimension parsing

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactoring (no behaviour change)
- [ ] Documentation
- [ ] CI / build

## Test plan

- [x] `dotnet test` — all tests pass (211 tests)
- [ ] Manual smoke-test in the demo app