### PR TITLE
feat: add more markdig extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,12 @@ viewer.Pipeline = new MarkdownPipelineBuilder()
 Convenience methods configure a pipeline with a single opt-in feature:
 
 ```csharp
-viewer.UseFootnotes();
-viewer.UseAlertBlocks();
 viewer.UseAbbreviations();
+viewer.UseAlertBlocks();
+viewer.UseCitations();
 viewer.UseFigures();
+viewer.UseFootnotes();
+viewer.UseHardlineBreaks();
 viewer.UseMediaLinks();
 ```
 
@@ -136,6 +138,9 @@ Per-instance `Pipeline` and `Extensions` take precedence over the defaults; an e
 | Pipe tables | GFM-style `\| col \| col \|` |
 | Grid tables | RST-style grid tables |
 | Autolinks | bare `https://…` URLs |
+| Emoji shortcodes | `:rocket:` → 🚀 (ASCII smileys like `:)` are intentionally left as plain text) |
+| CJK-friendly emphasis | parser-only fix for emphasis next to CJK punctuation |
+| YAML front matter | `---` metadata block at the top of a document is parsed and hidden |
 
 ### Opt-in extensions
 
@@ -143,10 +148,12 @@ These require adding `.UseXxx()` to the pipeline (see [Extension Methods](#exten
 
 | Feature | Activation | Syntax |
 |---------|-----------|--------|
-| Footnotes | `UseFootnotes()` | `[^1]` / `[^1]: …` |
-| GitHub alert blocks | `UseAlertBlocks()` | `> [!NOTE]` etc. |
 | Abbreviations | `UseAbbreviations()` | `*[HTML]: …` |
+| GitHub alert blocks | `UseAlertBlocks()` | `> [!NOTE]` etc. |
+| Citations | `UseCitations()` | `""quoted text""` |
 | Figures | `UseFigures()` | `^^^` / `^^^ caption` |
+| Footnotes | `UseFootnotes()` | `[^1]` / `[^1]: …` |
+| Hardline breaks | `UseHardlineBreaks()` | every soft line break renders as a hard break |
 | YouTube embeds | `UseMediaLinks()` | `![title](https://youtu.be/…)` |
 
 ## Extension Packages

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,36 +17,44 @@ The pipeline controls which Markdig extensions parse the input markdown. Build o
 
 ```csharp
 viewer.Pipeline = new MarkdownPipelineBuilder()
-    .UseSupportedExtensions()   // bold, italic, strikethrough, subscript, superscript,
-                                // underline, highlight, task lists, tables, autolinks
-    .UseFootnotes()             // [^1] footnotes
-    .UseAlertBlocks()           // > [!NOTE] / > [!WARNING] etc.
+    .UseSupportedExtensions()   // bold, italic, strikethrough, subscript, superscript, underline,
+                                // highlight, task lists, tables, autolinks, emoji shortcodes,
+                                // CJK-friendly emphasis, YAML front matter (hidden)
     .UseAbbreviations()         // *[HTML]: HyperText Markup Language
+    .UseAlertBlocks()           // > [!NOTE] / > [!WARNING] etc.
+    .UseCitations()             // ""quoted text""
     .UseFigures()               // ^^^ figure blocks
+    .UseFootnotes()             // [^1] footnotes
+    .UseHardlineBreaks()        // every soft line break renders as a hard break
     .UseMediaLinks()            // YouTube thumbnail embeds
     .Build();
 ```
 
-`UseSupportedExtensions()` is a MarkView.Avalonia helper that enables the subset of Markdig extensions that have native renderers in the library:
+`UseSupportedExtensions()` is a MarkView.Avalonia helper that enables the subset of Markdig extensions that have native renderers in the library, or that are safe to enable unconditionally because they can't surprise ordinary markdown:
 
 - `EmphasisExtras` — strikethrough `~~`, subscript `~`, superscript `^`, underline `++`, highlight `==`
 - `AutoLinks` — bare URL auto-linking
 - `GridTables` — RST-style grid tables
 - `PipeTables` — GFM pipe tables
 - `TaskLists` — `- [x]` checkboxes
+- `CjkFriendlyEmphasis` — parser-only fix for emphasis next to CJK punctuation
+- `YamlFrontMatter` — `---` metadata block at the top of a document is parsed and hidden, not shown as garbled text
+- `EmojiAndSmiley` (shortcodes only) — `:rocket:` renders as 🚀; ASCII smileys (`:)`) are intentionally left as plain text, since silently rewriting them is more surprising than useful
 
-The five opt-in extensions above (`UseFootnotes()` etc.) are thin wrappers around the corresponding Markdig extension; they are defined in `MarkdownExtensions.cs` and re-exported as extension methods on `MarkdownPipelineBuilder`.
+The seven opt-in extensions above (`UseFootnotes()` etc.) are thin wrappers around the corresponding Markdig extension; they are defined in `MarkdownExtensions.cs` and re-exported as extension methods on `MarkdownPipelineBuilder`.
 
 ### Convenience extension methods
 
 For simple use cases, call a single method instead of building the pipeline manually:
 
 ```csharp
-viewer.UseFootnotes();     // pipeline + footnote rendering
-viewer.UseAlertBlocks();   // pipeline + alert block rendering
-viewer.UseAbbreviations(); // pipeline + abbreviation tooltips
-viewer.UseFigures();       // pipeline + figure blocks
-viewer.UseMediaLinks();    // pipeline + YouTube thumbnails
+viewer.UseAbbreviations();  // pipeline + abbreviation tooltips
+viewer.UseAlertBlocks();    // pipeline + alert block rendering
+viewer.UseCitations();      // pipeline + citation rendering
+viewer.UseFigures();        // pipeline + figure blocks
+viewer.UseFootnotes();      // pipeline + footnote rendering
+viewer.UseHardlineBreaks(); // pipeline + hardline breaks
+viewer.UseMediaLinks();     // pipeline + YouTube thumbnails
 ```
 
 Each method calls `UseSupportedExtensions()` plus the requested feature. To combine several opt-in features, build the pipeline explicitly.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -42,6 +42,12 @@ Every element rendered by `MarkdownViewer` is tagged with a CSS-style class name
 
 Subscript, superscript, underline (inserted), bold, italic, and strikethrough use standard Avalonia inline properties (`BaselineAlignment`, `FontFeatures`, `TextDecorations`) and do not have dedicated style classes.
 
+### Citations
+
+| Class | Control | Element |
+|-------|---------|---------|
+| `markdown-citation` | `Span` | Citation text (`""text""`), requires `UseCitations()` |
+
 ### Alert blocks
 
 | Class | Control | Element |

--- a/samples/MarkView.Avalonia.Demo/App.axaml.cs
+++ b/samples/MarkView.Avalonia.Demo/App.axaml.cs
@@ -21,10 +21,12 @@ public class App : Application
         // Global pipeline — applies to every MarkdownViewer in the app
         MarkdownViewerDefaults.Pipeline = new MarkdownPipelineBuilder()
             .UseSupportedExtensions()
-            .UseFootnotes()
-            .UseAlertBlocks()
             .UseAbbreviations()
+            .UseAlertBlocks()
+            .UseCitations()
             .UseFigures()
+            .UseFootnotes()
+            .UseHardlineBreaks()
             .UseMediaLinks()
             .Build();
 

--- a/samples/MarkView.Avalonia.Demo/MainViewModel.cs
+++ b/samples/MarkView.Avalonia.Demo/MainViewModel.cs
@@ -20,7 +20,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
     private const string ExtensionsShowcaseMarkdown = """
         # Opt-In Extensions Showcase
 
-        This page demonstrates the five opt-in extensions added to MarkView.Avalonia.
+        This page demonstrates the seven opt-in extensions added to MarkView.Avalonia.
         All are activated via a combined pipeline in this demo.
 
         ---
@@ -72,6 +72,14 @@ public sealed class MainViewModel : INotifyPropertyChanged
 
         ---
 
+        ## Citations
+
+        Double-quoted text — `""like this""` — renders as an italicized citation span:
+
+        Marshall McLuhan wrote ""the medium is the message"" in *Understanding Media*.
+
+        ---
+
         ## Figures
 
         Figures wrap block content in a borderd, centred container with an optional caption:
@@ -80,6 +88,18 @@ public sealed class MainViewModel : INotifyPropertyChanged
         ![Avalonia Logo](avares://MarkView.Avalonia.Demo/Assets/avalonia-logo.png =80x80)
 
         ^^^ **Figure 1** — The Avalonia UI logo (embedded avares:// resource).
+
+        ---
+
+        ## Hardline Breaks
+
+        With `UseHardlineBreaks()`, every soft line break renders as an explicit line break
+        instead of collapsing to a space — useful for poetry, addresses, or lyrics:
+
+        Roses are red,
+        Violets are blue,
+        Every line break here
+        renders exactly as typed.
 
         ---
 

--- a/samples/MarkView.Avalonia.Demo/README.md
+++ b/samples/MarkView.Avalonia.Demo/README.md
@@ -39,10 +39,12 @@ All configuration is done once in `App.axaml.cs` and applies globally to every `
 // Global pipeline — includes all opt-in extensions for the full showcase
 MarkdownViewerDefaults.Pipeline = new MarkdownPipelineBuilder()
     .UseSupportedExtensions()
-    .UseFootnotes()
-    .UseAlertBlocks()
     .UseAbbreviations()
+    .UseAlertBlocks()
+    .UseCitations()
     .UseFigures()
+    .UseFootnotes()
+    .UseHardlineBreaks()
     .UseMediaLinks()
     .Build();
 

--- a/src/MarkView.Avalonia/MarkdownExtensions.cs
+++ b/src/MarkView.Avalonia/MarkdownExtensions.cs
@@ -17,6 +17,7 @@ public static class MarkdownExtensions
     {
         return builder
             .UseAutoLinks()
+            .UseCjkFriendlyEmphasis()
             .UseEmojiAndSmiley(enableSmileys: false)
             .UseEmphasisExtras()
             .UseGridTables()

--- a/src/MarkView.Avalonia/MarkdownExtensions.cs
+++ b/src/MarkView.Avalonia/MarkdownExtensions.cs
@@ -17,6 +17,7 @@ public static class MarkdownExtensions
     {
         return builder
             .UseAutoLinks()
+            .UseEmojiAndSmiley(enableSmileys: false)
             .UseEmphasisExtras()
             .UseGridTables()
             .UsePipeTables()

--- a/src/MarkView.Avalonia/MarkdownExtensions.cs
+++ b/src/MarkView.Avalonia/MarkdownExtensions.cs
@@ -72,6 +72,16 @@ public static class MarkdownExtensions
     }
 
     /// <summary>
+    /// Enables Markdig hardline-break parsing: every soft line break within a paragraph renders
+    /// as an explicit line break instead of collapsing to a space.
+    /// Activate on the viewer with <c>viewer.UseHardlineBreaks()</c>.
+    /// </summary>
+    public static MarkdownPipelineBuilder UseHardlineBreaks(this MarkdownPipelineBuilder builder)
+    {
+        return builder.UseSoftlineBreakAsHardlineBreak();
+    }
+
+    /// <summary>
     /// Enables Markdig media link parsing. YouTube image-syntax links are rendered
     /// as clickable thumbnail embeds. Activate on the viewer with <c>viewer.UseMediaLinks()</c>.
     /// </summary>

--- a/src/MarkView.Avalonia/MarkdownExtensions.cs
+++ b/src/MarkView.Avalonia/MarkdownExtensions.cs
@@ -16,11 +16,12 @@ public static class MarkdownExtensions
     public static MarkdownPipelineBuilder UseSupportedExtensions(this MarkdownPipelineBuilder builder)
     {
         return builder
-            .UseEmphasisExtras()
             .UseAutoLinks()
+            .UseEmphasisExtras()
             .UseGridTables()
             .UsePipeTables()
-            .UseTaskLists();
+            .UseTaskLists()
+            .UseYamlFrontMatter();
     }
 
     /// <summary>

--- a/src/MarkView.Avalonia/MarkdownExtensions.cs
+++ b/src/MarkView.Avalonia/MarkdownExtensions.cs
@@ -27,12 +27,12 @@ public static class MarkdownExtensions
     }
 
     /// <summary>
-    /// Enables Markdig footnote parsing for use with MarkView.Avalonia's footnote renderers.
-    /// Activate on the viewer with <c>viewer.UseFootnotes()</c>.
+    /// Enables Markdig abbreviation parsing. Matched words gain tooltip definitions.
+    /// Activate on the viewer with <c>viewer.UseAbbreviations()</c>.
     /// </summary>
-    public static MarkdownPipelineBuilder UseFootnotes(this MarkdownPipelineBuilder builder)
+    public static MarkdownPipelineBuilder UseAbbreviations(this MarkdownPipelineBuilder builder)
     {
-        return builder.Use<Markdig.Extensions.Footnotes.FootnoteExtension>();
+        return builder.Use<Markdig.Extensions.Abbreviations.AbbreviationExtension>();
     }
 
     /// <summary>
@@ -45,12 +45,12 @@ public static class MarkdownExtensions
     }
 
     /// <summary>
-    /// Enables Markdig abbreviation parsing. Matched words gain tooltip definitions.
-    /// Activate on the viewer with <c>viewer.UseAbbreviations()</c>.
+    /// Enables Markdig citation parsing (<c>""quoted text""</c> renders as an italic citation span).
+    /// Activate on the viewer with <c>viewer.UseCitations()</c>.
     /// </summary>
-    public static MarkdownPipelineBuilder UseAbbreviations(this MarkdownPipelineBuilder builder)
+    public static MarkdownPipelineBuilder UseCitations(this MarkdownPipelineBuilder builder)
     {
-        return builder.Use<Markdig.Extensions.Abbreviations.AbbreviationExtension>();
+        return builder.Use<Markdig.Extensions.Citations.CitationExtension>();
     }
 
     /// <summary>
@@ -60,6 +60,15 @@ public static class MarkdownExtensions
     public static MarkdownPipelineBuilder UseFigures(this MarkdownPipelineBuilder builder)
     {
         return builder.Use<Markdig.Extensions.Figures.FigureExtension>();
+    }
+
+    /// <summary>
+    /// Enables Markdig footnote parsing for use with MarkView.Avalonia's footnote renderers.
+    /// Activate on the viewer with <c>viewer.UseFootnotes()</c>.
+    /// </summary>
+    public static MarkdownPipelineBuilder UseFootnotes(this MarkdownPipelineBuilder builder)
+    {
+        return builder.Use<Markdig.Extensions.Footnotes.FootnoteExtension>();
     }
 
     /// <summary>

--- a/src/MarkView.Avalonia/MarkdownViewerExtensions.cs
+++ b/src/MarkView.Avalonia/MarkdownViewerExtensions.cs
@@ -20,13 +20,13 @@ namespace MarkView.Avalonia;
 public static class MarkdownViewerExtensions
 {
     /// <summary>
-    /// Enables footnote rendering on the viewer.
+    /// Enables abbreviation tooltip rendering on the viewer.
     /// </summary>
-    public static MarkdownViewer UseFootnotes(this MarkdownViewer viewer)
+    public static MarkdownViewer UseAbbreviations(this MarkdownViewer viewer)
     {
         viewer.Pipeline = new MarkdownPipelineBuilder()
             .UseSupportedExtensions()
-            .UseFootnotes()
+            .UseAbbreviations()
             .Build();
         return viewer;
     }
@@ -44,13 +44,13 @@ public static class MarkdownViewerExtensions
     }
 
     /// <summary>
-    /// Enables abbreviation tooltip rendering on the viewer.
+    /// Enables citation rendering (<c>""quoted text""</c>) on the viewer.
     /// </summary>
-    public static MarkdownViewer UseAbbreviations(this MarkdownViewer viewer)
+    public static MarkdownViewer UseCitations(this MarkdownViewer viewer)
     {
         viewer.Pipeline = new MarkdownPipelineBuilder()
             .UseSupportedExtensions()
-            .UseAbbreviations()
+            .UseCitations()
             .Build();
         return viewer;
     }
@@ -63,6 +63,18 @@ public static class MarkdownViewerExtensions
         viewer.Pipeline = new MarkdownPipelineBuilder()
             .UseSupportedExtensions()
             .UseFigures()
+            .Build();
+        return viewer;
+    }
+
+    /// <summary>
+    /// Enables footnote rendering on the viewer.
+    /// </summary>
+    public static MarkdownViewer UseFootnotes(this MarkdownViewer viewer)
+    {
+        viewer.Pipeline = new MarkdownPipelineBuilder()
+            .UseSupportedExtensions()
+            .UseFootnotes()
             .Build();
         return viewer;
     }

--- a/src/MarkView.Avalonia/MarkdownViewerExtensions.cs
+++ b/src/MarkView.Avalonia/MarkdownViewerExtensions.cs
@@ -80,6 +80,19 @@ public static class MarkdownViewerExtensions
     }
 
     /// <summary>
+    /// Enables hardline-break rendering on the viewer: every soft line break renders as an
+    /// explicit line break instead of collapsing to a space.
+    /// </summary>
+    public static MarkdownViewer UseHardlineBreaks(this MarkdownViewer viewer)
+    {
+        viewer.Pipeline = new MarkdownPipelineBuilder()
+            .UseSupportedExtensions()
+            .UseHardlineBreaks()
+            .Build();
+        return viewer;
+    }
+
+    /// <summary>
     /// Enables YouTube thumbnail embed rendering on the viewer.
     /// </summary>
     public static MarkdownViewer UseMediaLinks(this MarkdownViewer viewer)

--- a/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
@@ -119,6 +119,9 @@ public class AvaloniaRenderer : RendererBase
         // Block renderers
         ObjectRenderers.Add(new ParagraphRenderer());
         ObjectRenderers.Add(new HeadingRenderer());
+        // YamlFrontMatterBlockRenderer must precede CodeBlockRenderer: YamlFrontMatterBlock extends
+        // CodeBlock and Markdig dispatches to the first renderer whose Accept() matches.
+        ObjectRenderers.Add(new YamlFrontMatterBlockRenderer());
         ObjectRenderers.Add(new CodeBlockRenderer());
         ObjectRenderers.Add(new ListRenderer());
         ObjectRenderers.Add(new ThematicBreakRenderer());

--- a/src/MarkView.Avalonia/Rendering/Blocks/YamlFrontMatterBlockRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Blocks/YamlFrontMatterBlockRenderer.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Markdig.Extensions.Yaml;
+
+namespace MarkView.Avalonia.Rendering.Blocks;
+
+/// <summary>
+/// Suppresses rendering of Markdig <see cref="YamlFrontMatterBlock"/>. Must be registered before
+/// <see cref="CodeBlockRenderer"/>: <see cref="YamlFrontMatterBlock"/> extends
+/// <see cref="Markdig.Syntax.CodeBlock"/>, so without this renderer the raw YAML would render as
+/// a visible code block.
+/// </summary>
+public sealed class YamlFrontMatterBlockRenderer : AvaloniaObjectRenderer<YamlFrontMatterBlock>
+{
+    protected override void Write(AvaloniaRenderer renderer, YamlFrontMatterBlock obj)
+    {
+        // Intentionally no-op: front matter is document metadata, not visible content.
+    }
+}

--- a/src/MarkView.Avalonia/Rendering/Inlines/EmphasisInlineRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/Inlines/EmphasisInlineRenderer.cs
@@ -42,6 +42,11 @@ public sealed class EmphasisInlineRenderer : AvaloniaObjectRenderer<EmphasisInli
             {
                 Classes = { "markdown-marked" }
             },
+            // citation
+            '"' when obj.DelimiterCount == 2 => new Span
+            {
+                Classes = { "markdown-citation" }
+            },
             _ => new Span(),
         };
 

--- a/src/MarkView.Avalonia/Rendering/SlugGenerator.cs
+++ b/src/MarkView.Avalonia/Rendering/SlugGenerator.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Nicolas Musset
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System.Globalization;
 using System.Text;
 
 namespace MarkView.Avalonia.Rendering;
@@ -36,45 +35,25 @@ public class SlugGenerator
     public void Reset() => _seen.Clear();
 
     /// <summary>
-    /// Single-pass normalisation: lowercase + filter + whitespace/hyphen collapsing.
-    /// Eliminates the four intermediate strings produced by the previous regex pipeline.
+    /// Mirrors GitHub's own heading-anchor algorithm (Markdig's <c>LinkHelper.UrilizeAsGfm</c>):
+    /// keep letters/digits/hyphen/underscore, map a literal space to a hyphen, drop everything else.
+    /// Unlike a naive slugifier this does NOT collapse consecutive separators — GitHub doesn't
+    /// either, so e.g. "C# Tips &amp; Tricks" intentionally becomes "c-tips--tricks" (double
+    /// hyphen), matching the anchor GitHub itself generates for the same heading.
     /// </summary>
     private static string Normalize(string text)
     {
         var sb = new StringBuilder(text.Length);
-        bool pendingHyphen = false;
 
-        foreach (char rawCh in text)
+        foreach (char ch in text)
         {
-            char ch = char.ToLowerInvariant(rawCh);
-            var cat = CharUnicodeInfo.GetUnicodeCategory(ch);
-
-            bool isKeepable =
-                cat is UnicodeCategory.LowercaseLetter
-                    or UnicodeCategory.UppercaseLetter  // after ToLowerInvariant — kept for safety
-                    or UnicodeCategory.TitlecaseLetter
-                    or UnicodeCategory.ModifierLetter
-                    or UnicodeCategory.OtherLetter
-                    or UnicodeCategory.DecimalDigitNumber
-                    or UnicodeCategory.LetterNumber
-                    or UnicodeCategory.OtherNumber;
-
-            if (isKeepable)
-            {
-                if (pendingHyphen && sb.Length > 0)
-                    sb.Append('-');
-                pendingHyphen = false;
-                sb.Append(ch);
-            }
-            else if (char.IsWhiteSpace(ch) || ch == '-')
-            {
-                // Defer hyphen until next keepable char; handles runs + leading/trailing
-                if (sb.Length > 0)
-                    pendingHyphen = true;
-            }
-            // else: stripped — not a letter, digit, whitespace, or hyphen
+            if (char.IsLetterOrDigit(ch) || ch == '-' || ch == '_')
+                sb.Append(char.ToLowerInvariant(ch));
+            else if (ch == ' ')
+                sb.Append('-');
+            // else: dropped — not a letter, digit, hyphen, underscore, or plain space
         }
 
-        return sb.ToString();
+        return sb.Length == 0 ? "section" : sb.ToString();
     }
 }

--- a/src/MarkView.Avalonia/Themes/MarkdownTheme.axaml
+++ b/src/MarkView.Avalonia/Themes/MarkdownTheme.axaml
@@ -108,6 +108,11 @@
     <Setter Property="Background" Value="{DynamicResource MarkdownMarkedBackground}"/>
   </Style>
 
+  <!-- Citation -->
+  <Style Selector="Span.markdown-citation">
+    <Setter Property="FontStyle" Value="Italic"/>
+  </Style>
+
   <!-- Blockquote -->
   <Style Selector="Border.markdown-blockquote">
     <Setter Property="BorderBrush" Value="#4A9ECC" />

--- a/tests/MarkView.Avalonia.Tests/Inlines/EmphasisTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Inlines/EmphasisTests.cs
@@ -101,6 +101,17 @@ public class EmphasisTests : RenderTestBase
     }
 
     [AvaloniaFact]
+    public void Citation_text_renders_with_markdown_citation_class()
+    {
+        var pipeline = new MarkdownPipelineBuilder().UseCitations().Build();
+        var result = Render("""He said ""hello there"" to me""", pipeline);
+
+        var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(result.Children));
+        var span = textBlock.Inlines!.OfType<Span>().Single();
+        Assert.Contains("markdown-citation", span.Classes);
+    }
+
+    [AvaloniaFact]
     public void Inserted_single_plus_falls_through_to_plain_span()
     {
         var span = RenderEmphasisInlineDirect('+', delimiterCount: 1);

--- a/tests/MarkView.Avalonia.Tests/Inlines/LineBreakTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Inlines/LineBreakTests.cs
@@ -4,6 +4,8 @@
 using Avalonia.Controls.Documents;
 using Avalonia.Headless.XUnit;
 
+using Markdig;
+
 using MarkView.Avalonia.Rendering;
 
 using Xunit;
@@ -35,5 +37,17 @@ public class LineBreakTests : RenderTestBase
         Assert.Equal(3, inlines.Count);
         var space = Assert.IsType<Run>(inlines[1]);
         Assert.Equal(" ", space.Text);
+    }
+
+    [AvaloniaFact]
+    public void Soft_break_renders_as_LineBreak_when_hardline_breaks_enabled()
+    {
+        var pipeline = new MarkdownPipelineBuilder().UseHardlineBreaks().Build();
+        var result = Render("line one\nline two", pipeline);
+        var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(result.Children));
+        var inlines = textBlock.Inlines!.ToList();
+        // Run("line one") + LineBreak + Run("line two")
+        Assert.Equal(3, inlines.Count);
+        Assert.IsType<LineBreak>(inlines[1]);
     }
 }

--- a/tests/MarkView.Avalonia.Tests/MarkdownExtensionsTests.cs
+++ b/tests/MarkView.Avalonia.Tests/MarkdownExtensionsTests.cs
@@ -64,6 +64,15 @@ public class MarkdownExtensionsTests : RenderTestBase
         Assert.Contains(inlines, i => i is MarkdownHyperlink);
     }
 
+    [AvaloniaFact]
+    public void UseSupportedExtensions_hides_yaml_front_matter()
+    {
+        var result = Render("---\ntitle: Test\n---\n# Heading", _pipeline);
+        var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(result.Children));
+        var run = Assert.IsType<Run>(Assert.Single(textBlock.Inlines!));
+        Assert.Equal("Heading", run.Text);
+    }
+
     private static T? FindFirst<T>(Control root) where T : Control
     {
         if (root is T match) return match;

--- a/tests/MarkView.Avalonia.Tests/MarkdownExtensionsTests.cs
+++ b/tests/MarkView.Avalonia.Tests/MarkdownExtensionsTests.cs
@@ -73,6 +73,25 @@ public class MarkdownExtensionsTests : RenderTestBase
         Assert.Equal("Heading", run.Text);
     }
 
+    [AvaloniaFact]
+    public void UseSupportedExtensions_renders_emoji_shortcode_as_unicode_glyph()
+    {
+        var result = Render("Launch :rocket: now", _pipeline);
+        var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(result.Children));
+        var runs = textBlock.Inlines!.OfType<Run>().ToList();
+        Assert.Contains(runs, r => r.Text == "\U0001F680"); // 🚀
+    }
+
+    [AvaloniaFact]
+    public void UseSupportedExtensions_does_not_convert_ascii_smileys()
+    {
+        // enableSmileys is explicitly false: only named :shortcode: emoji are recognized.
+        var result = Render("Great :) job", _pipeline);
+        var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(result.Children));
+        var run = Assert.IsType<Run>(Assert.Single(textBlock.Inlines!));
+        Assert.Equal("Great :) job", run.Text);
+    }
+
     private static T? FindFirst<T>(Control root) where T : Control
     {
         if (root is T match) return match;

--- a/tests/MarkView.Avalonia.Tests/MarkdownViewerExtensionsTests.cs
+++ b/tests/MarkView.Avalonia.Tests/MarkdownViewerExtensionsTests.cs
@@ -65,6 +65,15 @@ public class MarkdownViewerExtensionsTests
     }
 
     [AvaloniaFact]
+    public void UseHardlineBreaks_sets_pipeline_on_viewer()
+    {
+        var viewer = new MarkdownViewer();
+        var result = viewer.UseHardlineBreaks();
+        Assert.Same(viewer, result);
+        Assert.NotNull(viewer.Pipeline);
+    }
+
+    [AvaloniaFact]
     public void UseFootnotes_renders_footnote_when_markdown_set()
     {
         var viewer = new MarkdownViewer();

--- a/tests/MarkView.Avalonia.Tests/MarkdownViewerExtensionsTests.cs
+++ b/tests/MarkView.Avalonia.Tests/MarkdownViewerExtensionsTests.cs
@@ -3,7 +3,7 @@
 
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
-using Markdig;
+
 using Xunit;
 
 namespace MarkView.Avalonia.Tests;
@@ -51,6 +51,15 @@ public class MarkdownViewerExtensionsTests
     {
         var viewer = new MarkdownViewer();
         var result = viewer.UseMediaLinks();
+        Assert.Same(viewer, result);
+        Assert.NotNull(viewer.Pipeline);
+    }
+
+    [AvaloniaFact]
+    public void UseCitations_sets_pipeline_on_viewer()
+    {
+        var viewer = new MarkdownViewer();
+        var result = viewer.UseCitations();
         Assert.Same(viewer, result);
         Assert.NotNull(viewer.Pipeline);
     }

--- a/tests/MarkView.Avalonia.Tests/Rendering/SlugGeneratorTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Rendering/SlugGeneratorTests.cs
@@ -12,12 +12,22 @@ public class SlugGeneratorTests
     [InlineData("Hello World", "hello-world")]
     [InlineData("My Heading #1", "my-heading-1")]
     [InlineData("C# and .NET", "c-and-net")]
-    [InlineData("  leading and trailing  ", "leading-and-trailing")]
-    [InlineData("multiple   spaces", "multiple-spaces")]
+    [InlineData("my_function", "my_function")]
+    // GitHub does not collapse consecutive separators: dropping a punctuation char
+    // adjacent to a space leaves the space (and its hyphen) behind.
+    [InlineData("C# Tips & Tricks", "c-tips--tricks")]
+    [InlineData("multiple   spaces", "multiple---spaces")]
     public void GenerateSlug_produces_github_style_slug(string input, string expected)
     {
         var gen = new SlugGenerator();
         Assert.Equal(expected, gen.GenerateSlug(input));
+    }
+
+    [Fact]
+    public void GenerateSlug_falls_back_to_section_for_symbol_only_heading()
+    {
+        var gen = new SlugGenerator();
+        Assert.Equal("section", gen.GenerateSlug("!!!"));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Add support for more Markdig extensions:
- Citations
- CjkFriendlyEmphasis
- EmojiAndSmiley (only emojis, smileys are disabled for now)
- HardlineBreaks
- YamlFrontMatter

Fix:
- slug generator now follow more closely GitHub's heading-anchor algorithm

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [x] Documentation
- [ ] CI / build

## Test plan

- [x] `dotnet test` — all tests pass
- [x] Manual smoke-test in the demo app