### PR TITLE
perf: seal leaf classes for JIT devirtualization

### DIFF
--- a/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
@@ -253,7 +253,7 @@ public class AvaloniaRenderer : RendererBase
 /// <summary>
 /// Event args for hyperlink click events.
 /// </summary>
-public class LinkClickedEventArgs(string url) : RoutedEventArgs
+public sealed class LinkClickedEventArgs(string url) : RoutedEventArgs
 {
     /// <summary>
     /// The URL of the clicked link.

--- a/src/MarkView.Avalonia/Rendering/Inlines/MarkdownHyperlink.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/MarkdownHyperlink.cs
@@ -9,7 +9,7 @@ namespace MarkView.Avalonia.Rendering.Inlines;
 /// A <see cref="Span"/> that carries hyperlink metadata for click detection
 /// by the parent <see cref="MarkdownSelectableTextBlock"/>.
 /// </summary>
-public class MarkdownHyperlink : Span
+public sealed class MarkdownHyperlink : Span
 {
     public Uri? NavigateUri { get; set; }
     public string? Title { get; set; }


### PR DESCRIPTION
## Summary

Seal LinkClickedEventArgs and MarkdownHyperlink, two leaf classes that are never subclassed (event args and an internal-use Span carrying hyperlink metadata). Sealing lets the JIT devirtualize and inline virtual calls.

Other public types (MarkdownViewer, AvaloniaRenderer, MarkdownSelectableTextBlock, SlugGenerator) are left open as intentional extension points.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactoring (no behaviour change)
- [ ] Documentation
- [ ] CI / build

## Test plan

- [x] `dotnet test` — all tests pass
- [x] Manual smoke-test in the demo app