### PR TITLE
feat: image resize mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,6 +9,7 @@
 | `Pipeline` | `MarkdownPipeline?` | `null` | The Markdig pipeline. `null` falls back to `MarkdownViewerDefaults.Pipeline`, or the built-in default (`UseSupportedExtensions`). |
 | `BaseUri` | `Uri?` | `null` | Base URI for resolving relative links and image paths. When `Source` is set and `BaseUri` is not, it is inferred automatically from the source location. |
 | `Extensions` | `IList<IMarkViewExtension>` | `[]` | Per-instance rendering extensions. Applied after global defaults. |
+| `ImageResizeMode` | `ImageResizeMode` | `ScaleDownToFit` | Controls how images without an explicit `=WxH` size hint scale relative to their container. See [Image sizing](#image-sizing). |
 
 ## Markdig Pipeline
 
@@ -150,3 +151,31 @@ viewer.ScrollToAnchor("fn-1");            // matches footnote [^1]
 ```
 
 Anchors are generated from heading text using GitHub-compatible slug rules (lowercase, spaces to hyphens, non-alphanumeric stripped). Headings with identical slugs are disambiguated with a numeric suffix (`-1`, `-2`, …).
+
+## Image sizing
+
+`ImageResizeMode` controls how images without an explicit size scale relative to
+the viewer's width:
+
+| Mode | Behavior |
+|------|----------|
+| `ScaleDownToFit` (default) | Scales down to fit the container width; never enlarges past the image's native resolution. |
+| `Natural` | No scaling — renders at native pixel size. May appear cropped if the image is wider than the viewer, since horizontal scrolling is disabled by default. |
+| `Fill` | Always fills the container width, enlarging small images if necessary. |
+
+````csharp
+viewer.ImageResizeMode = MarkView.Avalonia.ImageResizeMode.Natural;
+````
+
+Set an app-wide default with a normal Avalonia style:
+
+````xml
+<Style Selector="mv|MarkdownViewer">
+  <Setter Property="ImageResizeMode" Value="Fill" />
+</Style>
+````
+
+**Explicit per-image sizing:** `![alt](url =WxH)` sets an exact size hint,
+independent of `ImageResizeMode`. It always acts as a ceiling — the image is
+scaled down to fit `WxH` if larger, but never enlarged past its native resolution
+to reach `WxH`, regardless of the active mode.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,19 +163,29 @@ the viewer's width:
 | `Natural` | No scaling — renders at native pixel size. May appear cropped if the image is wider than the viewer, since horizontal scrolling is disabled by default. |
 | `Fill` | Always fills the container width, enlarging small images if necessary. |
 
-````csharp
+```csharp
 viewer.ImageResizeMode = MarkView.Avalonia.ImageResizeMode.Natural;
-````
+```
 
 Set an app-wide default with a normal Avalonia style:
 
-````xml
+```xml
 <Style Selector="mv|MarkdownViewer">
   <Setter Property="ImageResizeMode" Value="Fill" />
 </Style>
-````
+```
 
-**Explicit per-image sizing:** `![alt](url =WxH)` sets an exact size hint,
+**Explicit per-image sizing:** `![alt](url =WxH)` sets a maximum size hint,
 independent of `ImageResizeMode`. It always acts as a ceiling — the image is
 scaled down to fit `WxH` if larger, but never enlarged past its native resolution
 to reach `WxH`, regardless of the active mode.
+
+**Note:** images are no longer capped at 800px by the theme — they scale to the
+container width instead (see `ScaleDownToFit` above). To restore the previous
+fixed cap, add your own style:
+
+```xml
+<Style Selector="Image.markdown-image">
+  <Setter Property="MaxWidth" Value="800" />
+</Style>
+```

--- a/src/MarkView.Avalonia/ImageResizeMode.cs
+++ b/src/MarkView.Avalonia/ImageResizeMode.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace MarkView.Avalonia;
+
+/// <summary>
+/// Controls how images without an explicit "=WxH" size hint are scaled relative to
+/// their container. Has no effect on images that specify an explicit size — those
+/// always use <see cref="Avalonia.Media.StretchDirection.DownOnly"/> regardless of
+/// this setting.
+/// </summary>
+public enum ImageResizeMode
+{
+    /// <summary>
+    /// Scale down to fit the container width; never enlarge past the image's native
+    /// resolution. Default.
+    /// </summary>
+    ScaleDownToFit,
+
+    /// <summary>
+    /// No scaling — render at native pixel size. May appear cropped if the image is
+    /// wider than the viewer, since horizontal scrolling is disabled by default.
+    /// </summary>
+    Natural,
+
+    /// <summary>
+    /// Always fill the container width, enlarging small images if necessary.
+    /// </summary>
+    Fill,
+}

--- a/src/MarkView.Avalonia/MarkdownViewer.cs
+++ b/src/MarkView.Avalonia/MarkdownViewer.cs
@@ -67,6 +67,12 @@ public partial class MarkdownViewer : ContentControl
         AvaloniaProperty.Register<MarkdownViewer, Uri?>(nameof(Source));
 
     /// <summary>
+    /// Defines the <see cref="ImageResizeMode"/> property.
+    /// </summary>
+    public static readonly StyledProperty<ImageResizeMode> ImageResizeModeProperty =
+        AvaloniaProperty.Register<MarkdownViewer, ImageResizeMode>(nameof(ImageResizeMode), ImageResizeMode.ScaleDownToFit);
+
+    /// <summary>
     /// Gets or sets the Markdown text to render.
     /// </summary>
     public string? Markdown
@@ -106,6 +112,16 @@ public partial class MarkdownViewer : ContentControl
     }
 
     /// <summary>
+    /// Gets or sets how images without an explicit "=WxH" size hint are scaled
+    /// relative to their container. Defaults to <see cref="ImageResizeMode.ScaleDownToFit"/>.
+    /// </summary>
+    public ImageResizeMode ImageResizeMode
+    {
+        get => GetValue(ImageResizeModeProperty);
+        set => SetValue(ImageResizeModeProperty, value);
+    }
+
+    /// <summary>
     /// Extensions that customise the renderer before each render pass.
     /// Add entries before setting <see cref="Markdown"/> or assigning
     /// a new <see cref="Pipeline"/>; each extension's
@@ -137,6 +153,7 @@ public partial class MarkdownViewer : ContentControl
         PipelineProperty.Changed.AddClassHandler<MarkdownViewer>((x, _) => x.RenderMarkdown());
         BaseUriProperty.Changed.AddClassHandler<MarkdownViewer>((x, _) => x.RenderMarkdown());
         SourceProperty.Changed.AddClassHandler<MarkdownViewer>((x, _) => x.OnSourceChanged());
+        ImageResizeModeProperty.Changed.AddClassHandler<MarkdownViewer>((x, _) => x.RenderMarkdown());
         FocusableProperty.OverrideDefaultValue<MarkdownViewer>(true);
     }
 
@@ -229,7 +246,11 @@ public partial class MarkdownViewer : ContentControl
         var markdownText = ImageSizePreprocessorRegex().Replace(markdown, "$1$2 \"=$3\"$4");
         var document = Markdig.Markdown.Parse(markdownText, pipeline);
 
-        var renderer = new AvaloniaRenderer { BaseUri = BaseUri ?? InferBaseUri(Source) };
+        var renderer = new AvaloniaRenderer
+        {
+            BaseUri = BaseUri ?? InferBaseUri(Source),
+            ImageResizeMode = ImageResizeMode,
+        };
         renderer.LinkClicked += OnLinkClicked;
 
         // Extensions register before pipeline.Setup() so they can swap renderers.

--- a/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
@@ -35,6 +35,12 @@ public class AvaloniaRenderer : RendererBase
     public Uri? BaseUri { get; set; }
 
     /// <summary>
+    /// Controls how images without an explicit "=WxH" size hint are scaled.
+    /// Defaults to <see cref="MarkView.Avalonia.ImageResizeMode.ScaleDownToFit"/>.
+    /// </summary>
+    public ImageResizeMode ImageResizeMode { get; set; } = ImageResizeMode.ScaleDownToFit;
+
+    /// <summary>
     /// Generates GitHub-style anchor IDs for headings. Reset on each render pass.
     /// </summary>
     public SlugGenerator SlugGenerator { get; } = new();

--- a/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
@@ -81,6 +81,8 @@ public sealed partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInli
                 image.Width = int.Parse(dim.Groups[1].Value, CultureInfo.InvariantCulture);
                 image.Height = int.Parse(dim.Groups[2].Value, CultureInfo.InvariantCulture);
                 image.Stretch = Stretch.Uniform;
+                // "=WxH" is a ceiling, never a forced upscale, regardless of ImageResizeMode.
+                image.StretchDirection = StretchDirection.DownOnly;
             }
         }
 

--- a/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
@@ -78,8 +78,11 @@ public sealed partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInli
             var dim = DimensionTitleRegex().Match(obj.Title);
             if (dim.Success)
             {
-                image.Width = int.Parse(dim.Groups[1].Value, CultureInfo.InvariantCulture);
-                image.Height = int.Parse(dim.Groups[2].Value, CultureInfo.InvariantCulture);
+                // MaxWidth/MaxHeight (not Width/Height) so the layout box itself shrinks to
+                // the image's native resolution when it's smaller than the requested size —
+                // Width/Height would hard-pin the arranged size regardless of StretchDirection.
+                image.MaxWidth = int.Parse(dim.Groups[1].Value, CultureInfo.InvariantCulture);
+                image.MaxHeight = int.Parse(dim.Groups[2].Value, CultureInfo.InvariantCulture);
                 image.Stretch = Stretch.Uniform;
                 // "=WxH" is a ceiling, never a forced upscale, regardless of ImageResizeMode.
                 image.StretchDirection = StretchDirection.DownOnly;

--- a/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/LinkInlineRenderer.cs
@@ -65,7 +65,8 @@ public sealed partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInli
             if (c is LiteralInline literal) sb.Append(literal.Content.AsSpan());
         var altText = sb.ToString();
 
-        var image = new Image { Stretch = Stretch.None };
+        var image = new Image();
+        ApplyResizeMode(image, renderer.ImageResizeMode);
         image.Classes.Add("markdown-image");
 
         if (!string.IsNullOrEmpty(altText))
@@ -102,6 +103,25 @@ public sealed partial class LinkInlineRenderer : AvaloniaObjectRenderer<LinkInli
         image.DetachedFromLogicalTree += (_, _) => cts?.Cancel();
 
         renderer.WriteInline(image);
+    }
+
+    private static void ApplyResizeMode(Image image, ImageResizeMode mode)
+    {
+        switch (mode)
+        {
+            case ImageResizeMode.Natural:
+                image.Stretch = Stretch.None;
+                break;
+            case ImageResizeMode.Fill:
+                image.Stretch = Stretch.Uniform;
+                image.StretchDirection = StretchDirection.Both;
+                break;
+            case ImageResizeMode.ScaleDownToFit:
+            default:
+                image.Stretch = Stretch.Uniform;
+                image.StretchDirection = StretchDirection.DownOnly;
+                break;
+        }
     }
 
     private static async Task LoadImageAsync(

--- a/src/MarkView.Avalonia/Themes/MarkdownTheme.axaml
+++ b/src/MarkView.Avalonia/Themes/MarkdownTheme.axaml
@@ -134,8 +134,6 @@
 
   <!-- Images -->
   <Style Selector="Image.markdown-image">
-    <Setter Property="MaxWidth" Value="800" />
-    <Setter Property="Stretch" Value="Uniform" />
     <Setter Property="Margin" Value="0,4" />
   </Style>
 

--- a/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
@@ -117,6 +117,11 @@ public class ImageTests : RenderTestBase
             => Task.FromResult<IImage?>(image);
     }
 
+    private sealed class FakeBitmapExtension(string url, IImage image) : IMarkViewExtension
+    {
+        public void Register(AvaloniaRenderer renderer) => renderer.ImageLoaders.Insert(0, new FakeBitmapLoader(url, image));
+    }
+
     private static async Task PumpUntilSettledAsync()
     {
         for (var i = 0; i < 20; i++)
@@ -266,6 +271,35 @@ public class ImageTests : RenderTestBase
 
         Assert.Equal(100, image!.Bounds.Width, 0);
         Assert.Equal(75, image.Bounds.Height, 0);
+    }
+
+    [AvaloniaFact]
+    public void MarkdownViewer_ImageResizeMode_defaults_to_ScaleDownToFit()
+    {
+        var viewer = new MarkdownViewer();
+        Assert.Equal(ImageResizeMode.ScaleDownToFit, viewer.ImageResizeMode);
+    }
+
+    [AvaloniaFact]
+    public async Task MarkdownViewer_ImageResizeMode_flows_through_to_rendered_image()
+    {
+        var smallImage = new RenderTargetBitmap(new PixelSize(200, 150));
+        var viewer = new MarkdownViewer { Width = 600, Height = 400, ImageResizeMode = ImageResizeMode.Fill };
+        // Extensions must be registered before Markdown is set — MarkdownViewer renders
+        // synchronously when Markdown changes, and extensions register at render time.
+        viewer.Extensions.Add(new FakeBitmapExtension("fake://small.png", smallImage));
+        viewer.Markdown = "![small](fake://small.png)";
+
+        var window = new Window { Width = 600, Height = 400, Content = viewer };
+        window.Show();
+        await PumpUntilSettledAsync();
+
+        var image = FindFirst<Image>(viewer);
+        Assert.NotNull(image);
+        Assert.Equal(Stretch.Uniform, image!.Stretch);
+        Assert.Equal(StretchDirection.Both, image.StretchDirection);
+        Assert.Equal(600, image.Bounds.Width, 0);
+        Assert.Equal(450, image.Bounds.Height, 0);
     }
 
     private static T? FindFirst<T>(Control root) where T : Control

--- a/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
@@ -82,7 +82,7 @@ public class ImageTests : RenderTestBase
     }
 
     [AvaloniaFact]
-    public void Image_size_hint_sets_Width_and_Height()
+    public void Image_size_hint_sets_MaxWidth_and_MaxHeight()
     {
         var viewer = new MarkdownViewer();
         viewer.Markdown = "![logo](https://example.com/logo.png =200x100)";
@@ -92,8 +92,8 @@ public class ImageTests : RenderTestBase
         var panel = Assert.IsType<StackPanel>(contentGrid.Children[0]);
         var image = FindFirst<Image>(panel);
         Assert.NotNull(image);
-        Assert.Equal(200.0, image.Width);
-        Assert.Equal(100.0, image.Height);
+        Assert.Equal(200.0, image.MaxWidth);
+        Assert.Equal(100.0, image.MaxHeight);
     }
 
     [AvaloniaFact]
@@ -235,8 +235,8 @@ public class ImageTests : RenderTestBase
             var renderer = RenderDocument("![img](fake://native.png \"=800x600\")", mode, loader);
             var image = FindFirst<Image>(renderer.RootPanel);
             Assert.NotNull(image);
-            Assert.Equal(800.0, image!.Width);
-            Assert.Equal(600.0, image.Height);
+            Assert.Equal(800.0, image!.MaxWidth);
+            Assert.Equal(600.0, image.MaxHeight);
             Assert.Equal(Stretch.Uniform, image.Stretch);
             Assert.Equal(StretchDirection.DownOnly, image.StretchDirection);
 

--- a/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
@@ -224,6 +224,50 @@ public class ImageTests : RenderTestBase
         Assert.Equal(450, image.Bounds.Height, 0);
     }
 
+    [AvaloniaFact]
+    public async Task Explicit_size_never_upscales_past_native_resolution_regardless_of_mode()
+    {
+        foreach (var mode in new[] { ImageResizeMode.ScaleDownToFit, ImageResizeMode.Fill, ImageResizeMode.Natural })
+        {
+            var nativeImage = new RenderTargetBitmap(new PixelSize(400, 300));
+            var loader = new FakeBitmapLoader("fake://native.png", nativeImage);
+            // Explicit request (800x600) is larger than native (400x300).
+            var renderer = RenderDocument("![img](fake://native.png \"=800x600\")", mode, loader);
+            var image = FindFirst<Image>(renderer.RootPanel);
+            Assert.NotNull(image);
+            Assert.Equal(800.0, image!.Width);
+            Assert.Equal(600.0, image.Height);
+            Assert.Equal(Stretch.Uniform, image.Stretch);
+            Assert.Equal(StretchDirection.DownOnly, image.StretchDirection);
+
+            var window = new Window { Width = 1000, Height = 800, Content = renderer.RootPanel };
+            window.Show();
+            await PumpUntilSettledAsync();
+
+            // Capped at native resolution — never upscaled to the requested 800x600.
+            Assert.Equal(400, image.Bounds.Width, 0);
+            Assert.Equal(300, image.Bounds.Height, 0);
+        }
+    }
+
+    [AvaloniaFact]
+    public async Task Explicit_size_downscale_request_is_honoured()
+    {
+        var nativeImage = new RenderTargetBitmap(new PixelSize(400, 300));
+        var loader = new FakeBitmapLoader("fake://native.png", nativeImage);
+        // Explicit request (100x75) is smaller than native (400x300) — a plain downscale.
+        var renderer = RenderDocument("![img](fake://native.png \"=100x75\")", ImageResizeMode.ScaleDownToFit, loader);
+        var image = FindFirst<Image>(renderer.RootPanel);
+        Assert.NotNull(image);
+
+        var window = new Window { Width = 1000, Height = 800, Content = renderer.RootPanel };
+        window.Show();
+        await PumpUntilSettledAsync();
+
+        Assert.Equal(100, image!.Bounds.Width, 0);
+        Assert.Equal(75, image.Bounds.Height, 0);
+    }
+
     private static T? FindFirst<T>(Control root) where T : Control
     {
         if (root is T match) return match;

--- a/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
@@ -5,7 +5,6 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Media;
-using Avalonia.Media.Imaging;
 using Avalonia.Threading;
 
 using MarkView.Avalonia;
@@ -117,6 +116,19 @@ public class ImageTests : RenderTestBase
             => Task.FromResult<IImage?>(image);
     }
 
+    /// <summary>
+    /// Minimal <see cref="IImage"/> stand-in reporting a fixed pixel size, used in place of
+    /// a real <c>RenderTargetBitmap</c> in layout tests. A real bitmap calls into the
+    /// platform's render interface to allocate an actual rendering surface — unnecessary
+    /// (and a source of platform-specific flakiness in headless CI) when the test only
+    /// needs Source.Size for Stretch/layout math, never an actual paint.
+    /// </summary>
+    private sealed class FakeImage(double width, double height) : IImage
+    {
+        public Size Size { get; } = new Size(width, height);
+        public void Draw(DrawingContext context, Rect sourceRect, Rect destRect) { }
+    }
+
     private sealed class FakeBitmapExtension(string url, IImage image) : IMarkViewExtension
     {
         public void Register(AvaloniaRenderer renderer) => renderer.ImageLoaders.Insert(0, new FakeBitmapLoader(url, image));
@@ -181,7 +193,7 @@ public class ImageTests : RenderTestBase
     [AvaloniaFact]
     public async Task ScaleDownToFit_large_image_scales_down_to_container_width()
     {
-        var bigImage = new RenderTargetBitmap(new PixelSize(1600, 1200));
+        var bigImage = new FakeImage(1600, 1200);
         var loader = new FakeBitmapLoader("fake://big.png", bigImage);
         var renderer = RenderDocument("![big](fake://big.png)", ImageResizeMode.ScaleDownToFit, loader);
 
@@ -198,7 +210,7 @@ public class ImageTests : RenderTestBase
     [AvaloniaFact]
     public async Task ScaleDownToFit_small_image_does_not_upscale()
     {
-        var smallImage = new RenderTargetBitmap(new PixelSize(200, 150));
+        var smallImage = new FakeImage(200, 150);
         var loader = new FakeBitmapLoader("fake://small.png", smallImage);
         var renderer = RenderDocument("![small](fake://small.png)", ImageResizeMode.ScaleDownToFit, loader);
 
@@ -215,7 +227,7 @@ public class ImageTests : RenderTestBase
     [AvaloniaFact]
     public async Task Fill_mode_upscales_small_image_to_container_width()
     {
-        var smallImage = new RenderTargetBitmap(new PixelSize(200, 150));
+        var smallImage = new FakeImage(200, 150);
         var loader = new FakeBitmapLoader("fake://small.png", smallImage);
         var renderer = RenderDocument("![small](fake://small.png)", ImageResizeMode.Fill, loader);
 
@@ -234,7 +246,7 @@ public class ImageTests : RenderTestBase
     {
         foreach (var mode in new[] { ImageResizeMode.ScaleDownToFit, ImageResizeMode.Fill, ImageResizeMode.Natural })
         {
-            var nativeImage = new RenderTargetBitmap(new PixelSize(400, 300));
+            var nativeImage = new FakeImage(400, 300);
             var loader = new FakeBitmapLoader("fake://native.png", nativeImage);
             // Explicit request (800x600) is larger than native (400x300).
             var renderer = RenderDocument("![img](fake://native.png \"=800x600\")", mode, loader);
@@ -258,7 +270,7 @@ public class ImageTests : RenderTestBase
     [AvaloniaFact]
     public async Task Explicit_size_downscale_request_is_honoured()
     {
-        var nativeImage = new RenderTargetBitmap(new PixelSize(400, 300));
+        var nativeImage = new FakeImage(400, 300);
         var loader = new FakeBitmapLoader("fake://native.png", nativeImage);
         // Explicit request (100x75) is smaller than native (400x300) — a plain downscale.
         var renderer = RenderDocument("![img](fake://native.png \"=100x75\")", ImageResizeMode.ScaleDownToFit, loader);
@@ -283,7 +295,7 @@ public class ImageTests : RenderTestBase
     [AvaloniaFact]
     public async Task MarkdownViewer_ImageResizeMode_flows_through_to_rendered_image()
     {
-        var smallImage = new RenderTargetBitmap(new PixelSize(200, 150));
+        var smallImage = new FakeImage(200, 150);
         var viewer = new MarkdownViewer { Width = 600, Height = 400, ImageResizeMode = ImageResizeMode.Fill };
         // Extensions must be registered before Markdown is set — MarkdownViewer renders
         // synchronously when Markdown changes, and extensions register at render time.
@@ -305,7 +317,7 @@ public class ImageTests : RenderTestBase
     [AvaloniaFact]
     public async Task MarkdownViewer_default_ScaleDownToFit_flows_through_to_rendered_image()
     {
-        var bigImage = new RenderTargetBitmap(new PixelSize(1600, 1200));
+        var bigImage = new FakeImage(1600, 1200);
         var viewer = new MarkdownViewer { Width = 600, Height = 400 };
         // Extensions must be registered before Markdown is set — MarkdownViewer renders
         // synchronously when Markdown changes, and extensions register at render time.

--- a/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Nicolas Musset
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
 
 using MarkView.Avalonia;
 using MarkView.Avalonia.Extensions;
@@ -105,6 +108,120 @@ public class ImageTests : RenderTestBase
         pipeline.Setup(renderer);
         renderer.Render(document);
         // No assertion beyond "doesn't throw"
+    }
+
+    private sealed class FakeBitmapLoader(string url, IImage image) : IImageLoader
+    {
+        public bool CanLoad(string checkUrl) => checkUrl == url;
+        public Task<IImage?> LoadAsync(string checkUrl, CancellationToken cancellationToken = default)
+            => Task.FromResult<IImage?>(image);
+    }
+
+    private static async Task PumpUntilSettledAsync()
+    {
+        for (var i = 0; i < 20; i++)
+        {
+            Dispatcher.UIThread.RunJobs();
+            await Task.Delay(10);
+        }
+    }
+
+    /// <summary>
+    /// Parses and renders markdown with the given mode/loader, returning the renderer so
+    /// callers can either inspect renderer.RootPanel directly or host it under a Window
+    /// for layout (mirrors the existing Custom_image_loader_is_invoked_for_matching_url
+    /// pattern, which already hosts renderer.RootPanel directly under a Window).
+    /// </summary>
+    private static AvaloniaRenderer RenderDocument(string markdown, ImageResizeMode mode, IImageLoader? loader = null)
+    {
+        var pipeline = new Markdig.MarkdownPipelineBuilder().Build();
+        var document = Markdig.Markdown.Parse(markdown, pipeline);
+        var renderer = new AvaloniaRenderer { ImageResizeMode = mode };
+        if (loader is not null)
+            renderer.ImageLoaders.Insert(0, loader);
+        pipeline.Setup(renderer);
+        renderer.Render(document);
+        return renderer;
+    }
+
+    [AvaloniaFact]
+    public void ScaleDownToFit_mode_sets_Uniform_and_DownOnly()
+    {
+        var renderer = RenderDocument("![img](https://example.com/image.png)", ImageResizeMode.ScaleDownToFit);
+        var image = FindFirst<Image>(renderer.RootPanel);
+        Assert.NotNull(image);
+        Assert.Equal(Stretch.Uniform, image!.Stretch);
+        Assert.Equal(StretchDirection.DownOnly, image.StretchDirection);
+    }
+
+    [AvaloniaFact]
+    public void Natural_mode_sets_Stretch_None()
+    {
+        var renderer = RenderDocument("![img](https://example.com/image.png)", ImageResizeMode.Natural);
+        var image = FindFirst<Image>(renderer.RootPanel);
+        Assert.NotNull(image);
+        Assert.Equal(Stretch.None, image!.Stretch);
+    }
+
+    [AvaloniaFact]
+    public void Fill_mode_sets_Uniform_and_Both()
+    {
+        var renderer = RenderDocument("![img](https://example.com/image.png)", ImageResizeMode.Fill);
+        var image = FindFirst<Image>(renderer.RootPanel);
+        Assert.NotNull(image);
+        Assert.Equal(Stretch.Uniform, image!.Stretch);
+        Assert.Equal(StretchDirection.Both, image.StretchDirection);
+    }
+
+    [AvaloniaFact]
+    public async Task ScaleDownToFit_large_image_scales_down_to_container_width()
+    {
+        var bigImage = new RenderTargetBitmap(new PixelSize(1600, 1200));
+        var loader = new FakeBitmapLoader("fake://big.png", bigImage);
+        var renderer = RenderDocument("![big](fake://big.png)", ImageResizeMode.ScaleDownToFit, loader);
+
+        var window = new Window { Width = 600, Height = 400, Content = renderer.RootPanel };
+        window.Show();
+        await PumpUntilSettledAsync();
+
+        var image = FindFirst<Image>(renderer.RootPanel);
+        Assert.NotNull(image);
+        Assert.Equal(600, image!.Bounds.Width, 0);
+        Assert.Equal(450, image.Bounds.Height, 0);
+    }
+
+    [AvaloniaFact]
+    public async Task ScaleDownToFit_small_image_does_not_upscale()
+    {
+        var smallImage = new RenderTargetBitmap(new PixelSize(200, 150));
+        var loader = new FakeBitmapLoader("fake://small.png", smallImage);
+        var renderer = RenderDocument("![small](fake://small.png)", ImageResizeMode.ScaleDownToFit, loader);
+
+        var window = new Window { Width = 1200, Height = 400, Content = renderer.RootPanel };
+        window.Show();
+        await PumpUntilSettledAsync();
+
+        var image = FindFirst<Image>(renderer.RootPanel);
+        Assert.NotNull(image);
+        Assert.Equal(200, image!.Bounds.Width, 0);
+        Assert.Equal(150, image.Bounds.Height, 0);
+    }
+
+    [AvaloniaFact]
+    public async Task Fill_mode_upscales_small_image_to_container_width()
+    {
+        var smallImage = new RenderTargetBitmap(new PixelSize(200, 150));
+        var loader = new FakeBitmapLoader("fake://small.png", smallImage);
+        var renderer = RenderDocument("![small](fake://small.png)", ImageResizeMode.Fill, loader);
+
+        var window = new Window { Width = 600, Height = 400, Content = renderer.RootPanel };
+        window.Show();
+        await PumpUntilSettledAsync();
+
+        var image = FindFirst<Image>(renderer.RootPanel);
+        Assert.NotNull(image);
+        Assert.Equal(600, image!.Bounds.Width, 0);
+        Assert.Equal(450, image.Bounds.Height, 0);
     }
 
     private static T? FindFirst<T>(Control root) where T : Control

--- a/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
@@ -302,6 +302,26 @@ public class ImageTests : RenderTestBase
         Assert.Equal(450, image.Bounds.Height, 0);
     }
 
+    [AvaloniaFact]
+    public async Task MarkdownViewer_default_ScaleDownToFit_flows_through_to_rendered_image()
+    {
+        var bigImage = new RenderTargetBitmap(new PixelSize(1600, 1200));
+        var viewer = new MarkdownViewer { Width = 600, Height = 400 };
+        // Extensions must be registered before Markdown is set — MarkdownViewer renders
+        // synchronously when Markdown changes, and extensions register at render time.
+        viewer.Extensions.Add(new FakeBitmapExtension("fake://big.png", bigImage));
+        viewer.Markdown = "![big](fake://big.png)";
+
+        var window = new Window { Width = 600, Height = 400, Content = viewer };
+        window.Show();
+        await PumpUntilSettledAsync();
+
+        var image = FindFirst<Image>(viewer);
+        Assert.NotNull(image);
+        Assert.Equal(600, image!.Bounds.Width, 0);
+        Assert.Equal(450, image.Bounds.Height, 0);
+    }
+
     private static T? FindFirst<T>(Control root) where T : Control
     {
         if (root is T match) return match;

--- a/tests/MarkView.Avalonia.Tests/Rendering/AvaloniaRendererTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Rendering/AvaloniaRendererTests.cs
@@ -33,4 +33,18 @@ public class AvaloniaRendererTests
         var result = renderer.ResolveUrl("images/pic.png");
         Assert.Equal("images/pic.png", result);
     }
+
+    [AvaloniaFact]
+    public void ImageResizeMode_defaults_to_ScaleDownToFit()
+    {
+        var renderer = new AvaloniaRenderer();
+        Assert.Equal(ImageResizeMode.ScaleDownToFit, renderer.ImageResizeMode);
+    }
+
+    [AvaloniaFact]
+    public void ImageResizeMode_can_be_set()
+    {
+        var renderer = new AvaloniaRenderer { ImageResizeMode = ImageResizeMode.Fill };
+        Assert.Equal(ImageResizeMode.Fill, renderer.ImageResizeMode);
+    }
 }

--- a/tests/MarkView.Avalonia.Tests/Rendering/MarkdownThemeTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Rendering/MarkdownThemeTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Xml.Linq;
+
+using Xunit;
+
+namespace MarkView.Avalonia.Tests.Rendering;
+
+public class MarkdownThemeTests
+{
+    /// <summary>
+    /// Walks up from the test assembly's output directory to the repo root (identified
+    /// by Directory.Build.props, which exists only at the root) rather than hardcoding a
+    /// fixed number of ".." segments, since that count depends on the build configuration
+    /// and target framework folder names.
+    /// </summary>
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Directory.Build.props")))
+            dir = dir.Parent;
+        if (dir is null)
+            throw new InvalidOperationException("Could not locate repo root (Directory.Build.props not found in any ancestor).");
+        return dir.FullName;
+    }
+
+    [Fact]
+    public void Image_markdown_image_style_has_no_static_MaxWidth()
+    {
+        var themePath = Path.Combine(FindRepoRoot(), "src", "MarkView.Avalonia", "Themes", "MarkdownTheme.axaml");
+        var doc = XDocument.Load(themePath);
+        XNamespace avalonia = "https://github.com/avaloniaui";
+
+        var style = doc.Descendants(avalonia + "Style")
+            .FirstOrDefault(s => (string?)s.Attribute("Selector") == "Image.markdown-image");
+
+        Assert.NotNull(style);
+        var maxWidthSetter = style!.Elements(avalonia + "Setter")
+            .FirstOrDefault(s => (string?)s.Attribute("Property") == "MaxWidth");
+        Assert.Null(maxWidthSetter);
+    }
+}


### PR DESCRIPTION
## Summary

- New `ImageResizeMode` enum (`ScaleDownToFit` default, `Natural`, `Fill`) and a matching `MarkdownViewer.ImageResizeMode` property
- Images without an explicit size now scale correctly to their real container width instead of cropping (root cause: `Stretch.None` default didn't scale; fixed via `Stretch`/`StretchDirection` mapping)
- Explicit `=WxH` sizing now uses `MaxWidth`/`MaxHeight` instead of `Width`/`Height` so it acts as a true ceiling — never upscales past native resolution, in any mode
- Redundant theme `MaxWidth="800"` removed; documented with a restore snippet for anyone relying on the old cap
- `docs/configuration.md` updated with the new property and an "Image sizing" section

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [x] Documentation
- [ ] CI / build

## Test plan

- [x] `dotnet test` — all tests pass
- [ ] Manual smoke-test in the demo app