### PR TITLE
feat: add Source property to MarkdownViewer

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,19 +6,19 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Core dependencies -->
-    <PackageVersion Include="Avalonia" Version="12.0.1" />
+    <PackageVersion Include="Avalonia" Version="12.0.2" />
     <PackageVersion Include="Mermaider" Version="0.6.0" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.1" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.1" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.2" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.2" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.2" />
     <PackageVersion Include="Markdig" Version="1.1.3" />
     <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.3" />
     <PackageVersion Include="TextMateSharp" Version="2.0.3" />
     <PackageVersion Include="TextMateSharp.Grammars" Version="2.0.3" />
     <!-- Test dependencies -->
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.2" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,20 +6,20 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Core dependencies -->
-    <PackageVersion Include="Avalonia" Version="12.0.*" />
-    <PackageVersion Include="Mermaider" Version="0.*" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.*" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.*" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.*" />
-    <PackageVersion Include="Markdig" Version="1.1.*" />
-    <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.*" />
-    <PackageVersion Include="TextMateSharp" Version="2.*" />
-    <PackageVersion Include="TextMateSharp.Grammars" Version="2.*" />
+    <PackageVersion Include="Avalonia" Version="12.0.1" />
+    <PackageVersion Include="Mermaider" Version="0.6.0" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.1" />
+    <PackageVersion Include="Markdig" Version="1.1.3" />
+    <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.3" />
+    <PackageVersion Include="TextMateSharp" Version="2.0.3" />
+    <PackageVersion Include="TextMateSharp.Grammars" Version="2.0.3" />
     <!-- Test dependencies -->
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.*" />
-    <PackageVersion Include="coverlet.collector" Version="10.*" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.*" />
-    <PackageVersion Include="xunit.v3" Version="3.*" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.*" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 </Project>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,8 +5,9 @@
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `Markdown` | `string?` | `null` | The markdown text to render. Setting this triggers a full re-render. |
+| `Source` | `Uri?` | `null` | URI of a markdown document to load and render. Takes precedence over `Markdown` when set. Supports `avares://`, `file://`, and `http/https`. |
 | `Pipeline` | `MarkdownPipeline?` | `null` | The Markdig pipeline. `null` falls back to `MarkdownViewerDefaults.Pipeline`, or the built-in default (`UseSupportedExtensions`). |
-| `BaseUri` | `Uri?` | `null` | Base URI for resolving relative links and image paths. |
+| `BaseUri` | `Uri?` | `null` | Base URI for resolving relative links and image paths. When `Source` is set and `BaseUri` is not, it is inferred automatically from the source location. |
 | `Extensions` | `IList<IMarkViewExtension>` | `[]` | Per-instance rendering extensions. Applied after global defaults. |
 
 ## Markdig Pipeline
@@ -71,17 +72,51 @@ MarkdownViewerDefaults.Extensions.AddMermaid();
 2. `MarkdownViewerDefaults.Extensions` are registered first, then `viewer.Extensions`.
 3. If the same extension object appears in both lists it is registered only once (reference equality check).
 
+## Source property
+
+`Source` is a `Uri?` that tells the viewer where to load its markdown from, instead
+of supplying the text directly via `Markdown`.
+
+```xml
+<!-- Embedded Avalonia resource (avares://) -->
+<mv:MarkdownViewer Source="avares://MyApp/Docs/guide.md" />
+```
+
+```csharp
+// File on disk (file://)
+viewer.Source = new Uri("/home/user/documents/notes.md");
+
+// Remote URL
+viewer.Source = new Uri("https://example.com/readme.md");
+
+// Clear Source — falls back to the Markdown property
+viewer.Source = null;
+```
+
+**Supported schemes:**
+
+| Scheme | Loading | Notes |
+|--------|---------|-------|
+| `avares://` | Synchronous | `ManifestResourceStream` — already in memory, no I/O cost |
+| `file://` | Async | Suitable for local and network paths |
+| `http/https` | Async | In-flight request is cancelled when `Source` changes |
+
+**Precedence:** when both `Source` and `Markdown` are set, `Source` wins.
+
+**BaseUri inference:** when `Source` is set and `BaseUri` is not, the viewer infers
+the base URI from the source directory. Relative image links in the loaded document
+resolve correctly without any extra configuration.
+
 ## BaseUri
 
-`BaseUri` is used to resolve relative links in markdown:
+`BaseUri` is used to resolve relative links in markdown when `Source` is not set
+(or when you need to override the inferred base):
 
 ```csharp
 // Load markdown from a GitHub URL — relative image paths resolve against this base
 viewer.BaseUri = new Uri("https://raw.githubusercontent.com/org/repo/main/docs/");
 viewer.Markdown = File.ReadAllText("README.md");
 ```
-
-`BaseUri` is also passed to `IImageLoader.LoadAsync` for each image URL, allowing image loaders to convert relative paths to absolute ones.
 
 ## LinkClicked event
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,6 +45,8 @@ Add the built-in stylesheet to your application. The standard place is `App.axam
 
 ## 3. Bind to a view model
 
+Bind the `Markdown` property to a string on your view model:
+
 ```xml
 <mv:MarkdownViewer Markdown="{Binding DocumentText}" />
 ```
@@ -61,6 +63,22 @@ public class MainViewModel : INotifyPropertyChanged
     }
 }
 ```
+
+Alternatively, use the `Source` property to point directly at a file:
+
+```xml
+<!-- Embedded Avalonia resource -->
+<mv:MarkdownViewer Source="avares://MyApp/Docs/readme.md" />
+
+<!-- Or bind to a Uri on the view model -->
+<mv:MarkdownViewer Source="{Binding DocumentSource}" />
+```
+
+When `Source` is set it takes precedence over `Markdown`. The viewer supports
+`avares://` (embedded resources), `file://` (local files), and `http/https` URIs.
+The base URI for relative image links is inferred automatically from the source location.
+
+See [configuration.md](configuration.md) for the full list of properties.
 
 ## 4. Enable extension packages (optional)
 

--- a/samples/MarkView.Avalonia.Demo/Assets/showcase.md
+++ b/samples/MarkView.Avalonia.Demo/Assets/showcase.md
@@ -1,0 +1,165 @@
+# MarkView.Avalonia Feature Showcase
+
+> Welcome to the **MarkView.Avalonia** feature showcase. This document demonstrates every
+> rendering capability supported by the viewer and its extension packages.
+
+## Table of Contents
+
+- [Headings](#headings)
+- [Text Formatting](#text-formatting)
+- [Emphasis Extras](#emphasis-extras)
+- [Blockquotes](#blockquotes)
+- [Task List](#task-list)
+- [Tables](#tables)
+- [Code Blocks](#code-blocks)
+- [Bitmap Image](#bitmap-image)
+- [SVG Image](#svg-image)
+- [Mermaid Diagram](#mermaid-diagram)
+
+---
+
+## Headings
+
+# Heading 1
+## Heading 2
+### Heading 3
+#### Heading 4
+##### Heading 5
+###### Heading 6
+
+---
+
+## Text Formatting
+
+Regular paragraph with **bold text**, *italic text*, ~~strikethrough~~, and `inline code`.
+
+You can also combine them: ***bold and italic***, **`bold code`**, *~~italic strikethrough~~*.
+
+---
+
+## Emphasis Extras
+
+The `EmphasisExtras` Markdig extension unlocks four additional inline styles:
+
+| Syntax | Result | Description |
+|--------|--------|-----------|
+| `~text~` | H~2~O | Subscript |
+| `^text^` | x^2^ + y^2^ = r^2^ | Superscript |
+| `++text++` | ++inserted++ | Underline (inserted) |
+| `==text==` | ==marked== | Highlighted (marked) |
+
+---
+
+## Blockquotes
+
+> This is a top-level blockquote. It can contain *formatted* text and **multiple** lines.
+>
+> > This is a nested blockquote inside the first one.
+> > Nested content can also span multiple lines.
+>
+> Back to the outer blockquote.
+
+---
+
+## Task List
+
+- [x] Core markdown rendering (headings, paragraphs, lists)
+- [x] Syntax-highlighted code blocks via `MarkView.Avalonia.SyntaxHighlighting`
+- [x] SVG image rendering via `MarkView.Avalonia.Svg`
+- [x] Mermaid diagram rendering via `MarkView.Avalonia.Mermaid`
+- [x] Tables, blockquotes, task lists
+- [ ] PDF export (planned)
+
+---
+
+## Tables
+
+| Extension Package | Feature | NuGet Status | Notes |
+|---|---|---|---|
+| `MarkView.Avalonia` | Core rendering | ✅ Published | Markdig-based |
+| `MarkView.Avalonia.SyntaxHighlighting` | Code highlighting | ✅ Published | TextMate grammars |
+| `MarkView.Avalonia.Svg` | SVG images | ✅ Published | Avalonia.Svg |
+| `MarkView.Avalonia.Mermaid` | Mermaid diagrams | ✅ Published | Pure .NET |
+
+---
+
+## Code Blocks
+
+### C#
+
+```csharp
+using MarkView.Avalonia;
+
+var viewer = new MarkdownViewer();
+viewer.UseTextMateHighlighting()
+      .UseSvg()
+      .UseMermaid();
+
+viewer.Markdown = "# Hello, **World**!";
+```
+
+### JSON
+
+```json
+{
+  "name": "MarkView.Avalonia",
+  "version": "1.0.0",
+  "extensions": [
+    "SyntaxHighlighting",
+    "Svg",
+    "Mermaid"
+  ],
+  "targetFramework": "net8.0"
+}
+```
+
+### Python
+
+```python
+import base64
+
+svg = '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="120"></svg>'
+encoded = base64.b64encode(svg.encode()).decode()
+data_uri = f"data:image/svg+xml;base64,{encoded}"
+print(data_uri)
+```
+
+---
+
+## Bitmap Image
+
+The image below is an Avalonia resource embedded in the demo app (`avares://` URI):
+
+![Avalonia Logo](avares://MarkView.Avalonia.Demo/Assets/avalonia-logo.png =80x80)
+
+---
+
+## SVG Image
+
+The image below is rendered from an inline `data:image/svg+xml;base64` URI using the
+`MarkView.Avalonia.Svg` extension:
+
+![Colorful shapes on dark background](data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMTIwIj4KICA8cmVjdCB3aWR0aD0iMjAwIiBoZWlnaHQ9IjEyMCIgZmlsbD0iIzFlMWUyZSIvPgogIDxjaXJjbGUgY3g9IjQwIiBjeT0iNjAiIHI9IjI4IiBmaWxsPSIjODliNGZhIi8+CiAgPHJlY3QgeD0iODAiIHk9IjMyIiB3aWR0aD0iNTAiIGhlaWdodD0iNTAiIGZpbGw9IiNhNmUzYTEiLz4KICA8cG9seWdvbiBwb2ludHM9IjE2MCwzMiAxNDAsOTIgMTgwLDkyIiBmaWxsPSIjZmFiMzg3Ii8+Cjwvc3ZnPg==)
+
+---
+
+## Mermaid Diagram
+
+The diagram below is rendered live by the `MarkView.Avalonia.Mermaid` extension:
+
+```mermaid
+flowchart LR
+    MD[Markdown Text] --> MV[MarkView.Avalonia]
+    MV --> Core[Core Renderer]
+    MV --> SH[SyntaxHighlighting\nextension]
+    MV --> SVG[Svg\nextension]
+    MV --> MM[Mermaid\nextension]
+    Core --> Out[Avalonia UI]
+    SH --> Out
+    SVG --> Out
+    MM --> Out
+```
+
+---
+
+*End of showcase.*

--- a/samples/MarkView.Avalonia.Demo/MainViewModel.cs
+++ b/samples/MarkView.Avalonia.Demo/MainViewModel.cs
@@ -2,7 +2,6 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.ComponentModel;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 
 using Avalonia;
@@ -12,175 +11,11 @@ namespace MarkView.Avalonia.Demo;
 
 public sealed class MainViewModel : INotifyPropertyChanged
 {
-    private static readonly string ReadmeMarkdown = LoadReadme();
+    private static readonly Uri ShowcaseSource =
+        new("avares://MarkView.Avalonia.Demo/Assets/showcase.md");
 
-    private const string ShowcaseMarkdown = """
-        # MarkView.Avalonia Feature Showcase
-
-        > Welcome to the **MarkView.Avalonia** feature showcase. This document demonstrates every
-        > rendering capability supported by the viewer and its extension packages.
-
-        ## Table of Contents
-
-        - [Headings](#headings)
-        - [Text Formatting](#text-formatting)
-        - [Emphasis Extras](#emphasis-extras)
-        - [Blockquotes](#blockquotes)
-        - [Task List](#task-list)
-        - [Tables](#tables)
-        - [Code Blocks](#code-blocks)
-        - [Bitmap Image](#bitmap-image)
-        - [SVG Image](#svg-image)
-        - [Mermaid Diagram](#mermaid-diagram)
-
-        ---
-
-        ## Headings
-
-        # Heading 1
-        ## Heading 2
-        ### Heading 3
-        #### Heading 4
-        ##### Heading 5
-        ###### Heading 6
-
-        ---
-
-        ## Text Formatting
-
-        Regular paragraph with **bold text**, *italic text*, ~~strikethrough~~, and `inline code`.
-
-        You can also combine them: ***bold and italic***, **`bold code`**, *~~italic strikethrough~~*.
-
-        ---
-
-        ## Emphasis Extras
-
-        The `EmphasisExtras` Markdig extension unlocks four additional inline styles:
-
-        | Syntax | Result | Description |
-        |--------|--------|-----------|
-        | `~text~` | H~2~O | Subscript |
-        | `^text^` | x^2^ + y^2^ = r^2^ | Superscript |
-        | `++text++` | ++inserted++ | Underline (inserted) |
-        | `==text==` | ==marked== | Highlighted (marked) |
-
-        ---
-
-        ## Blockquotes
-
-        > This is a top-level blockquote. It can contain *formatted* text and **multiple** lines.
-        >
-        > > This is a nested blockquote inside the first one.
-        > > Nested content can also span multiple lines.
-        >
-        > Back to the outer blockquote.
-
-        ---
-
-        ## Task List
-
-        - [x] Core markdown rendering (headings, paragraphs, lists)
-        - [x] Syntax-highlighted code blocks via `MarkView.Avalonia.SyntaxHighlighting`
-        - [x] SVG image rendering via `MarkView.Avalonia.Svg`
-        - [x] Mermaid diagram rendering via `MarkView.Avalonia.Mermaid`
-        - [x] Tables, blockquotes, task lists
-        - [ ] PDF export (planned)
-
-        ---
-
-        ## Tables
-
-        | Extension Package | Feature | NuGet Status | Notes |
-        |---|---|---|---|
-        | `MarkView.Avalonia` | Core rendering | ✅ Published | Markdig-based |
-        | `MarkView.Avalonia.SyntaxHighlighting` | Code highlighting | ✅ Published | TextMate grammars |
-        | `MarkView.Avalonia.Svg` | SVG images | ✅ Published | Avalonia.Svg |
-        | `MarkView.Avalonia.Mermaid` | Mermaid diagrams | ✅ Published | Pure .NET |
-
-        ---
-
-        ## Code Blocks
-
-        ### C#
-
-        ```csharp
-        using MarkView.Avalonia;
-
-        var viewer = new MarkdownViewer();
-        viewer.UseTextMateHighlighting()
-              .UseSvg()
-              .UseMermaid();
-
-        viewer.Markdown = "# Hello, **World**!";
-        ```
-
-        ### JSON
-
-        ```json
-        {
-          "name": "MarkView.Avalonia",
-          "version": "1.0.0",
-          "extensions": [
-            "SyntaxHighlighting",
-            "Svg",
-            "Mermaid"
-          ],
-          "targetFramework": "net8.0"
-        }
-        ```
-
-        ### Python
-
-        ```python
-        import base64
-
-        svg = '<svg xmlns="http://www.w3.org/2000/svg" width="200" height="120"></svg>'
-        encoded = base64.b64encode(svg.encode()).decode()
-        data_uri = f"data:image/svg+xml;base64,{encoded}"
-        print(data_uri)
-        ```
-
-        ---
-
-        ## Bitmap Image
-
-        The image below is an Avalonia resource embedded in the demo app (`avares://` URI):
-
-        ![Avalonia Logo](avares://MarkView.Avalonia.Demo/Assets/avalonia-logo.png =80x80)
-
-        ---
-
-        ## SVG Image
-
-        The image below is rendered from an inline `data:image/svg+xml;base64` URI using the
-        `MarkView.Avalonia.Svg` extension:
-
-        ![Colorful shapes on dark background](data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMTIwIj4KICA8cmVjdCB3aWR0aD0iMjAwIiBoZWlnaHQ9IjEyMCIgZmlsbD0iIzFlMWUyZSIvPgogIDxjaXJjbGUgY3g9IjQwIiBjeT0iNjAiIHI9IjI4IiBmaWxsPSIjODliNGZhIi8+CiAgPHJlY3QgeD0iODAiIHk9IjMyIiB3aWR0aD0iNTAiIGhlaWdodD0iNTAiIGZpbGw9IiNhNmUzYTEiLz4KICA8cG9seWdvbiBwb2ludHM9IjE2MCwzMiAxNDAsOTIgMTgwLDkyIiBmaWxsPSIjZmFiMzg3Ii8+Cjwvc3ZnPg==)
-
-        ---
-
-        ## Mermaid Diagram
-
-        The diagram below is rendered live by the `MarkView.Avalonia.Mermaid` extension:
-
-        ```mermaid
-        flowchart LR
-            MD[Markdown Text] --> MV[MarkView.Avalonia]
-            MV --> Core[Core Renderer]
-            MV --> SH[SyntaxHighlighting\nextension]
-            MV --> SVG[Svg\nextension]
-            MV --> MM[Mermaid\nextension]
-            Core --> Out[Avalonia UI]
-            SH --> Out
-            SVG --> Out
-            MM --> Out
-        ```
-
-        ---
-
-        *End of showcase.*
-        """;
+    private static Uri ReadmeSource =>
+        new(Path.Combine(AppContext.BaseDirectory, "README.md"));
 
     private const string ExtensionsShowcaseMarkdown = """
         # Opt-In Extensions Showcase
@@ -260,12 +95,12 @@ public sealed class MainViewModel : INotifyPropertyChanged
         ![Big Buck Bunny trailer](https://youtu.be/aqz-KE-bpKQ)
         """;
 
-    private readonly List<(string? Markdown, Uri? BaseUri)> _history = [];
+    private readonly List<(Uri? Source, string? Markdown)> _history = [];
     private int _historyIndex = -1;
     private bool _navigating;
 
+    private Uri? _source;
     private string? _markdown;
-    private Uri? _baseUri;
     private int _selectedIndex;
     private bool _isLightTheme;
 
@@ -291,16 +126,16 @@ public sealed class MainViewModel : INotifyPropertyChanged
         }
     }
 
+    public Uri? Source
+    {
+        get => _source;
+        private set => SetField(ref _source, value);
+    }
+
     public string? Markdown
     {
         get => _markdown;
         private set => SetField(ref _markdown, value);
-    }
-
-    public Uri? BaseUri
-    {
-        get => _baseUri;
-        private set => SetField(ref _baseUri, value);
     }
 
     public bool CanGoBack => _historyIndex > 0;
@@ -320,22 +155,22 @@ public sealed class MainViewModel : INotifyPropertyChanged
         RestoreEntry(_history[_historyIndex]);
     }
 
-    private void RestoreEntry((string? Markdown, Uri? BaseUri) entry)
+    private void RestoreEntry((Uri? Source, string? Markdown) entry)
     {
         _navigating = true;
-        BaseUri = entry.BaseUri;
+        Source = entry.Source;
         Markdown = entry.Markdown;
         _navigating = false;
         NotifyNavigation();
     }
 
-    private void PushEntry(string? markdown, Uri? baseUri)
+    private void PushEntry(Uri? source, string? markdown)
     {
         if (_navigating) return;
         // Discard any forward entries
         if (_historyIndex < _history.Count - 1)
             _history.RemoveRange(_historyIndex + 1, _history.Count - _historyIndex - 1);
-        _history.Add((markdown, baseUri));
+        _history.Add((source, markdown));
         _historyIndex = _history.Count - 1;
         NotifyNavigation();
     }
@@ -353,31 +188,29 @@ public sealed class MainViewModel : INotifyPropertyChanged
 
     private void LoadContent()
     {
-        BaseUri = null;
-        Markdown = _selectedIndex switch
+        switch (_selectedIndex)
         {
-            0 => ShowcaseMarkdown,
-            1 => ExtensionsShowcaseMarkdown,
-            _ => ReadmeMarkdown,
-        };
-        PushEntry(Markdown, null);
+            case 0:
+                Source = ShowcaseSource;
+                Markdown = null;
+                break;
+            case 1:
+                Source = null;
+                Markdown = ExtensionsShowcaseMarkdown;
+                break;
+            default:
+                Source = ReadmeSource;
+                Markdown = null;
+                break;
+        }
+        PushEntry(Source, Markdown);
     }
 
     public void LoadFile(string filePath)
     {
-        var dir = Path.GetFullPath(Path.GetDirectoryName(filePath)!);
-        BaseUri = new Uri(dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar);
-        Markdown = File.ReadAllText(filePath);
-        PushEntry(Markdown, BaseUri);
-    }
-
-    private static string LoadReadme()
-    {
-        using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("README.md");
-        if (stream is null)
-            return "# README not found";
-        using var reader = new StreamReader(stream);
-        return reader.ReadToEnd();
+        Source = new Uri(Path.GetFullPath(filePath));
+        Markdown = null;
+        PushEntry(Source, null);
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;

--- a/samples/MarkView.Avalonia.Demo/MainWindow.axaml
+++ b/samples/MarkView.Avalonia.Demo/MainWindow.axaml
@@ -36,8 +36,8 @@
 
     <!-- Markdown content -->
     <mv:MarkdownViewer x:Name="MarkdownView"
-                       Markdown="{Binding Markdown}"
-                       BaseUri="{Binding BaseUri}" />
+                       Source="{Binding Source}"
+                       Markdown="{Binding Markdown}" />
   </DockPanel>
 
 </Window>

--- a/samples/MarkView.Avalonia.Demo/MarkView.Avalonia.Demo.csproj
+++ b/samples/MarkView.Avalonia.Demo/MarkView.Avalonia.Demo.csproj
@@ -5,7 +5,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\..\README.md" LogicalName="README.md" />
+    <Content Include="..\..\README.md" CopyToOutputDirectory="PreserveNewest" />
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/MarkView.Avalonia.Demo/packages.lock.json
+++ b/samples/MarkView.Avalonia.Demo/packages.lock.json
@@ -4,7 +4,7 @@
     "net10.0": {
       "Avalonia.Desktop": {
         "type": "Direct",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "jSjO026cA8IqgXszxlcdTkaOM60veMjFgA/D6eqEYLwtLvho/72hdzLeOj/qzgF+ZgEo40gmDKca2Se5VkqlNQ==",
         "dependencies": {
@@ -18,7 +18,7 @@
       },
       "Avalonia.Fonts.Inter": {
         "type": "Direct",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "Pm7Xb9fMpjM4i1cpUGtpDtxkMC/oVfijaT93cPl30LPUKPYPbpwm1jkrYwtWLtEr/xTgbUmxyZZvJd0cV9oF8g==",
         "dependencies": {
@@ -27,7 +27,7 @@
       },
       "Avalonia.Themes.Fluent": {
         "type": "Direct",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "/vfTVnz0mZR91cDQn5dHKzngLV0OfCZ0i/uT01uxKu6jqyaPbRwpO68d07N0d6ll6hnvdfySfP4lDY7JWtqr4A==",
         "dependencies": {
@@ -269,36 +269,36 @@
       "markview.avalonia": {
         "type": "Project",
         "dependencies": {
-          "Avalonia": "[12.0.*, )",
-          "Markdig": "[1.1.*, )"
+          "Avalonia": "[12.0.1, )",
+          "Markdig": "[1.1.3, )"
         }
       },
       "markview.avalonia.mermaid": {
         "type": "Project",
         "dependencies": {
           "MarkView.Avalonia": "[1.0.0, )",
-          "Mermaider": "[0.*, )",
-          "Svg.Controls.Skia.Avalonia": "[12.0.*, )"
+          "Mermaider": "[0.6.0, )",
+          "Svg.Controls.Skia.Avalonia": "[12.0.0.3, )"
         }
       },
       "markview.avalonia.svg": {
         "type": "Project",
         "dependencies": {
           "MarkView.Avalonia": "[1.0.0, )",
-          "Svg.Controls.Skia.Avalonia": "[12.0.*, )"
+          "Svg.Controls.Skia.Avalonia": "[12.0.0.3, )"
         }
       },
       "markview.avalonia.syntaxhighlighting": {
         "type": "Project",
         "dependencies": {
           "MarkView.Avalonia": "[1.0.0, )",
-          "TextMateSharp": "[2.*, )",
-          "TextMateSharp.Grammars": "[2.*, )"
+          "TextMateSharp": "[2.0.3, )",
+          "TextMateSharp.Grammars": "[2.0.3, )"
         }
       },
       "Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
         "dependencies": {
@@ -309,13 +309,13 @@
       },
       "Markdig": {
         "type": "CentralTransitive",
-        "requested": "[1.1.*, )",
+        "requested": "[1.1.3, )",
         "resolved": "1.1.3",
         "contentHash": "wboYc6YToID7koq+onej7rjd/kv4urZaZ4QMiJoF/jXt/ZlXe2Af9gWG4nOe5tk654UaOPYvKL64iFum7qWEYA=="
       },
       "Mermaider": {
         "type": "CentralTransitive",
-        "requested": "[0.*, )",
+        "requested": "[0.6.0, )",
         "resolved": "0.6.0",
         "contentHash": "cmtlEM+xFvWnzPwCXz4mMsOa8Le4DjakNjs57nKHS7xX5ecslqC7fve0iYCwwk+mq/Ggr7BY1n/jSKYjsxyIlg==",
         "dependencies": {
@@ -325,7 +325,7 @@
       },
       "Svg.Controls.Skia.Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.0.3, )",
         "resolved": "12.0.0.3",
         "contentHash": "TtoRNswWI6CBzcLliWvLaEFiDf0wo9Zi/GTX1H0Q4QVcX2aXItkzPK4MELKv3B3bE+cRmVbXAt1PvwiuD2n6TA==",
         "dependencies": {
@@ -335,7 +335,7 @@
       },
       "TextMateSharp": {
         "type": "CentralTransitive",
-        "requested": "[2.*, )",
+        "requested": "[2.0.3, )",
         "resolved": "2.0.3",
         "contentHash": "w0wGeqlBi9SYrzxpS1DBcEfiVCs5NY18Yl5YBIsHzXTXQd0OLOh3mP4LRuFvcktR/1MG8nSBHSMJj0rFvrPk+A==",
         "dependencies": {
@@ -344,7 +344,7 @@
       },
       "TextMateSharp.Grammars": {
         "type": "CentralTransitive",
-        "requested": "[2.*, )",
+        "requested": "[2.0.3, )",
         "resolved": "2.0.3",
         "contentHash": "qkI1ogusuyGCGTgeyhljDM+GEfATOexoUTqLIgSb5P0ojmfhRXWfSTRXXJRpZkLDErShJ7RWOb+p10lHfhhO+Q==",
         "dependencies": {

--- a/samples/MarkView.Avalonia.Demo/packages.lock.json
+++ b/samples/MarkView.Avalonia.Demo/packages.lock.json
@@ -4,34 +4,34 @@
     "net10.0": {
       "Avalonia.Desktop": {
         "type": "Direct",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "jSjO026cA8IqgXszxlcdTkaOM60veMjFgA/D6eqEYLwtLvho/72hdzLeOj/qzgF+ZgEo40gmDKca2Se5VkqlNQ==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "7Hs7AsEoLh4UHNZnwaAZ5d4db2X0BjdLePuev526tm2ZJIOZGLUxKHvY1GcrWIDO9NBw4Iu3WXBUvsFPZ6vXlQ==",
         "dependencies": {
-          "Avalonia": "12.0.1",
-          "Avalonia.HarfBuzz": "12.0.1",
-          "Avalonia.Native": "12.0.1",
-          "Avalonia.Skia": "12.0.1",
-          "Avalonia.Win32": "12.0.1",
-          "Avalonia.X11": "12.0.1"
+          "Avalonia": "12.0.2",
+          "Avalonia.HarfBuzz": "12.0.2",
+          "Avalonia.Native": "12.0.2",
+          "Avalonia.Skia": "12.0.2",
+          "Avalonia.Win32": "12.0.2",
+          "Avalonia.X11": "12.0.2"
         }
       },
       "Avalonia.Fonts.Inter": {
         "type": "Direct",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "Pm7Xb9fMpjM4i1cpUGtpDtxkMC/oVfijaT93cPl30LPUKPYPbpwm1jkrYwtWLtEr/xTgbUmxyZZvJd0cV9oF8g==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "2QEaZc52qqO3W58LfGkcV9V3lX4A6uyIt8zJaSb2ULyeyw9CwdLurJ/bwDcYO3M1dwV7LMDcqjOTuqCf8TIZ0Q==",
         "dependencies": {
-          "Avalonia": "12.0.1"
+          "Avalonia": "12.0.2"
         }
       },
       "Avalonia.Themes.Fluent": {
         "type": "Direct",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "/vfTVnz0mZR91cDQn5dHKzngLV0OfCZ0i/uT01uxKu6jqyaPbRwpO68d07N0d6ll6hnvdfySfP4lDY7JWtqr4A==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "uEDLnrS7flCulIjWHnW6eiPiUqjxxAOh76suASMpQ0pJ+kntTEua5R1VcIulwZff79ArMqTVPejf7u0cxlVI2A==",
         "dependencies": {
-          "Avalonia": "12.0.1"
+          "Avalonia": "12.0.2"
         }
       },
       "Avalonia.Angle.Windows.Natives": {
@@ -46,27 +46,27 @@
       },
       "Avalonia.FreeDesktop": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "BbYDbu3hEwv2stkLlCh8/+2Y94IjdyxQNj8wQVAiKton2yZEmnwYpBRfQ8v/q7I6BjIJing6dofZk8IG/i82/g==",
+        "resolved": "12.0.2",
+        "contentHash": "KHionmetHeH7g4M653eNPD+GKFHTpX0xd6daBt+Gj03Y9ztEjD4B/P34bCrG81f+KK8evcx3ZygAC79O4M05GQ==",
         "dependencies": {
-          "Avalonia": "12.0.1",
+          "Avalonia": "12.0.2",
           "Tmds.DBus.Protocol": "0.92.0"
         }
       },
       "Avalonia.FreeDesktop.AtSpi": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "cswoLoW/QkCQ9X/CRUTscLYS1OgUSAf67N/7BucENwaNX+lQoTPOS4dd8aD+cQjcSPEctc9SH11D4dW1hPx5vw==",
+        "resolved": "12.0.2",
+        "contentHash": "tuo8ry4mFhns6p31RHvCTineppfc8cI0i6J8ifEnmQ5FSHVATTna1tBjyi26ri8qPEX6nmcVgifKTewfpZEMmw==",
         "dependencies": {
-          "Avalonia": "12.0.1"
+          "Avalonia": "12.0.2"
         }
       },
       "Avalonia.HarfBuzz": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "17A+VIAeIGsYqZSK/ydYzZbbzatBDj2Ls8aF/ZVo6OdeN5W+J9eAQGhS1wPw/GIkGuOkRPBSVwicFXIFCDf/kA==",
+        "resolved": "12.0.2",
+        "contentHash": "HGqFe/HmWHQGvwtji7827/RDtEgQxvm3zdnCFl/P6XAwnqek8MoJpnISRTid76XzTBDtNlVqp7qjOujSIE0QCw==",
         "dependencies": {
-          "Avalonia": "12.0.1",
+          "Avalonia": "12.0.2",
           "HarfBuzzSharp": "8.3.1.3",
           "HarfBuzzSharp.NativeAssets.Linux": "8.3.1.3",
           "HarfBuzzSharp.NativeAssets.WebAssembly": "8.3.1.3"
@@ -74,49 +74,49 @@
       },
       "Avalonia.Native": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "RmMRxAMsZDbouQEZtayAR1JBhQ/CSYKpmjyQocAIjUtOWprifueBigr685VCt5TNJRGPPY0OZbDvD8aVpMNUbw==",
+        "resolved": "12.0.2",
+        "contentHash": "ar8S5eXQY8ttZ3YG5dbtinbC2ltybJU89iwgkpAlLKkV3V7u+4ZXX13o6ilplVyd1lVVSfXgOMvfSMnKQm02Bg==",
         "dependencies": {
-          "Avalonia": "12.0.1"
+          "Avalonia": "12.0.2"
         }
       },
       "Avalonia.Remote.Protocol": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "8rqhNyde2I/JiW2TjQ8AkUoRclynr0e8yFXKB8VhehA07ejthx4Bnmt3k1DTSlpwTXbM0FRgYAtB1bTlUc6rgg=="
+        "resolved": "12.0.2",
+        "contentHash": "mlKTvn0cAEQVkRMJunLzDNugZRbtZIksT5yu+XgcAlOvqTHGyZY+mGP+4/+1IwakZx9nrz6SGwI5yrzNT5g0TQ=="
       },
       "Avalonia.Skia": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "T850YAUgHpkRX4d3RkfH1ewabA2aLTgdGK+f4hyqeGhZlJYmMs6YjVps266wvr+MggAVUCZ601OLQd9KVfJb6g==",
+        "resolved": "12.0.2",
+        "contentHash": "rtnB7M3VymQY4ErpPMot37bNoZ67mTk4tCb1mJjQCnTkCYgTx/o0yDvPPBFgLZAmcmHp00BxT5w12GkXTQjDMQ==",
         "dependencies": {
-          "Avalonia": "12.0.1",
+          "Avalonia": "12.0.2",
           "HarfBuzzSharp": "8.3.1.3",
           "HarfBuzzSharp.NativeAssets.Linux": "8.3.1.3",
           "HarfBuzzSharp.NativeAssets.WebAssembly": "8.3.1.3",
-          "SkiaSharp": "3.119.3-preview.1.1",
-          "SkiaSharp.NativeAssets.Linux": "3.119.3-preview.1.1",
-          "SkiaSharp.NativeAssets.WebAssembly": "3.119.3-preview.1.1"
+          "SkiaSharp": "3.119.4-preview.1.1",
+          "SkiaSharp.NativeAssets.Linux": "3.119.4-preview.1.1",
+          "SkiaSharp.NativeAssets.WebAssembly": "3.119.4-preview.1.1"
         }
       },
       "Avalonia.Win32": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "7ETmt7DUlpmGiGRP923B+O8T+I5xjA9yYlUROMAa5Om/IfMutUndj2GOd6RGYw2O9yMgEKJuU0sIumqfB9lAFg==",
+        "resolved": "12.0.2",
+        "contentHash": "gVUm4hyUvrFlocL0ycPZGAiN2TQhTv7vTa1I2nRkq/G/h6b5hKNoURjGfnZnXuPK3OnRENGPJjvZ+A9+0d5Jsg==",
         "dependencies": {
-          "Avalonia": "12.0.1",
+          "Avalonia": "12.0.2",
           "Avalonia.Angle.Windows.Natives": "2.1.25547.20250602"
         }
       },
       "Avalonia.X11": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "8YipKW4Icadwv3og4Fyf2Gj1ISHDjVRy/2qUgWkJTYK9/pXvB0zVsHv96ktWM7CIlpCq1VHkSrrVhnpeQUcXEw==",
+        "resolved": "12.0.2",
+        "contentHash": "FXFYfqjYYUAWqtgxEQl1cUWsH61GwTUojbRWURfmPAGcYYbm+2djrSOki5ppzAKKcm5lOmjoafYaeti39bSGQA==",
         "dependencies": {
-          "Avalonia": "12.0.1",
-          "Avalonia.FreeDesktop": "12.0.1",
-          "Avalonia.FreeDesktop.AtSpi": "12.0.1",
-          "Avalonia.Skia": "12.0.1"
+          "Avalonia": "12.0.2",
+          "Avalonia.FreeDesktop": "12.0.2",
+          "Avalonia.FreeDesktop.AtSpi": "12.0.2",
+          "Avalonia.Skia": "12.0.2"
         }
       },
       "ExCSS": {
@@ -175,32 +175,32 @@
       },
       "SkiaSharp": {
         "type": "Transitive",
-        "resolved": "3.119.3-preview.1.1",
-        "contentHash": "+3ndwD845G4jfuyhtg5rrjryh2mEOr2QfAPFtncvAsRLzGX0ferSJ0223av6Sbw9zsEL6Wk0sk/DrXtEpJoo5A==",
+        "resolved": "3.119.4-preview.1.1",
+        "contentHash": "cyRjWksj/SwFWo7uPfpFk0sOPyUcE+FhF6ENFc3Q100sdJWHEA2nU1PcEeT7LsLFKBvDP/67q0A8vEXc4kvXnA==",
         "dependencies": {
-          "SkiaSharp.NativeAssets.Win32": "3.119.3-preview.1.1",
-          "SkiaSharp.NativeAssets.macOS": "3.119.3-preview.1.1"
+          "SkiaSharp.NativeAssets.Win32": "3.119.4-preview.1.1",
+          "SkiaSharp.NativeAssets.macOS": "3.119.4-preview.1.1"
         }
       },
       "SkiaSharp.NativeAssets.Linux": {
         "type": "Transitive",
-        "resolved": "3.119.3-preview.1.1",
-        "contentHash": "ZvpglyfQzhVIUmnPGngliPYcg6ROJNs0BV7XwJ+kktdqY0qe8jifP+UUgaMqTlOTjvuvyCbV7AI4qIBUfRe3Vw=="
+        "resolved": "3.119.4-preview.1.1",
+        "contentHash": "rZEnNkds7UWOWCCsi//v3VQ7MWbhqn83J1mCzl9069N1Zza7SXufVvsvpI4qJYUHaRx8ZhAaL0yi3zlKoXaUJw=="
       },
       "SkiaSharp.NativeAssets.macOS": {
         "type": "Transitive",
-        "resolved": "3.119.3-preview.1.1",
-        "contentHash": "rv8B3OxG5PGQVxudIPV+ppjqUkt98VRzczNV3qNtearHebWXIcelpHEWzCtMSAYBm1rIsTs+KKAQv8/1exr0kQ=="
+        "resolved": "3.119.4-preview.1.1",
+        "contentHash": "77gyFnZD0uU12ABgI6pe8Iw2GRBYGryMP4EaHFs7fniffthVT5sf4PTug4ytwNzLKkVDiLobEpIvAJAj3UXwEw=="
       },
       "SkiaSharp.NativeAssets.WebAssembly": {
         "type": "Transitive",
-        "resolved": "3.119.3-preview.1.1",
-        "contentHash": "Gzvr/fcJZODWNoLVBAIiM8NKudvZ9yL6WHb87fk7iadio9BWQR7GS0fUvWvE3kYaRAAutsjPdGAnkDR0ujlVDw=="
+        "resolved": "3.119.4-preview.1.1",
+        "contentHash": "IyNI0QRJGl5sT0Dz2rGHBYVmenNoXcOCaC21avrLG5LwkX8ou0PluW2Hgz7NxHxiRL9D0kPmtoYWrr3uxd1NgA=="
       },
       "SkiaSharp.NativeAssets.Win32": {
         "type": "Transitive",
-        "resolved": "3.119.3-preview.1.1",
-        "contentHash": "PkMb1pGPBSW3ZL0IVKP9DZs+w065HVs4jGQELsbkmKzKSL5P8KHLkrrmnv2XpFpXtx2njOllB8243N1dBMK+CQ=="
+        "resolved": "3.119.4-preview.1.1",
+        "contentHash": "BYwNLG02IAYMsBPgU9lM37xJgCM3B/2X5z1FQEBR34dmn+Hxvcw8X83PInY2rzix7mlbcv7OF8UHjf7yMbsDaA=="
       },
       "Sugiyama": {
         "type": "Transitive",
@@ -269,7 +269,7 @@
       "markview.avalonia": {
         "type": "Project",
         "dependencies": {
-          "Avalonia": "[12.0.1, )",
+          "Avalonia": "[12.0.2, )",
           "Markdig": "[1.1.3, )"
         }
       },
@@ -298,12 +298,12 @@
       },
       "Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "852xwfNNAUWE+aKWFackMALAKofcpKnM2g4PN8VKfxG1SO8Stlih7d6QFCbjQl46vuR9WBw/ZVGwn4Ovbj/oxQ==",
         "dependencies": {
           "Avalonia.BuildServices": "11.3.2",
-          "Avalonia.Remote.Protocol": "12.0.1",
+          "Avalonia.Remote.Protocol": "12.0.2",
           "MicroCom.Runtime": "0.11.4"
         }
       },

--- a/src/MarkView.Avalonia.Mermaid/packages.lock.json
+++ b/src/MarkView.Avalonia.Mermaid/packages.lock.json
@@ -4,7 +4,7 @@
     "net10.0": {
       "Mermaider": {
         "type": "Direct",
-        "requested": "[0.*, )",
+        "requested": "[0.6.0, )",
         "resolved": "0.6.0",
         "contentHash": "cmtlEM+xFvWnzPwCXz4mMsOa8Le4DjakNjs57nKHS7xX5ecslqC7fve0iYCwwk+mq/Ggr7BY1n/jSKYjsxyIlg==",
         "dependencies": {
@@ -14,7 +14,7 @@
       },
       "Svg.Controls.Skia.Avalonia": {
         "type": "Direct",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.0.3, )",
         "resolved": "12.0.0.3",
         "contentHash": "TtoRNswWI6CBzcLliWvLaEFiDf0wo9Zi/GTX1H0Q4QVcX2aXItkzPK4MELKv3B3bE+cRmVbXAt1PvwiuD2n6TA==",
         "dependencies": {
@@ -186,13 +186,13 @@
       "markview.avalonia": {
         "type": "Project",
         "dependencies": {
-          "Avalonia": "[12.0.*, )",
-          "Markdig": "[1.1.*, )"
+          "Avalonia": "[12.0.1, )",
+          "Markdig": "[1.1.3, )"
         }
       },
       "Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
         "dependencies": {
@@ -203,7 +203,7 @@
       },
       "Markdig": {
         "type": "CentralTransitive",
-        "requested": "[1.1.*, )",
+        "requested": "[1.1.3, )",
         "resolved": "1.1.3",
         "contentHash": "wboYc6YToID7koq+onej7rjd/kv4urZaZ4QMiJoF/jXt/ZlXe2Af9gWG4nOe5tk654UaOPYvKL64iFum7qWEYA=="
       }

--- a/src/MarkView.Avalonia.Mermaid/packages.lock.json
+++ b/src/MarkView.Avalonia.Mermaid/packages.lock.json
@@ -29,8 +29,8 @@
       },
       "Avalonia.Remote.Protocol": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "8rqhNyde2I/JiW2TjQ8AkUoRclynr0e8yFXKB8VhehA07ejthx4Bnmt3k1DTSlpwTXbM0FRgYAtB1bTlUc6rgg=="
+        "resolved": "12.0.2",
+        "contentHash": "mlKTvn0cAEQVkRMJunLzDNugZRbtZIksT5yu+XgcAlOvqTHGyZY+mGP+4/+1IwakZx9nrz6SGwI5yrzNT5g0TQ=="
       },
       "Avalonia.Skia": {
         "type": "Transitive",
@@ -186,18 +186,18 @@
       "markview.avalonia": {
         "type": "Project",
         "dependencies": {
-          "Avalonia": "[12.0.1, )",
+          "Avalonia": "[12.0.2, )",
           "Markdig": "[1.1.3, )"
         }
       },
       "Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "852xwfNNAUWE+aKWFackMALAKofcpKnM2g4PN8VKfxG1SO8Stlih7d6QFCbjQl46vuR9WBw/ZVGwn4Ovbj/oxQ==",
         "dependencies": {
           "Avalonia.BuildServices": "11.3.2",
-          "Avalonia.Remote.Protocol": "12.0.1",
+          "Avalonia.Remote.Protocol": "12.0.2",
           "MicroCom.Runtime": "0.11.4"
         }
       },

--- a/src/MarkView.Avalonia.Svg/packages.lock.json
+++ b/src/MarkView.Avalonia.Svg/packages.lock.json
@@ -19,8 +19,8 @@
       },
       "Avalonia.Remote.Protocol": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "8rqhNyde2I/JiW2TjQ8AkUoRclynr0e8yFXKB8VhehA07ejthx4Bnmt3k1DTSlpwTXbM0FRgYAtB1bTlUc6rgg=="
+        "resolved": "12.0.2",
+        "contentHash": "mlKTvn0cAEQVkRMJunLzDNugZRbtZIksT5yu+XgcAlOvqTHGyZY+mGP+4/+1IwakZx9nrz6SGwI5yrzNT5g0TQ=="
       },
       "Avalonia.Skia": {
         "type": "Transitive",
@@ -166,18 +166,18 @@
       "markview.avalonia": {
         "type": "Project",
         "dependencies": {
-          "Avalonia": "[12.0.1, )",
+          "Avalonia": "[12.0.2, )",
           "Markdig": "[1.1.3, )"
         }
       },
       "Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "852xwfNNAUWE+aKWFackMALAKofcpKnM2g4PN8VKfxG1SO8Stlih7d6QFCbjQl46vuR9WBw/ZVGwn4Ovbj/oxQ==",
         "dependencies": {
           "Avalonia.BuildServices": "11.3.2",
-          "Avalonia.Remote.Protocol": "12.0.1",
+          "Avalonia.Remote.Protocol": "12.0.2",
           "MicroCom.Runtime": "0.11.4"
         }
       },

--- a/src/MarkView.Avalonia.Svg/packages.lock.json
+++ b/src/MarkView.Avalonia.Svg/packages.lock.json
@@ -4,7 +4,7 @@
     "net10.0": {
       "Svg.Controls.Skia.Avalonia": {
         "type": "Direct",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.0.3, )",
         "resolved": "12.0.0.3",
         "contentHash": "TtoRNswWI6CBzcLliWvLaEFiDf0wo9Zi/GTX1H0Q4QVcX2aXItkzPK4MELKv3B3bE+cRmVbXAt1PvwiuD2n6TA==",
         "dependencies": {
@@ -166,13 +166,13 @@
       "markview.avalonia": {
         "type": "Project",
         "dependencies": {
-          "Avalonia": "[12.0.*, )",
-          "Markdig": "[1.1.*, )"
+          "Avalonia": "[12.0.1, )",
+          "Markdig": "[1.1.3, )"
         }
       },
       "Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
         "dependencies": {
@@ -183,7 +183,7 @@
       },
       "Markdig": {
         "type": "CentralTransitive",
-        "requested": "[1.1.*, )",
+        "requested": "[1.1.3, )",
         "resolved": "1.1.3",
         "contentHash": "wboYc6YToID7koq+onej7rjd/kv4urZaZ4QMiJoF/jXt/ZlXe2Af9gWG4nOe5tk654UaOPYvKL64iFum7qWEYA=="
       }

--- a/src/MarkView.Avalonia.SyntaxHighlighting/packages.lock.json
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/packages.lock.json
@@ -4,7 +4,7 @@
     "net10.0": {
       "TextMateSharp": {
         "type": "Direct",
-        "requested": "[2.*, )",
+        "requested": "[2.0.3, )",
         "resolved": "2.0.3",
         "contentHash": "w0wGeqlBi9SYrzxpS1DBcEfiVCs5NY18Yl5YBIsHzXTXQd0OLOh3mP4LRuFvcktR/1MG8nSBHSMJj0rFvrPk+A==",
         "dependencies": {
@@ -13,7 +13,7 @@
       },
       "TextMateSharp.Grammars": {
         "type": "Direct",
-        "requested": "[2.*, )",
+        "requested": "[2.0.3, )",
         "resolved": "2.0.3",
         "contentHash": "qkI1ogusuyGCGTgeyhljDM+GEfATOexoUTqLIgSb5P0ojmfhRXWfSTRXXJRpZkLDErShJ7RWOb+p10lHfhhO+Q==",
         "dependencies": {
@@ -43,13 +43,13 @@
       "markview.avalonia": {
         "type": "Project",
         "dependencies": {
-          "Avalonia": "[12.0.*, )",
-          "Markdig": "[1.1.*, )"
+          "Avalonia": "[12.0.1, )",
+          "Markdig": "[1.1.3, )"
         }
       },
       "Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
         "dependencies": {
@@ -60,7 +60,7 @@
       },
       "Markdig": {
         "type": "CentralTransitive",
-        "requested": "[1.1.*, )",
+        "requested": "[1.1.3, )",
         "resolved": "1.1.3",
         "contentHash": "wboYc6YToID7koq+onej7rjd/kv4urZaZ4QMiJoF/jXt/ZlXe2Af9gWG4nOe5tk654UaOPYvKL64iFum7qWEYA=="
       }

--- a/src/MarkView.Avalonia.SyntaxHighlighting/packages.lock.json
+++ b/src/MarkView.Avalonia.SyntaxHighlighting/packages.lock.json
@@ -27,8 +27,8 @@
       },
       "Avalonia.Remote.Protocol": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "8rqhNyde2I/JiW2TjQ8AkUoRclynr0e8yFXKB8VhehA07ejthx4Bnmt3k1DTSlpwTXbM0FRgYAtB1bTlUc6rgg=="
+        "resolved": "12.0.2",
+        "contentHash": "mlKTvn0cAEQVkRMJunLzDNugZRbtZIksT5yu+XgcAlOvqTHGyZY+mGP+4/+1IwakZx9nrz6SGwI5yrzNT5g0TQ=="
       },
       "MicroCom.Runtime": {
         "type": "Transitive",
@@ -43,18 +43,18 @@
       "markview.avalonia": {
         "type": "Project",
         "dependencies": {
-          "Avalonia": "[12.0.1, )",
+          "Avalonia": "[12.0.2, )",
           "Markdig": "[1.1.3, )"
         }
       },
       "Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "852xwfNNAUWE+aKWFackMALAKofcpKnM2g4PN8VKfxG1SO8Stlih7d6QFCbjQl46vuR9WBw/ZVGwn4Ovbj/oxQ==",
         "dependencies": {
           "Avalonia.BuildServices": "11.3.2",
-          "Avalonia.Remote.Protocol": "12.0.1",
+          "Avalonia.Remote.Protocol": "12.0.2",
           "MicroCom.Runtime": "0.11.4"
         }
       },

--- a/src/MarkView.Avalonia/MarkdownViewer.cs
+++ b/src/MarkView.Avalonia/MarkdownViewer.cs
@@ -8,6 +8,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Platform;
 
 using Markdig;
 
@@ -35,6 +36,9 @@ public partial class MarkdownViewer : ContentControl
     private Point _dragStart;
     private const double DragThreshold = 3.0;
 
+    private string? _sourceMarkdown;
+    private CancellationTokenSource? _sourceLoadCts;
+
     private static readonly MarkdownPipeline DefaultPipeline =
         new MarkdownPipelineBuilder().UseSupportedExtensions().Build();
 
@@ -55,6 +59,12 @@ public partial class MarkdownViewer : ContentControl
     /// </summary>
     public static readonly StyledProperty<Uri?> BaseUriProperty =
         AvaloniaProperty.Register<MarkdownViewer, Uri?>(nameof(BaseUri));
+
+    /// <summary>
+    /// Defines the <see cref="Source"/> property.
+    /// </summary>
+    public static readonly StyledProperty<Uri?> SourceProperty =
+        AvaloniaProperty.Register<MarkdownViewer, Uri?>(nameof(Source));
 
     /// <summary>
     /// Gets or sets the Markdown text to render.
@@ -81,6 +91,18 @@ public partial class MarkdownViewer : ContentControl
     {
         get => GetValue(BaseUriProperty);
         set => SetValue(BaseUriProperty, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a URI that points to a Markdown document to load and render.
+    /// Supports <c>avares://</c> embedded resources, <c>file://</c>, and <c>http/https</c> schemes.
+    /// When both <see cref="Source"/> and <see cref="Markdown"/> are set,
+    /// <see cref="Source"/> takes precedence.
+    /// </summary>
+    public Uri? Source
+    {
+        get => GetValue(SourceProperty);
+        set => SetValue(SourceProperty, value);
     }
 
     /// <summary>
@@ -114,12 +136,88 @@ public partial class MarkdownViewer : ContentControl
         MarkdownProperty.Changed.AddClassHandler<MarkdownViewer>((x, _) => x.RenderMarkdown());
         PipelineProperty.Changed.AddClassHandler<MarkdownViewer>((x, _) => x.RenderMarkdown());
         BaseUriProperty.Changed.AddClassHandler<MarkdownViewer>((x, _) => x.RenderMarkdown());
+        SourceProperty.Changed.AddClassHandler<MarkdownViewer>((x, _) => x.OnSourceChanged());
         FocusableProperty.OverrideDefaultValue<MarkdownViewer>(true);
+    }
+
+    // ── Source loading ────────────────────────────────────────────────────────
+
+    private void OnSourceChanged()
+    {
+        _sourceLoadCts?.Cancel();
+        _sourceLoadCts = null;
+        _sourceMarkdown = null;
+
+        var source = Source;
+        if (source is null)
+        {
+            RenderMarkdown();
+            return;
+        }
+
+        switch (source.Scheme)
+        {
+            // avares:// is a ManifestResourceStream — memory-mapped into the loaded assembly,
+            // effectively zero I/O cost. No async API exists; synchronous read is appropriate.
+            case "avares":
+            {
+                using var stream = AssetLoader.Open(source);
+                using var reader = new StreamReader(stream);
+                _sourceMarkdown = reader.ReadToEnd();
+                RenderMarkdown();
+                break;
+            }
+            case "file":
+            case "http":
+            case "https":
+                _ = LoadFromUriAsync(source);
+                break;
+        }
+    }
+
+    private async Task LoadFromUriAsync(Uri uri)
+    {
+        var cts = new CancellationTokenSource();
+        _sourceLoadCts = cts;
+        try
+        {
+            string text;
+            if (uri.Scheme == "file")
+            {
+                using var stream = File.OpenRead(uri.LocalPath);
+                using var reader = new StreamReader(stream);
+                text = await reader.ReadToEndAsync(cts.Token);
+            }
+            else
+            {
+                using var stream = await SharedHttpClient.Instance.GetStreamAsync(uri, cts.Token);
+                using var reader = new StreamReader(stream);
+                text = await reader.ReadToEndAsync(cts.Token);
+            }
+
+            if (!cts.IsCancellationRequested)
+            {
+                _sourceMarkdown = text;
+                RenderMarkdown();
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (HttpRequestException) { }
+        catch (IOException) { }
+    }
+
+    private static Uri? InferBaseUri(Uri? source)
+    {
+        if (source is null) return null;
+        var abs = source.AbsoluteUri;
+        var lastSlash = abs.LastIndexOf('/');
+        return lastSlash > 0 ? new Uri(abs[..(lastSlash + 1)]) : null;
     }
 
     private void RenderMarkdown()
     {
-        if (string.IsNullOrEmpty(Markdown))
+        var markdown = _sourceMarkdown ?? Markdown;
+        if (string.IsNullOrEmpty(markdown))
         {
             Content = null;
             _anchors = new(StringComparer.OrdinalIgnoreCase);
@@ -128,10 +226,10 @@ public partial class MarkdownViewer : ContentControl
         }
 
         var pipeline = Pipeline ?? MarkdownViewerDefaults.Pipeline ?? DefaultPipeline;
-        var markdownText = ImageSizePreprocessorRegex().Replace(Markdown, "$1$2 \"=$3\"$4");
+        var markdownText = ImageSizePreprocessorRegex().Replace(markdown, "$1$2 \"=$3\"$4");
         var document = Markdig.Markdown.Parse(markdownText, pipeline);
 
-        var renderer = new AvaloniaRenderer { BaseUri = BaseUri };
+        var renderer = new AvaloniaRenderer { BaseUri = BaseUri ?? InferBaseUri(Source) };
         renderer.LinkClicked += OnLinkClicked;
 
         // Extensions register before pipeline.Setup() so they can swap renderers.

--- a/src/MarkView.Avalonia/packages.lock.json
+++ b/src/MarkView.Avalonia/packages.lock.json
@@ -4,7 +4,7 @@
     "net10.0": {
       "Avalonia": {
         "type": "Direct",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
         "dependencies": {
@@ -15,7 +15,7 @@
       },
       "Markdig": {
         "type": "Direct",
-        "requested": "[1.1.*, )",
+        "requested": "[1.1.3, )",
         "resolved": "1.1.3",
         "contentHash": "wboYc6YToID7koq+onej7rjd/kv4urZaZ4QMiJoF/jXt/ZlXe2Af9gWG4nOe5tk654UaOPYvKL64iFum7qWEYA=="
       },

--- a/src/MarkView.Avalonia/packages.lock.json
+++ b/src/MarkView.Avalonia/packages.lock.json
@@ -4,12 +4,12 @@
     "net10.0": {
       "Avalonia": {
         "type": "Direct",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "852xwfNNAUWE+aKWFackMALAKofcpKnM2g4PN8VKfxG1SO8Stlih7d6QFCbjQl46vuR9WBw/ZVGwn4Ovbj/oxQ==",
         "dependencies": {
           "Avalonia.BuildServices": "11.3.2",
-          "Avalonia.Remote.Protocol": "12.0.1",
+          "Avalonia.Remote.Protocol": "12.0.2",
           "MicroCom.Runtime": "0.11.4"
         }
       },
@@ -26,8 +26,8 @@
       },
       "Avalonia.Remote.Protocol": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "8rqhNyde2I/JiW2TjQ8AkUoRclynr0e8yFXKB8VhehA07ejthx4Bnmt3k1DTSlpwTXbM0FRgYAtB1bTlUc6rgg=="
+        "resolved": "12.0.2",
+        "contentHash": "mlKTvn0cAEQVkRMJunLzDNugZRbtZIksT5yu+XgcAlOvqTHGyZY+mGP+4/+1IwakZx9nrz6SGwI5yrzNT5g0TQ=="
       },
       "MicroCom.Runtime": {
         "type": "Transitive",

--- a/tests/MarkView.Avalonia.Mermaid.Tests/packages.lock.json
+++ b/tests/MarkView.Avalonia.Mermaid.Tests/packages.lock.json
@@ -4,21 +4,21 @@
     "net10.0": {
       "Avalonia.Headless.XUnit": {
         "type": "Direct",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "umwbvHUnbq++HYHoDM42KGuLL3Yy0m2L6O6rnPviYHtG9/YKFCqInBxDgWr9MJhl6yh3ECx6L7Dxef0d4/gvWQ==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "wXy0b0r5kvSbcGNDMeNts3bHohdSwbHJ5tczXL8xoGicY32yLNkZzsR+zjmNRB0qz55kPKysFO3uYqxf5KLLJQ==",
         "dependencies": {
-          "Avalonia.Headless": "12.0.1",
+          "Avalonia.Headless": "12.0.2",
           "xunit.v3.extensibility.core": "3.2.2"
         }
       },
       "Avalonia.Themes.Fluent": {
         "type": "Direct",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "/vfTVnz0mZR91cDQn5dHKzngLV0OfCZ0i/uT01uxKu6jqyaPbRwpO68d07N0d6ll6hnvdfySfP4lDY7JWtqr4A==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "uEDLnrS7flCulIjWHnW6eiPiUqjxxAOh76suASMpQ0pJ+kntTEua5R1VcIulwZff79ArMqTVPejf7u0cxlVI2A==",
         "dependencies": {
-          "Avalonia": "12.0.1"
+          "Avalonia": "12.0.2"
         }
       },
       "coverlet.collector": {
@@ -29,12 +29,12 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "requested": "[18.5.1, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.4.0",
-          "Microsoft.TestPlatform.TestHost": "18.4.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "xunit.runner.visualstudio": {
@@ -59,10 +59,10 @@
       },
       "Avalonia.HarfBuzz": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "17A+VIAeIGsYqZSK/ydYzZbbzatBDj2Ls8aF/ZVo6OdeN5W+J9eAQGhS1wPw/GIkGuOkRPBSVwicFXIFCDf/kA==",
+        "resolved": "12.0.2",
+        "contentHash": "HGqFe/HmWHQGvwtji7827/RDtEgQxvm3zdnCFl/P6XAwnqek8MoJpnISRTid76XzTBDtNlVqp7qjOujSIE0QCw==",
         "dependencies": {
-          "Avalonia": "12.0.1",
+          "Avalonia": "12.0.2",
           "HarfBuzzSharp": "8.3.1.3",
           "HarfBuzzSharp.NativeAssets.Linux": "8.3.1.3",
           "HarfBuzzSharp.NativeAssets.WebAssembly": "8.3.1.3"
@@ -70,18 +70,18 @@
       },
       "Avalonia.Headless": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "Hzb5sZWhytdByLwVX/1BTv+ahAESgh6AlgjvAsmhCEif9/nIrsMt7+9CtYLOpyAiczeE8DZXqKX/bqLh4XOOIg==",
+        "resolved": "12.0.2",
+        "contentHash": "9GjjJIe2VHQcJQkKaBNZS2r5ivOUkNQ5uiWDm8ipTZqCKTn8grG0c9ngOdIeB5ibFMbOT7/0If4IBFK9ZkAWhw==",
         "dependencies": {
-          "Avalonia": "12.0.1",
-          "Avalonia.Fonts.Inter": "12.0.1",
-          "Avalonia.HarfBuzz": "12.0.1"
+          "Avalonia": "12.0.2",
+          "Avalonia.Fonts.Inter": "12.0.2",
+          "Avalonia.HarfBuzz": "12.0.2"
         }
       },
       "Avalonia.Remote.Protocol": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "8rqhNyde2I/JiW2TjQ8AkUoRclynr0e8yFXKB8VhehA07ejthx4Bnmt3k1DTSlpwTXbM0FRgYAtB1bTlUc6rgg=="
+        "resolved": "12.0.2",
+        "contentHash": "mlKTvn0cAEQVkRMJunLzDNugZRbtZIksT5yu+XgcAlOvqTHGyZY+mGP+4/+1IwakZx9nrz6SGwI5yrzNT5g0TQ=="
       },
       "Avalonia.Skia": {
         "type": "Transitive",
@@ -148,8 +148,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Transitive",
@@ -188,15 +188,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "gZsCHI+zOmZCcKZieIL4Jg14qKD2OGZOmX5DehuIk1EA9BN6Crm0+taXQNEuajOH1G9CCyBxw8VWR4t5tumcng==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -373,7 +373,7 @@
       "markview.avalonia": {
         "type": "Project",
         "dependencies": {
-          "Avalonia": "[12.0.1, )",
+          "Avalonia": "[12.0.2, )",
           "Markdig": "[1.1.3, )"
         }
       },
@@ -387,22 +387,22 @@
       },
       "Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "852xwfNNAUWE+aKWFackMALAKofcpKnM2g4PN8VKfxG1SO8Stlih7d6QFCbjQl46vuR9WBw/ZVGwn4Ovbj/oxQ==",
         "dependencies": {
           "Avalonia.BuildServices": "11.3.2",
-          "Avalonia.Remote.Protocol": "12.0.1",
+          "Avalonia.Remote.Protocol": "12.0.2",
           "MicroCom.Runtime": "0.11.4"
         }
       },
       "Avalonia.Fonts.Inter": {
         "type": "CentralTransitive",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "Pm7Xb9fMpjM4i1cpUGtpDtxkMC/oVfijaT93cPl30LPUKPYPbpwm1jkrYwtWLtEr/xTgbUmxyZZvJd0cV9oF8g==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "2QEaZc52qqO3W58LfGkcV9V3lX4A6uyIt8zJaSb2ULyeyw9CwdLurJ/bwDcYO3M1dwV7LMDcqjOTuqCf8TIZ0Q==",
         "dependencies": {
-          "Avalonia": "12.0.1"
+          "Avalonia": "12.0.2"
         }
       },
       "Markdig": {

--- a/tests/MarkView.Avalonia.Mermaid.Tests/packages.lock.json
+++ b/tests/MarkView.Avalonia.Mermaid.Tests/packages.lock.json
@@ -4,7 +4,7 @@
     "net10.0": {
       "Avalonia.Headless.XUnit": {
         "type": "Direct",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "umwbvHUnbq++HYHoDM42KGuLL3Yy0m2L6O6rnPviYHtG9/YKFCqInBxDgWr9MJhl6yh3ECx6L7Dxef0d4/gvWQ==",
         "dependencies": {
@@ -14,7 +14,7 @@
       },
       "Avalonia.Themes.Fluent": {
         "type": "Direct",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "/vfTVnz0mZR91cDQn5dHKzngLV0OfCZ0i/uT01uxKu6jqyaPbRwpO68d07N0d6ll6hnvdfySfP4lDY7JWtqr4A==",
         "dependencies": {
@@ -23,13 +23,13 @@
       },
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[10.*, )",
+        "requested": "[10.0.0, )",
         "resolved": "10.0.0",
         "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.*, )",
+        "requested": "[18.4.0, )",
         "resolved": "18.4.0",
         "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
         "dependencies": {
@@ -39,13 +39,13 @@
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
-        "requested": "[3.*, )",
+        "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
       },
       "xunit.v3": {
         "type": "Direct",
-        "requested": "[3.*, )",
+        "requested": "[3.2.2, )",
         "resolved": "3.2.2",
         "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
         "dependencies": {
@@ -373,21 +373,21 @@
       "markview.avalonia": {
         "type": "Project",
         "dependencies": {
-          "Avalonia": "[12.0.*, )",
-          "Markdig": "[1.1.*, )"
+          "Avalonia": "[12.0.1, )",
+          "Markdig": "[1.1.3, )"
         }
       },
       "markview.avalonia.mermaid": {
         "type": "Project",
         "dependencies": {
           "MarkView.Avalonia": "[1.0.0, )",
-          "Mermaider": "[0.*, )",
-          "Svg.Controls.Skia.Avalonia": "[12.0.*, )"
+          "Mermaider": "[0.6.0, )",
+          "Svg.Controls.Skia.Avalonia": "[12.0.0.3, )"
         }
       },
       "Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
         "dependencies": {
@@ -398,7 +398,7 @@
       },
       "Avalonia.Fonts.Inter": {
         "type": "CentralTransitive",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "Pm7Xb9fMpjM4i1cpUGtpDtxkMC/oVfijaT93cPl30LPUKPYPbpwm1jkrYwtWLtEr/xTgbUmxyZZvJd0cV9oF8g==",
         "dependencies": {
@@ -407,13 +407,13 @@
       },
       "Markdig": {
         "type": "CentralTransitive",
-        "requested": "[1.1.*, )",
+        "requested": "[1.1.3, )",
         "resolved": "1.1.3",
         "contentHash": "wboYc6YToID7koq+onej7rjd/kv4urZaZ4QMiJoF/jXt/ZlXe2Af9gWG4nOe5tk654UaOPYvKL64iFum7qWEYA=="
       },
       "Mermaider": {
         "type": "CentralTransitive",
-        "requested": "[0.*, )",
+        "requested": "[0.6.0, )",
         "resolved": "0.6.0",
         "contentHash": "cmtlEM+xFvWnzPwCXz4mMsOa8Le4DjakNjs57nKHS7xX5ecslqC7fve0iYCwwk+mq/Ggr7BY1n/jSKYjsxyIlg==",
         "dependencies": {
@@ -423,7 +423,7 @@
       },
       "Svg.Controls.Skia.Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.0.3, )",
         "resolved": "12.0.0.3",
         "contentHash": "TtoRNswWI6CBzcLliWvLaEFiDf0wo9Zi/GTX1H0Q4QVcX2aXItkzPK4MELKv3B3bE+cRmVbXAt1PvwiuD2n6TA==",
         "dependencies": {

--- a/tests/MarkView.Avalonia.Svg.Tests/packages.lock.json
+++ b/tests/MarkView.Avalonia.Svg.Tests/packages.lock.json
@@ -4,7 +4,7 @@
     "net10.0": {
       "Avalonia.Headless.XUnit": {
         "type": "Direct",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "umwbvHUnbq++HYHoDM42KGuLL3Yy0m2L6O6rnPviYHtG9/YKFCqInBxDgWr9MJhl6yh3ECx6L7Dxef0d4/gvWQ==",
         "dependencies": {
@@ -14,7 +14,7 @@
       },
       "Avalonia.Themes.Fluent": {
         "type": "Direct",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "/vfTVnz0mZR91cDQn5dHKzngLV0OfCZ0i/uT01uxKu6jqyaPbRwpO68d07N0d6ll6hnvdfySfP4lDY7JWtqr4A==",
         "dependencies": {
@@ -23,13 +23,13 @@
       },
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[10.*, )",
+        "requested": "[10.0.0, )",
         "resolved": "10.0.0",
         "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.*, )",
+        "requested": "[18.4.0, )",
         "resolved": "18.4.0",
         "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
         "dependencies": {
@@ -39,13 +39,13 @@
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
-        "requested": "[3.*, )",
+        "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
       },
       "xunit.v3": {
         "type": "Direct",
-        "requested": "[3.*, )",
+        "requested": "[3.2.2, )",
         "resolved": "3.2.2",
         "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
         "dependencies": {
@@ -363,20 +363,20 @@
       "markview.avalonia": {
         "type": "Project",
         "dependencies": {
-          "Avalonia": "[12.0.*, )",
-          "Markdig": "[1.1.*, )"
+          "Avalonia": "[12.0.1, )",
+          "Markdig": "[1.1.3, )"
         }
       },
       "markview.avalonia.svg": {
         "type": "Project",
         "dependencies": {
           "MarkView.Avalonia": "[1.0.0, )",
-          "Svg.Controls.Skia.Avalonia": "[12.0.*, )"
+          "Svg.Controls.Skia.Avalonia": "[12.0.0.3, )"
         }
       },
       "Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
         "dependencies": {
@@ -387,7 +387,7 @@
       },
       "Avalonia.Fonts.Inter": {
         "type": "CentralTransitive",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "Pm7Xb9fMpjM4i1cpUGtpDtxkMC/oVfijaT93cPl30LPUKPYPbpwm1jkrYwtWLtEr/xTgbUmxyZZvJd0cV9oF8g==",
         "dependencies": {
@@ -396,13 +396,13 @@
       },
       "Markdig": {
         "type": "CentralTransitive",
-        "requested": "[1.1.*, )",
+        "requested": "[1.1.3, )",
         "resolved": "1.1.3",
         "contentHash": "wboYc6YToID7koq+onej7rjd/kv4urZaZ4QMiJoF/jXt/ZlXe2Af9gWG4nOe5tk654UaOPYvKL64iFum7qWEYA=="
       },
       "Svg.Controls.Skia.Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.0.3, )",
         "resolved": "12.0.0.3",
         "contentHash": "TtoRNswWI6CBzcLliWvLaEFiDf0wo9Zi/GTX1H0Q4QVcX2aXItkzPK4MELKv3B3bE+cRmVbXAt1PvwiuD2n6TA==",
         "dependencies": {

--- a/tests/MarkView.Avalonia.Svg.Tests/packages.lock.json
+++ b/tests/MarkView.Avalonia.Svg.Tests/packages.lock.json
@@ -4,21 +4,21 @@
     "net10.0": {
       "Avalonia.Headless.XUnit": {
         "type": "Direct",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "umwbvHUnbq++HYHoDM42KGuLL3Yy0m2L6O6rnPviYHtG9/YKFCqInBxDgWr9MJhl6yh3ECx6L7Dxef0d4/gvWQ==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "wXy0b0r5kvSbcGNDMeNts3bHohdSwbHJ5tczXL8xoGicY32yLNkZzsR+zjmNRB0qz55kPKysFO3uYqxf5KLLJQ==",
         "dependencies": {
-          "Avalonia.Headless": "12.0.1",
+          "Avalonia.Headless": "12.0.2",
           "xunit.v3.extensibility.core": "3.2.2"
         }
       },
       "Avalonia.Themes.Fluent": {
         "type": "Direct",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "/vfTVnz0mZR91cDQn5dHKzngLV0OfCZ0i/uT01uxKu6jqyaPbRwpO68d07N0d6ll6hnvdfySfP4lDY7JWtqr4A==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "uEDLnrS7flCulIjWHnW6eiPiUqjxxAOh76suASMpQ0pJ+kntTEua5R1VcIulwZff79ArMqTVPejf7u0cxlVI2A==",
         "dependencies": {
-          "Avalonia": "12.0.1"
+          "Avalonia": "12.0.2"
         }
       },
       "coverlet.collector": {
@@ -29,12 +29,12 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "requested": "[18.5.1, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.4.0",
-          "Microsoft.TestPlatform.TestHost": "18.4.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "xunit.runner.visualstudio": {
@@ -59,10 +59,10 @@
       },
       "Avalonia.HarfBuzz": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "17A+VIAeIGsYqZSK/ydYzZbbzatBDj2Ls8aF/ZVo6OdeN5W+J9eAQGhS1wPw/GIkGuOkRPBSVwicFXIFCDf/kA==",
+        "resolved": "12.0.2",
+        "contentHash": "HGqFe/HmWHQGvwtji7827/RDtEgQxvm3zdnCFl/P6XAwnqek8MoJpnISRTid76XzTBDtNlVqp7qjOujSIE0QCw==",
         "dependencies": {
-          "Avalonia": "12.0.1",
+          "Avalonia": "12.0.2",
           "HarfBuzzSharp": "8.3.1.3",
           "HarfBuzzSharp.NativeAssets.Linux": "8.3.1.3",
           "HarfBuzzSharp.NativeAssets.WebAssembly": "8.3.1.3"
@@ -70,18 +70,18 @@
       },
       "Avalonia.Headless": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "Hzb5sZWhytdByLwVX/1BTv+ahAESgh6AlgjvAsmhCEif9/nIrsMt7+9CtYLOpyAiczeE8DZXqKX/bqLh4XOOIg==",
+        "resolved": "12.0.2",
+        "contentHash": "9GjjJIe2VHQcJQkKaBNZS2r5ivOUkNQ5uiWDm8ipTZqCKTn8grG0c9ngOdIeB5ibFMbOT7/0If4IBFK9ZkAWhw==",
         "dependencies": {
-          "Avalonia": "12.0.1",
-          "Avalonia.Fonts.Inter": "12.0.1",
-          "Avalonia.HarfBuzz": "12.0.1"
+          "Avalonia": "12.0.2",
+          "Avalonia.Fonts.Inter": "12.0.2",
+          "Avalonia.HarfBuzz": "12.0.2"
         }
       },
       "Avalonia.Remote.Protocol": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "8rqhNyde2I/JiW2TjQ8AkUoRclynr0e8yFXKB8VhehA07ejthx4Bnmt3k1DTSlpwTXbM0FRgYAtB1bTlUc6rgg=="
+        "resolved": "12.0.2",
+        "contentHash": "mlKTvn0cAEQVkRMJunLzDNugZRbtZIksT5yu+XgcAlOvqTHGyZY+mGP+4/+1IwakZx9nrz6SGwI5yrzNT5g0TQ=="
       },
       "Avalonia.Skia": {
         "type": "Transitive",
@@ -148,8 +148,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -183,15 +183,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "gZsCHI+zOmZCcKZieIL4Jg14qKD2OGZOmX5DehuIk1EA9BN6Crm0+taXQNEuajOH1G9CCyBxw8VWR4t5tumcng==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -363,7 +363,7 @@
       "markview.avalonia": {
         "type": "Project",
         "dependencies": {
-          "Avalonia": "[12.0.1, )",
+          "Avalonia": "[12.0.2, )",
           "Markdig": "[1.1.3, )"
         }
       },
@@ -376,22 +376,22 @@
       },
       "Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "852xwfNNAUWE+aKWFackMALAKofcpKnM2g4PN8VKfxG1SO8Stlih7d6QFCbjQl46vuR9WBw/ZVGwn4Ovbj/oxQ==",
         "dependencies": {
           "Avalonia.BuildServices": "11.3.2",
-          "Avalonia.Remote.Protocol": "12.0.1",
+          "Avalonia.Remote.Protocol": "12.0.2",
           "MicroCom.Runtime": "0.11.4"
         }
       },
       "Avalonia.Fonts.Inter": {
         "type": "CentralTransitive",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "Pm7Xb9fMpjM4i1cpUGtpDtxkMC/oVfijaT93cPl30LPUKPYPbpwm1jkrYwtWLtEr/xTgbUmxyZZvJd0cV9oF8g==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "2QEaZc52qqO3W58LfGkcV9V3lX4A6uyIt8zJaSb2ULyeyw9CwdLurJ/bwDcYO3M1dwV7LMDcqjOTuqCf8TIZ0Q==",
         "dependencies": {
-          "Avalonia": "12.0.1"
+          "Avalonia": "12.0.2"
         }
       },
       "Markdig": {

--- a/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/packages.lock.json
+++ b/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/packages.lock.json
@@ -4,21 +4,21 @@
     "net10.0": {
       "Avalonia.Headless.XUnit": {
         "type": "Direct",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "umwbvHUnbq++HYHoDM42KGuLL3Yy0m2L6O6rnPviYHtG9/YKFCqInBxDgWr9MJhl6yh3ECx6L7Dxef0d4/gvWQ==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "wXy0b0r5kvSbcGNDMeNts3bHohdSwbHJ5tczXL8xoGicY32yLNkZzsR+zjmNRB0qz55kPKysFO3uYqxf5KLLJQ==",
         "dependencies": {
-          "Avalonia.Headless": "12.0.1",
+          "Avalonia.Headless": "12.0.2",
           "xunit.v3.extensibility.core": "3.2.2"
         }
       },
       "Avalonia.Themes.Fluent": {
         "type": "Direct",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "/vfTVnz0mZR91cDQn5dHKzngLV0OfCZ0i/uT01uxKu6jqyaPbRwpO68d07N0d6ll6hnvdfySfP4lDY7JWtqr4A==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "uEDLnrS7flCulIjWHnW6eiPiUqjxxAOh76suASMpQ0pJ+kntTEua5R1VcIulwZff79ArMqTVPejf7u0cxlVI2A==",
         "dependencies": {
-          "Avalonia": "12.0.1"
+          "Avalonia": "12.0.2"
         }
       },
       "coverlet.collector": {
@@ -29,12 +29,12 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "requested": "[18.5.1, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.4.0",
-          "Microsoft.TestPlatform.TestHost": "18.4.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "xunit.runner.visualstudio": {
@@ -59,10 +59,10 @@
       },
       "Avalonia.HarfBuzz": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "17A+VIAeIGsYqZSK/ydYzZbbzatBDj2Ls8aF/ZVo6OdeN5W+J9eAQGhS1wPw/GIkGuOkRPBSVwicFXIFCDf/kA==",
+        "resolved": "12.0.2",
+        "contentHash": "HGqFe/HmWHQGvwtji7827/RDtEgQxvm3zdnCFl/P6XAwnqek8MoJpnISRTid76XzTBDtNlVqp7qjOujSIE0QCw==",
         "dependencies": {
-          "Avalonia": "12.0.1",
+          "Avalonia": "12.0.2",
           "HarfBuzzSharp": "8.3.1.3",
           "HarfBuzzSharp.NativeAssets.Linux": "8.3.1.3",
           "HarfBuzzSharp.NativeAssets.WebAssembly": "8.3.1.3"
@@ -70,18 +70,18 @@
       },
       "Avalonia.Headless": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "Hzb5sZWhytdByLwVX/1BTv+ahAESgh6AlgjvAsmhCEif9/nIrsMt7+9CtYLOpyAiczeE8DZXqKX/bqLh4XOOIg==",
+        "resolved": "12.0.2",
+        "contentHash": "9GjjJIe2VHQcJQkKaBNZS2r5ivOUkNQ5uiWDm8ipTZqCKTn8grG0c9ngOdIeB5ibFMbOT7/0If4IBFK9ZkAWhw==",
         "dependencies": {
-          "Avalonia": "12.0.1",
-          "Avalonia.Fonts.Inter": "12.0.1",
-          "Avalonia.HarfBuzz": "12.0.1"
+          "Avalonia": "12.0.2",
+          "Avalonia.Fonts.Inter": "12.0.2",
+          "Avalonia.HarfBuzz": "12.0.2"
         }
       },
       "Avalonia.Remote.Protocol": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "8rqhNyde2I/JiW2TjQ8AkUoRclynr0e8yFXKB8VhehA07ejthx4Bnmt3k1DTSlpwTXbM0FRgYAtB1bTlUc6rgg=="
+        "resolved": "12.0.2",
+        "contentHash": "mlKTvn0cAEQVkRMJunLzDNugZRbtZIksT5yu+XgcAlOvqTHGyZY+mGP+4/+1IwakZx9nrz6SGwI5yrzNT5g0TQ=="
       },
       "HarfBuzzSharp": {
         "type": "Transitive",
@@ -129,8 +129,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -164,15 +164,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "gZsCHI+zOmZCcKZieIL4Jg14qKD2OGZOmX5DehuIk1EA9BN6Crm0+taXQNEuajOH1G9CCyBxw8VWR4t5tumcng==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -261,7 +261,7 @@
       "markview.avalonia": {
         "type": "Project",
         "dependencies": {
-          "Avalonia": "[12.0.1, )",
+          "Avalonia": "[12.0.2, )",
           "Markdig": "[1.1.3, )"
         }
       },
@@ -275,22 +275,22 @@
       },
       "Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "852xwfNNAUWE+aKWFackMALAKofcpKnM2g4PN8VKfxG1SO8Stlih7d6QFCbjQl46vuR9WBw/ZVGwn4Ovbj/oxQ==",
         "dependencies": {
           "Avalonia.BuildServices": "11.3.2",
-          "Avalonia.Remote.Protocol": "12.0.1",
+          "Avalonia.Remote.Protocol": "12.0.2",
           "MicroCom.Runtime": "0.11.4"
         }
       },
       "Avalonia.Fonts.Inter": {
         "type": "CentralTransitive",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "Pm7Xb9fMpjM4i1cpUGtpDtxkMC/oVfijaT93cPl30LPUKPYPbpwm1jkrYwtWLtEr/xTgbUmxyZZvJd0cV9oF8g==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "2QEaZc52qqO3W58LfGkcV9V3lX4A6uyIt8zJaSb2ULyeyw9CwdLurJ/bwDcYO3M1dwV7LMDcqjOTuqCf8TIZ0Q==",
         "dependencies": {
-          "Avalonia": "12.0.1"
+          "Avalonia": "12.0.2"
         }
       },
       "Markdig": {

--- a/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/packages.lock.json
+++ b/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/packages.lock.json
@@ -4,7 +4,7 @@
     "net10.0": {
       "Avalonia.Headless.XUnit": {
         "type": "Direct",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "umwbvHUnbq++HYHoDM42KGuLL3Yy0m2L6O6rnPviYHtG9/YKFCqInBxDgWr9MJhl6yh3ECx6L7Dxef0d4/gvWQ==",
         "dependencies": {
@@ -14,7 +14,7 @@
       },
       "Avalonia.Themes.Fluent": {
         "type": "Direct",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "/vfTVnz0mZR91cDQn5dHKzngLV0OfCZ0i/uT01uxKu6jqyaPbRwpO68d07N0d6ll6hnvdfySfP4lDY7JWtqr4A==",
         "dependencies": {
@@ -23,13 +23,13 @@
       },
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[10.*, )",
+        "requested": "[10.0.0, )",
         "resolved": "10.0.0",
         "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.*, )",
+        "requested": "[18.4.0, )",
         "resolved": "18.4.0",
         "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
         "dependencies": {
@@ -39,13 +39,13 @@
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
-        "requested": "[3.*, )",
+        "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
       },
       "xunit.v3": {
         "type": "Direct",
-        "requested": "[3.*, )",
+        "requested": "[3.2.2, )",
         "resolved": "3.2.2",
         "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
         "dependencies": {
@@ -261,21 +261,21 @@
       "markview.avalonia": {
         "type": "Project",
         "dependencies": {
-          "Avalonia": "[12.0.*, )",
-          "Markdig": "[1.1.*, )"
+          "Avalonia": "[12.0.1, )",
+          "Markdig": "[1.1.3, )"
         }
       },
       "markview.avalonia.syntaxhighlighting": {
         "type": "Project",
         "dependencies": {
           "MarkView.Avalonia": "[1.0.0, )",
-          "TextMateSharp": "[2.*, )",
-          "TextMateSharp.Grammars": "[2.*, )"
+          "TextMateSharp": "[2.0.3, )",
+          "TextMateSharp.Grammars": "[2.0.3, )"
         }
       },
       "Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
         "dependencies": {
@@ -286,7 +286,7 @@
       },
       "Avalonia.Fonts.Inter": {
         "type": "CentralTransitive",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "Pm7Xb9fMpjM4i1cpUGtpDtxkMC/oVfijaT93cPl30LPUKPYPbpwm1jkrYwtWLtEr/xTgbUmxyZZvJd0cV9oF8g==",
         "dependencies": {
@@ -295,13 +295,13 @@
       },
       "Markdig": {
         "type": "CentralTransitive",
-        "requested": "[1.1.*, )",
+        "requested": "[1.1.3, )",
         "resolved": "1.1.3",
         "contentHash": "wboYc6YToID7koq+onej7rjd/kv4urZaZ4QMiJoF/jXt/ZlXe2Af9gWG4nOe5tk654UaOPYvKL64iFum7qWEYA=="
       },
       "TextMateSharp": {
         "type": "CentralTransitive",
-        "requested": "[2.*, )",
+        "requested": "[2.0.3, )",
         "resolved": "2.0.3",
         "contentHash": "w0wGeqlBi9SYrzxpS1DBcEfiVCs5NY18Yl5YBIsHzXTXQd0OLOh3mP4LRuFvcktR/1MG8nSBHSMJj0rFvrPk+A==",
         "dependencies": {
@@ -310,7 +310,7 @@
       },
       "TextMateSharp.Grammars": {
         "type": "CentralTransitive",
-        "requested": "[2.*, )",
+        "requested": "[2.0.3, )",
         "resolved": "2.0.3",
         "contentHash": "qkI1ogusuyGCGTgeyhljDM+GEfATOexoUTqLIgSb5P0ojmfhRXWfSTRXXJRpZkLDErShJ7RWOb+p10lHfhhO+Q==",
         "dependencies": {

--- a/tests/MarkView.Avalonia.Tests/MarkView.Avalonia.Tests.csproj
+++ b/tests/MarkView.Avalonia.Tests/MarkView.Avalonia.Tests.csproj
@@ -18,4 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\MarkView.Avalonia\MarkView.Avalonia.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <AvaloniaResource Include="TestAssets\**" />
+  </ItemGroup>
 </Project>

--- a/tests/MarkView.Avalonia.Tests/MarkdownViewerSourceTests.cs
+++ b/tests/MarkView.Avalonia.Tests/MarkdownViewerSourceTests.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using MarkView.Avalonia.Rendering;
+using Xunit;
+
+namespace MarkView.Avalonia.Tests;
+
+public class MarkdownViewerSourceTests
+{
+    // avares:// resource embedded in this test assembly.
+    private static readonly Uri AvaresTestDoc =
+        new("avares://MarkView.Avalonia.Tests/TestAssets/test.md");
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static StackPanel GetRootPanel(MarkdownViewer viewer)
+    {
+        var sv = Assert.IsType<ScrollViewer>(viewer.Content);
+        var grid = Assert.IsType<Grid>(sv.Content);
+        return Assert.IsType<StackPanel>(grid.Children[0]);
+    }
+
+    private static Task WaitForContentAsync(MarkdownViewer viewer, int timeoutMs = 5_000)
+    {
+        if (viewer.Content is not null)
+            return Task.CompletedTask;
+
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        viewer.PropertyChanged += (_, e) =>
+        {
+            if (e.Property == ContentControl.ContentProperty)
+                tcs.TrySetResult();
+        };
+        return Task.WhenAny(tcs.Task, Task.Delay(timeoutMs))
+            .ContinueWith(_ =>
+            {
+                if (!tcs.Task.IsCompleted)
+                    throw new TimeoutException("MarkdownViewer.Content was not set within the timeout.");
+            }, TaskScheduler.Default);
+    }
+
+    // ── avares:// ─────────────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void Source_avares_loads_and_renders_content()
+    {
+        var viewer = new MarkdownViewer { Source = AvaresTestDoc };
+
+        // avares:// is synchronous — Content is set before the property setter returns.
+        var panel = GetRootPanel(viewer);
+        Assert.NotEmpty(panel.Children);
+    }
+
+    [AvaloniaFact]
+    public void Source_avares_renders_heading_from_asset()
+    {
+        var viewer = new MarkdownViewer { Source = AvaresTestDoc };
+
+        var panel = GetRootPanel(viewer);
+        Assert.Contains(panel.Children, c =>
+            c is MarkdownSelectableTextBlock tb && tb.Classes.Contains("markdown-h1"));
+    }
+
+    // ── file:// ───────────────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public async Task Source_file_uri_loads_and_renders_content()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(path, "# Hello from file\n\nParagraph.");
+
+            var viewer = new MarkdownViewer { Source = new Uri(path) };
+            await WaitForContentAsync(viewer);
+
+            var panel = GetRootPanel(viewer);
+            Assert.NotEmpty(panel.Children);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Source_file_uri_renders_correct_content()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            await File.WriteAllTextAsync(path, "# File Heading\n\nBody text.");
+
+            var viewer = new MarkdownViewer { Source = new Uri(path) };
+            await WaitForContentAsync(viewer);
+
+            var panel = GetRootPanel(viewer);
+            Assert.Contains(panel.Children, c =>
+                c is MarkdownSelectableTextBlock tb && tb.Classes.Contains("markdown-h1"));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    // ── Precedence ───────────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void Source_takes_precedence_over_Markdown_property()
+    {
+        // The test asset has a heading; Markdown has plain text only.
+        // After both are set, Source content (with markdown-h1) must win.
+        var viewer = new MarkdownViewer
+        {
+            Markdown = "plain text — no heading",
+            Source = AvaresTestDoc,
+        };
+
+        var panel = GetRootPanel(viewer);
+        Assert.Contains(panel.Children, c =>
+            c is MarkdownSelectableTextBlock tb && tb.Classes.Contains("markdown-h1"));
+    }
+
+    // ── Null / clear ─────────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void Setting_Source_to_null_falls_back_to_Markdown()
+    {
+        var viewer = new MarkdownViewer
+        {
+            Markdown = "fallback paragraph",
+            Source = AvaresTestDoc,
+        };
+
+        // Source is active — heading is present.
+        var beforePanel = GetRootPanel(viewer);
+        Assert.Contains(beforePanel.Children, c =>
+            c is MarkdownSelectableTextBlock tb && tb.Classes.Contains("markdown-h1"));
+
+        // Clear Source → Markdown takes over.
+        viewer.Source = null;
+
+        var afterPanel = GetRootPanel(viewer);
+        Assert.NotEmpty(afterPanel.Children);
+        // No heading in "fallback paragraph".
+        Assert.DoesNotContain(afterPanel.Children, c =>
+            c is MarkdownSelectableTextBlock tb && tb.Classes.Contains("markdown-h1"));
+    }
+
+    [AvaloniaFact]
+    public void Setting_Source_to_null_with_no_Markdown_clears_content()
+    {
+        var viewer = new MarkdownViewer { Source = AvaresTestDoc };
+        Assert.NotNull(viewer.Content);
+
+        viewer.Source = null;
+
+        Assert.Null(viewer.Content);
+    }
+
+    // ── BaseUri inference ─────────────────────────────────────────────────────
+
+    [AvaloniaFact]
+    public void Source_avares_infers_BaseUri_when_not_explicitly_set()
+    {
+        // When no explicit BaseUri is given, the renderer BaseUri should be
+        // inferred from the source directory so that relative image links resolve.
+        // We verify indirectly: loading succeeds and content is not null.
+        var viewer = new MarkdownViewer { Source = AvaresTestDoc };
+
+        Assert.NotNull(viewer.Content);
+    }
+}

--- a/tests/MarkView.Avalonia.Tests/MarkdownViewerSourceTests.cs
+++ b/tests/MarkView.Avalonia.Tests/MarkdownViewerSourceTests.cs
@@ -34,12 +34,10 @@ public class MarkdownViewerSourceTests
             if (e.Property == ContentControl.ContentProperty)
                 tcs.TrySetResult();
         };
-        return Task.WhenAny(tcs.Task, Task.Delay(timeoutMs))
-            .ContinueWith(_ =>
-            {
-                if (!tcs.Task.IsCompleted)
-                    throw new TimeoutException("MarkdownViewer.Content was not set within the timeout.");
-            }, TaskScheduler.Default);
+        // Task.WaitAsync keeps the continuation on the current (Avalonia dispatcher)
+        // sync context, avoiding the scheduler mismatch that Task.WhenAny +
+        // ContinueWith(TaskScheduler.Default) could cause.
+        return tcs.Task.WaitAsync(TimeSpan.FromMilliseconds(timeoutMs));
     }
 
     // ── avares:// ─────────────────────────────────────────────────────────────

--- a/tests/MarkView.Avalonia.Tests/TestAssets/test.md
+++ b/tests/MarkView.Avalonia.Tests/TestAssets/test.md
@@ -1,0 +1,3 @@
+# Test Heading
+
+This is a test document for the Source property.

--- a/tests/MarkView.Avalonia.Tests/packages.lock.json
+++ b/tests/MarkView.Avalonia.Tests/packages.lock.json
@@ -4,7 +4,7 @@
     "net10.0": {
       "Avalonia.Headless.XUnit": {
         "type": "Direct",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "umwbvHUnbq++HYHoDM42KGuLL3Yy0m2L6O6rnPviYHtG9/YKFCqInBxDgWr9MJhl6yh3ECx6L7Dxef0d4/gvWQ==",
         "dependencies": {
@@ -14,7 +14,7 @@
       },
       "Avalonia.Themes.Fluent": {
         "type": "Direct",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "/vfTVnz0mZR91cDQn5dHKzngLV0OfCZ0i/uT01uxKu6jqyaPbRwpO68d07N0d6ll6hnvdfySfP4lDY7JWtqr4A==",
         "dependencies": {
@@ -23,13 +23,13 @@
       },
       "coverlet.collector": {
         "type": "Direct",
-        "requested": "[10.*, )",
+        "requested": "[10.0.0, )",
         "resolved": "10.0.0",
         "contentHash": "WFejCcOUR6k8UYyDnnR6Gk+obFYMsWrZuNqPJnsVFGVhpPSN0y20D4qbdKJnXinYGx9PQ397Hf9TnU1NBST8vA=="
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.*, )",
+        "requested": "[18.4.0, )",
         "resolved": "18.4.0",
         "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
         "dependencies": {
@@ -39,13 +39,13 @@
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
-        "requested": "[3.*, )",
+        "requested": "[3.1.5, )",
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
       },
       "xunit.v3": {
         "type": "Direct",
-        "requested": "[3.*, )",
+        "requested": "[3.2.2, )",
         "resolved": "3.2.2",
         "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
         "dependencies": {
@@ -256,13 +256,13 @@
       "markview.avalonia": {
         "type": "Project",
         "dependencies": {
-          "Avalonia": "[12.0.*, )",
-          "Markdig": "[1.1.*, )"
+          "Avalonia": "[12.0.1, )",
+          "Markdig": "[1.1.3, )"
         }
       },
       "Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
         "dependencies": {
@@ -273,7 +273,7 @@
       },
       "Avalonia.Fonts.Inter": {
         "type": "CentralTransitive",
-        "requested": "[12.0.*, )",
+        "requested": "[12.0.1, )",
         "resolved": "12.0.1",
         "contentHash": "Pm7Xb9fMpjM4i1cpUGtpDtxkMC/oVfijaT93cPl30LPUKPYPbpwm1jkrYwtWLtEr/xTgbUmxyZZvJd0cV9oF8g==",
         "dependencies": {
@@ -282,7 +282,7 @@
       },
       "Markdig": {
         "type": "CentralTransitive",
-        "requested": "[1.1.*, )",
+        "requested": "[1.1.3, )",
         "resolved": "1.1.3",
         "contentHash": "wboYc6YToID7koq+onej7rjd/kv4urZaZ4QMiJoF/jXt/ZlXe2Af9gWG4nOe5tk654UaOPYvKL64iFum7qWEYA=="
       }

--- a/tests/MarkView.Avalonia.Tests/packages.lock.json
+++ b/tests/MarkView.Avalonia.Tests/packages.lock.json
@@ -4,21 +4,21 @@
     "net10.0": {
       "Avalonia.Headless.XUnit": {
         "type": "Direct",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "umwbvHUnbq++HYHoDM42KGuLL3Yy0m2L6O6rnPviYHtG9/YKFCqInBxDgWr9MJhl6yh3ECx6L7Dxef0d4/gvWQ==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "wXy0b0r5kvSbcGNDMeNts3bHohdSwbHJ5tczXL8xoGicY32yLNkZzsR+zjmNRB0qz55kPKysFO3uYqxf5KLLJQ==",
         "dependencies": {
-          "Avalonia.Headless": "12.0.1",
+          "Avalonia.Headless": "12.0.2",
           "xunit.v3.extensibility.core": "3.2.2"
         }
       },
       "Avalonia.Themes.Fluent": {
         "type": "Direct",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "/vfTVnz0mZR91cDQn5dHKzngLV0OfCZ0i/uT01uxKu6jqyaPbRwpO68d07N0d6ll6hnvdfySfP4lDY7JWtqr4A==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "uEDLnrS7flCulIjWHnW6eiPiUqjxxAOh76suASMpQ0pJ+kntTEua5R1VcIulwZff79ArMqTVPejf7u0cxlVI2A==",
         "dependencies": {
-          "Avalonia": "12.0.1"
+          "Avalonia": "12.0.2"
         }
       },
       "coverlet.collector": {
@@ -29,12 +29,12 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.4.0, )",
-        "resolved": "18.4.0",
-        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "requested": "[18.5.1, )",
+        "resolved": "18.5.1",
+        "contentHash": "SfqVaLiIqAbRWuPg5BP4QFwBIirQj/YIL8Dhxl6zntBKbXp0cQykoV480SmwG+yRMiWptxEI6NbHQuGSZ8b97w==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.4.0",
-          "Microsoft.TestPlatform.TestHost": "18.4.0"
+          "Microsoft.CodeCoverage": "18.5.1",
+          "Microsoft.TestPlatform.TestHost": "18.5.1"
         }
       },
       "xunit.runner.visualstudio": {
@@ -59,10 +59,10 @@
       },
       "Avalonia.HarfBuzz": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "17A+VIAeIGsYqZSK/ydYzZbbzatBDj2Ls8aF/ZVo6OdeN5W+J9eAQGhS1wPw/GIkGuOkRPBSVwicFXIFCDf/kA==",
+        "resolved": "12.0.2",
+        "contentHash": "HGqFe/HmWHQGvwtji7827/RDtEgQxvm3zdnCFl/P6XAwnqek8MoJpnISRTid76XzTBDtNlVqp7qjOujSIE0QCw==",
         "dependencies": {
-          "Avalonia": "12.0.1",
+          "Avalonia": "12.0.2",
           "HarfBuzzSharp": "8.3.1.3",
           "HarfBuzzSharp.NativeAssets.Linux": "8.3.1.3",
           "HarfBuzzSharp.NativeAssets.WebAssembly": "8.3.1.3"
@@ -70,18 +70,18 @@
       },
       "Avalonia.Headless": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "Hzb5sZWhytdByLwVX/1BTv+ahAESgh6AlgjvAsmhCEif9/nIrsMt7+9CtYLOpyAiczeE8DZXqKX/bqLh4XOOIg==",
+        "resolved": "12.0.2",
+        "contentHash": "9GjjJIe2VHQcJQkKaBNZS2r5ivOUkNQ5uiWDm8ipTZqCKTn8grG0c9ngOdIeB5ibFMbOT7/0If4IBFK9ZkAWhw==",
         "dependencies": {
-          "Avalonia": "12.0.1",
-          "Avalonia.Fonts.Inter": "12.0.1",
-          "Avalonia.HarfBuzz": "12.0.1"
+          "Avalonia": "12.0.2",
+          "Avalonia.Fonts.Inter": "12.0.2",
+          "Avalonia.HarfBuzz": "12.0.2"
         }
       },
       "Avalonia.Remote.Protocol": {
         "type": "Transitive",
-        "resolved": "12.0.1",
-        "contentHash": "8rqhNyde2I/JiW2TjQ8AkUoRclynr0e8yFXKB8VhehA07ejthx4Bnmt3k1DTSlpwTXbM0FRgYAtB1bTlUc6rgg=="
+        "resolved": "12.0.2",
+        "contentHash": "mlKTvn0cAEQVkRMJunLzDNugZRbtZIksT5yu+XgcAlOvqTHGyZY+mGP+4/+1IwakZx9nrz6SGwI5yrzNT5g0TQ=="
       },
       "HarfBuzzSharp": {
         "type": "Transitive",
@@ -129,8 +129,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+        "resolved": "18.5.1",
+        "contentHash": "vMFDR1ZjqzzgKmM0zrPie7Gv9Y+ZppjODB5Quzu9Eq0TlIusUfUCYFPEawO91zQuqwzvdFbJSU7WHNtjStffJQ=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -164,15 +164,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg=="
+        "resolved": "18.5.1",
+        "contentHash": "KNZd+M0S0rz5eNAln0pbZX+A/RbokYZCbGKx4fN4CkhtWhkz6nSJDO+9LGYjRE4d0WPVriJ2JnVubkjt3+PpMg=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.4.0",
-        "contentHash": "gZsCHI+zOmZCcKZieIL4Jg14qKD2OGZOmX5DehuIk1EA9BN6Crm0+taXQNEuajOH1G9CCyBxw8VWR4t5tumcng==",
+        "resolved": "18.5.1",
+        "contentHash": "RM+3JNHEoHOCFXzVntUcIiYxzPjzBN0N8wto6HYXi76YyBTZ/3CeRL8U+Pk5zx3AUrOmHxDvKJwGUCdElU9bJg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Microsoft.TestPlatform.ObjectModel": "18.5.1",
           "Newtonsoft.Json": "13.0.3"
         }
       },
@@ -256,28 +256,28 @@
       "markview.avalonia": {
         "type": "Project",
         "dependencies": {
-          "Avalonia": "[12.0.1, )",
+          "Avalonia": "[12.0.2, )",
           "Markdig": "[1.1.3, )"
         }
       },
       "Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "852xwfNNAUWE+aKWFackMALAKofcpKnM2g4PN8VKfxG1SO8Stlih7d6QFCbjQl46vuR9WBw/ZVGwn4Ovbj/oxQ==",
         "dependencies": {
           "Avalonia.BuildServices": "11.3.2",
-          "Avalonia.Remote.Protocol": "12.0.1",
+          "Avalonia.Remote.Protocol": "12.0.2",
           "MicroCom.Runtime": "0.11.4"
         }
       },
       "Avalonia.Fonts.Inter": {
         "type": "CentralTransitive",
-        "requested": "[12.0.1, )",
-        "resolved": "12.0.1",
-        "contentHash": "Pm7Xb9fMpjM4i1cpUGtpDtxkMC/oVfijaT93cPl30LPUKPYPbpwm1jkrYwtWLtEr/xTgbUmxyZZvJd0cV9oF8g==",
+        "requested": "[12.0.2, )",
+        "resolved": "12.0.2",
+        "contentHash": "2QEaZc52qqO3W58LfGkcV9V3lX4A6uyIt8zJaSb2ULyeyw9CwdLurJ/bwDcYO3M1dwV7LMDcqjOTuqCf8TIZ0Q==",
         "dependencies": {
-          "Avalonia": "12.0.1"
+          "Avalonia": "12.0.2"
         }
       },
       "Markdig": {


### PR DESCRIPTION
## Summary

Adds a `Uri`-typed `Source` property as an alternative to setting `Markdown` directly. Consumers can point to an embedded `avares://` resource, a `file://` path, or an http/https URL.

- `avares://` loads synchronously via `AssetLoader.Open()` (`ManifestResourceStream`, no real I/O cost)
- `file://` and http/https load asynchronously; an in-flight load is cancelled when `Source` changes again
- When both `Source` and `Markdown` are set, `Source` takes precedence
- `BaseUri` is inferred from the `Source` directory when not set explicitly, so relative image links in the loaded document resolve correctly

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [x] Documentation
- [ ] CI / build

## Test plan

<!--
Check each item that was verified. Add new lines for any scenario specific to
this PR. Reference new test names where applicable.
-->

- [x] `dotnet test` — all tests pass
- [x] Manual smoke-test in the demo app
