### PR TITLE
docs: document =WxH image sizing and fix preprocessor skipping code spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Per-instance `Pipeline` and `Extensions` take precedence over the defaults; an e
 | Ordered and unordered lists | CommonMark, tight and loose |
 | Links and autolinks | CommonMark + extension |
 | Images | CommonMark, remote URLs loaded async |
+| Image sizing | `![alt](url =WxH)` — inline pixel dimensions, e.g. `=80x80` |
 | Thematic breaks | CommonMark |
 | Hard line breaks | CommonMark (`\` or two spaces) |
 | HTML `<br>` / `<br />` | Rendered as line break |

--- a/samples/MarkView.Avalonia.Demo/Assets/showcase.md
+++ b/samples/MarkView.Avalonia.Demo/Assets/showcase.md
@@ -128,9 +128,23 @@ print(data_uri)
 
 ## Bitmap Image
 
-The image below is an Avalonia resource embedded in the demo app (`avares://` URI):
+The images below use relative paths — they resolve against the `BaseUri` that MarkView infers automatically from the `Source` location (here, `avares://MarkView.Avalonia.Demo/Assets/`).
 
-![Avalonia Logo](avares://MarkView.Avalonia.Demo/Assets/avalonia-logo.png =80x80)
+Two equivalent syntaxes are supported for specifying image dimensions:
+
+| Form | Syntax | Notes |
+|------|--------|-------|
+| Quoted title | `![alt](url "=WxH")` | Valid CommonMark — portable across renderers (others show the title as a tooltip) |
+| Shorthand | `![alt](url =WxH)` | MarkView-only convenience; preprocessed to the quoted form before parsing |
+
+The table below shows the same image at different sizes:
+
+| Syntax | Result |
+|--------|--------|
+| `![alt](url "=40x40")` | ![Avalonia Logo](avalonia-logo.png "=40x40") 40×40 |
+| `![alt](url "=80x80")` | ![Avalonia Logo](avalonia-logo.png "=80x80") 80×80 |
+| `![alt](url "=160x160")` | ![Avalonia Logo](avalonia-logo.png "=160x160") 160×160 |
+| `![alt](url)` (no size) | ![Avalonia Logo](avalonia-logo.png) natural size |
 
 ---
 

--- a/src/MarkView.Avalonia/MarkdownViewer.cs
+++ b/src/MarkView.Avalonia/MarkdownViewer.cs
@@ -23,9 +23,10 @@ namespace MarkView.Avalonia;
 /// </summary>
 public partial class MarkdownViewer : ContentControl
 {
-    // Converts the non-standard "![alt](url =WxH)" size hint to the title slot so Markdig
-    // can parse it: "![alt](url "=WxH")". CommonMark has no image-size syntax.
-    [GeneratedRegex(@"(\!\[[^\]]*\]\()([^\s\)]+)\s+=(\d+x\d+)(\))")]
+    // Matches a backtick code span (group 1) or the non-standard "![alt](url =WxH)" size hint
+    // (groups 2-5). Code spans are passed through unchanged so literal syntax examples in
+    // documentation are not mangled.
+    [GeneratedRegex(@"(`+)[\s\S]*?\1|(\!\[[^\]]*\]\()([^\s\)]+)\s+=(\d+x\d+)(\))")]
     private static partial Regex ImageSizePreprocessorRegex();
 
     private static readonly Cursor HandCursor = new(StandardCursorType.Hand);
@@ -226,7 +227,10 @@ public partial class MarkdownViewer : ContentControl
         }
 
         var pipeline = Pipeline ?? MarkdownViewerDefaults.Pipeline ?? DefaultPipeline;
-        var markdownText = ImageSizePreprocessorRegex().Replace(markdown, "$1$2 \"=$3\"$4");
+        var markdownText = ImageSizePreprocessorRegex().Replace(markdown, static m =>
+            m.Groups[1].Success
+                ? m.Value
+                : $"{m.Groups[2].Value}{m.Groups[3].Value} \"={m.Groups[4].Value}\"{m.Groups[5].Value}");
         var document = Markdig.Markdown.Parse(markdownText, pipeline);
 
         var renderer = new AvaloniaRenderer { BaseUri = BaseUri ?? InferBaseUri(Source) };


### PR DESCRIPTION
## Summary

- Add image sizing row to README features table
- Expand showcase Bitmap Image section with syntax comparison (quoted vs shorthand) and size demonstration using relative paths + BaseUri note
- Fix ImageSizePreprocessorRegex to skip backtick code spans so literal syntax examples in documentation are not mangled by the preprocessor

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [x] Documentation
- [ ] CI / build

## Test plan

- [x] `dotnet test` — all tests pass
- [x] Manual smoke-test in the demo app