### PR TITLE
feat: LaTeX math (CSharpMath.SkiaSharp)

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -16,9 +16,10 @@ jobs:
       matrix:
         test-project:
           - MarkView.Avalonia.Tests
+          - MarkView.Avalonia.Math.Tests
+          - MarkView.Avalonia.Mermaid.Tests
           - MarkView.Avalonia.Svg.Tests
           - MarkView.Avalonia.SyntaxHighlighting.Tests
-          - MarkView.Avalonia.Mermaid.Tests
     steps:
       - uses: actions/checkout@v7
 

--- a/.gitignore
+++ b/.gitignore
@@ -482,3 +482,4 @@ $RECYCLE.BIN/
 *.swp
 
 .worktrees
+.superpowers

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
+    <!-- Prerelease: do NOT merge MarkView.Avalonia.Math to main until CSharpMath ships a stable 1.0.0. -->
     <PackageVersion Include="CSharpMath.SkiaSharp" Version="1.0.0-pre.1" />
     <PackageVersion Include="Markdig" Version="1.3.2" />
     <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.15" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,16 +10,17 @@
   <ItemGroup>
     <!-- Core dependencies -->
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="Mermaider" Version="0.12.2" />
-    <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
-    <!-- Prerelease: do NOT merge MarkView.Avalonia.Math to main until CSharpMath ships a stable 1.0.0. -->
-    <PackageVersion Include="CSharpMath.SkiaSharp" Version="1.0.0-pre.1" />
     <PackageVersion Include="Markdig" Version="1.3.2" />
+    <!-- Plugin dependencies -->
+    <PackageVersion Include="CSharpMath.SkiaSharp" Version="0.5.1" />
+    <PackageVersion Include="Mermaider" Version="0.12.2" />
     <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.15" />
     <PackageVersion Include="TextMateSharp" Version="2.0.4" />
     <PackageVersion Include="TextMateSharp.Grammars" Version="2.0.4" />
+    <!-- Samples dependencies -->
+    <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
     <!-- Test dependencies -->
     <PackageVersion Include="Avalonia.Headless.XUnit" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
+    <PackageVersion Include="CSharpMath.SkiaSharp" Version="1.0.0-pre.1" />
     <PackageVersion Include="Markdig" Version="1.3.2" />
     <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.15" />
     <PackageVersion Include="TextMateSharp" Version="2.0.4" />

--- a/MarkView.Avalonia.slnx
+++ b/MarkView.Avalonia.slnx
@@ -4,12 +4,14 @@
     <Project Path="src/MarkView.Avalonia.SyntaxHighlighting/MarkView.Avalonia.SyntaxHighlighting.csproj" />
     <Project Path="src/MarkView.Avalonia.Svg/MarkView.Avalonia.Svg.csproj" />
     <Project Path="src/MarkView.Avalonia.Mermaid/MarkView.Avalonia.Mermaid.csproj" />
+    <Project Path="src/MarkView.Avalonia.Math/MarkView.Avalonia.Math.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/MarkView.Avalonia.Tests/MarkView.Avalonia.Tests.csproj" />
     <Project Path="tests/MarkView.Avalonia.SyntaxHighlighting.Tests/MarkView.Avalonia.SyntaxHighlighting.Tests.csproj" />
     <Project Path="tests/MarkView.Avalonia.Svg.Tests/MarkView.Avalonia.Svg.Tests.csproj" />
     <Project Path="tests/MarkView.Avalonia.Mermaid.Tests/MarkView.Avalonia.Mermaid.Tests.csproj" />
+    <Project Path="tests/MarkView.Avalonia.Math.Tests/MarkView.Avalonia.Math.Tests.csproj" />
   </Folder>
   <Folder Name="/samples/">
     <Project Path="samples/MarkView.Avalonia.Demo/MarkView.Avalonia.Demo.csproj" />

--- a/README.md
+++ b/README.md
@@ -187,6 +187,20 @@ viewer.UseSvg();
 
 The extension inserts `SvgImageLoader` at the front of the image loader chain. Regular raster images continue to load via the built-in HTTP fallback.
 
+### LaTeX Math (`MarkView.Avalonia.Math`)
+
+Renders `$...$` (inline) and `$$...$$` (block) LaTeX math using CSharpMath's SkiaSharp renderer — pure .NET, no browser or WebView required.
+
+```bash
+dotnet add package MarkView.Avalonia.Math
+```
+
+```csharp
+viewer.UseMath();
+```
+
+> Currently pins a CSharpMath prerelease (`1.0.0-pre.1`) — see the [package README](src/MarkView.Avalonia.Math/README.md) for details.
+
 ### Mermaid Diagrams (`MarkView.Avalonia.Mermaid`)
 
 Renders fenced `mermaid` code blocks as SVG diagrams using the [Mermaider](https://github.com/nullean/mermaider) library (pure .NET, no browser required). Works on all platforms including Linux. Diagrams re-render automatically when the user switches between light and dark themes.

--- a/README.md
+++ b/README.md
@@ -226,13 +226,14 @@ graph TD
 
 ### Combining extensions
 
-All three can be stacked:
+All four can be stacked:
 
 ```csharp
 viewer
     .UseTextMateHighlighting()
     .UseSvg()
-    .UseMermaid();
+    .UseMermaid()
+    .UseMath();
 ```
 
 Extensions are applied in the order they are added to `viewer.Extensions`. Each extension's `Register` method is called once per render pass, before the Markdig pipeline is set up.

--- a/README.md
+++ b/README.md
@@ -206,8 +206,6 @@ dotnet add package MarkView.Avalonia.Math
 viewer.UseMath();
 ```
 
-> **Do not merge/release with this dependency as-is** — currently pins a CSharpMath prerelease (`1.0.0-pre.1`); see the [package README](src/MarkView.Avalonia.Math/README.md) for the merge gate.
-
 ### Mermaid Diagrams (`MarkView.Avalonia.Mermaid`)
 
 Renders fenced `mermaid` code blocks as SVG diagrams using the [Mermaider](https://github.com/nullean/mermaider) library (pure .NET, no browser required). Works on all platforms including Linux. Diagrams re-render automatically when the user switches between light and dark themes.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ dotnet add package MarkView.Avalonia.Math
 viewer.UseMath();
 ```
 
-> Currently pins a CSharpMath prerelease (`1.0.0-pre.1`) — see the [package README](src/MarkView.Avalonia.Math/README.md) for details.
+> **Do not merge/release with this dependency as-is** — currently pins a CSharpMath prerelease (`1.0.0-pre.1`); see the [package README](src/MarkView.Avalonia.Math/README.md) for the merge gate.
 
 ### Mermaid Diagrams (`MarkView.Avalonia.Mermaid`)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ This folder contains developer-facing documentation for the MarkView.Avalonia li
 |----------|-------------|
 | [getting-started.md](getting-started.md) | Installation, XAML setup, and first render |
 | [configuration.md](configuration.md) | Pipeline, global defaults, BaseUri, and opt-in extensions |
-| [extensions.md](extensions.md) | Extension packages: SyntaxHighlighting, Svg, Mermaid |
+| [extensions.md](extensions.md) | Extension packages: SyntaxHighlighting, Svg, Mermaid, Math |
 | [text-selection.md](text-selection.md) | Text selection, clipboard, and programmatic API |
 | [theming.md](theming.md) | Style classes, theme switching, and customisation |
 | [custom-extensions.md](custom-extensions.md) | Writing your own `IMarkViewExtension`, image loaders, and renderers |

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -108,12 +108,44 @@ If rendering fails, the extension falls back to a plain-text block containing th
 
 ---
 
-## Using all three together
+## Math
+
+**Package:** `MarkView.Avalonia.Math`
+**[README](../src/MarkView.Avalonia.Math/README.md)**
+
+Renders `$...$` (inline) and `$$...$$` (block) LaTeX math via CSharpMath's SkiaSharp renderer.
+
+### Activation
+
+```csharp
+viewer.UseMath();
+// or globally:
+MarkdownViewerDefaults.Extensions.AddMath();
+MarkdownViewerDefaults.Pipeline = new MarkdownPipelineBuilder()
+    .UseSupportedExtensions()
+    .UseMathematics()
+    .Build();
+```
+
+### Theme awareness
+
+Formulas re-render automatically on light/dark theme switch, matching Mermaid's exact two-hex
+convention (dark `#FAFAFA`, light `#27272A` text).
+
+### Fallback
+
+Invalid LaTeX renders CSharpMath's own inline error text. Unexpected exceptions fall back to a
+plain-text panel for block math, or leave the last successful render in place for inline math.
+
+---
+
+## Using all four together
 
 ```csharp
 MarkdownViewerDefaults.Extensions.AddTextMateHighlighting();
 MarkdownViewerDefaults.Extensions.AddSvg();
 MarkdownViewerDefaults.Extensions.AddMermaid();
+MarkdownViewerDefaults.Extensions.AddMath();
 ```
 
 `MermaidBlockRenderer` is inserted at index 0 of `renderer.ObjectRenderers` and intercepts every `FencedCodeBlock`. Mermaid blocks are rendered as diagrams; all other fenced blocks pass through to `TextMateCodeBlockRenderer` (or the default `CodeBlockRenderer` if the SyntaxHighlighting extension is not active).

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -148,4 +148,4 @@ MarkdownViewerDefaults.Extensions.AddMermaid();
 MarkdownViewerDefaults.Extensions.AddMath();
 ```
 
-`MermaidBlockRenderer` is inserted at index 0 of `renderer.ObjectRenderers` and intercepts every `FencedCodeBlock`. Mermaid blocks are rendered as diagrams; all other fenced blocks pass through to `TextMateCodeBlockRenderer` (or the default `CodeBlockRenderer` if the SyntaxHighlighting extension is not active).
+`MermaidBlockRenderer` is inserted immediately before the first renderer that already accepts a `FencedCodeBlock` (rather than always at index 0 — this keeps registration order-independent relative to sibling extensions like `MarkView.Avalonia.Math`'s `MathBlockRenderer`) and intercepts every `FencedCodeBlock`. Mermaid blocks are rendered as diagrams; all other fenced blocks pass through to `TextMateCodeBlockRenderer` (or the default `CodeBlockRenderer` if the SyntaxHighlighting extension is not active).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,6 +14,7 @@ Optionally add extension packages for richer rendering:
 dotnet add package MarkView.Avalonia.SyntaxHighlighting  # TextMate code highlighting
 dotnet add package MarkView.Avalonia.Svg                 # SVG image rendering
 dotnet add package MarkView.Avalonia.Mermaid             # Mermaid diagram rendering
+dotnet add package MarkView.Avalonia.Math                # LaTeX math rendering
 ```
 
 ## 1. Include the default theme

--- a/samples/MarkView.Avalonia.Demo/App.axaml.cs
+++ b/samples/MarkView.Avalonia.Demo/App.axaml.cs
@@ -26,12 +26,14 @@ public class App : Application
             .UseAbbreviations()
             .UseFigures()
             .UseMediaLinks()
+            .UseMathematics()
             .Build();
 
         // Global extensions — applies to every MarkdownViewer in the app
         MarkdownViewerDefaults.Extensions.AddTextMateHighlighting();
         MarkdownViewerDefaults.Extensions.AddSvg();
         MarkdownViewerDefaults.Extensions.AddMermaid();
+        MarkdownViewerDefaults.Extensions.AddMath();
 
         // Global link handler — handles external links for every MarkdownViewer in the app
         MarkdownViewer.LinkClickedEvent.AddClassHandler<MarkdownViewer>(OnLinkClicked);

--- a/samples/MarkView.Avalonia.Demo/Assets/showcase.md
+++ b/samples/MarkView.Avalonia.Demo/Assets/showcase.md
@@ -82,7 +82,7 @@ The `EmphasisExtras` Markdig extension unlocks four additional inline styles:
 | `MarkView.Avalonia.SyntaxHighlighting` | Code highlighting | ✅ Published | TextMate grammars |
 | `MarkView.Avalonia.Svg` | SVG images | ✅ Published | Avalonia.Svg |
 | `MarkView.Avalonia.Mermaid` | Mermaid diagrams | ✅ Published | Pure .NET |
-| `MarkView.Avalonia.Math` | LaTeX math | ⚠️ Prerelease dependency | CSharpMath.SkiaSharp |
+| `MarkView.Avalonia.Math` | LaTeX math | ✅ Published | CSharpMath.SkiaSharp |
 
 ---
 

--- a/samples/MarkView.Avalonia.Demo/Assets/showcase.md
+++ b/samples/MarkView.Avalonia.Demo/Assets/showcase.md
@@ -15,6 +15,7 @@
 - [Bitmap Image](#bitmap-image)
 - [SVG Image](#svg-image)
 - [Mermaid Diagram](#mermaid-diagram)
+- [Math](#math)
 
 ---
 
@@ -67,6 +68,7 @@ The `EmphasisExtras` Markdig extension unlocks four additional inline styles:
 - [x] Syntax-highlighted code blocks via `MarkView.Avalonia.SyntaxHighlighting`
 - [x] SVG image rendering via `MarkView.Avalonia.Svg`
 - [x] Mermaid diagram rendering via `MarkView.Avalonia.Mermaid`
+- [x] LaTeX math rendering via `MarkView.Avalonia.Math`
 - [x] Tables, blockquotes, task lists
 - [ ] PDF export (planned)
 
@@ -80,6 +82,7 @@ The `EmphasisExtras` Markdig extension unlocks four additional inline styles:
 | `MarkView.Avalonia.SyntaxHighlighting` | Code highlighting | ✅ Published | TextMate grammars |
 | `MarkView.Avalonia.Svg` | SVG images | ✅ Published | Avalonia.Svg |
 | `MarkView.Avalonia.Mermaid` | Mermaid diagrams | ✅ Published | Pure .NET |
+| `MarkView.Avalonia.Math` | LaTeX math | ⚠️ Prerelease dependency | CSharpMath.SkiaSharp |
 
 ---
 
@@ -173,6 +176,23 @@ flowchart LR
     SVG --> Out
     MM --> Out
 ```
+
+---
+
+## Math
+
+LaTeX math is rendered by the `MarkView.Avalonia.Math` extension, via
+[CSharpMath](https://github.com/verybadcat/CSharpMath)'s SkiaSharp renderer — pure .NET, no
+browser or WebView required.
+
+Inline math sits within a sentence, e.g. mass–energy equivalence, $E = mc^2$, or the Pythagorean
+theorem, $a^2 + b^2 = c^2$.
+
+Block math renders as its own centred element:
+
+$$
+\lim_{n \to \infty} \left(1 + \frac{1}{n}\right)^n = e = \sum_{k=0}^{\infty} \frac{1}{k!}
+$$
 
 ---
 

--- a/samples/MarkView.Avalonia.Demo/MarkView.Avalonia.Demo.csproj
+++ b/samples/MarkView.Avalonia.Demo/MarkView.Avalonia.Demo.csproj
@@ -10,9 +10,9 @@
     <AvaloniaResource Include="Assets\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia.Themes.Fluent" />
-    <PackageReference Include="Avalonia.Fonts.Inter" />
     <PackageReference Include="Avalonia.Desktop" />
+    <PackageReference Include="Avalonia.Fonts.Inter" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MarkView.Avalonia\MarkView.Avalonia.csproj" />

--- a/samples/MarkView.Avalonia.Demo/MarkView.Avalonia.Demo.csproj
+++ b/samples/MarkView.Avalonia.Demo/MarkView.Avalonia.Demo.csproj
@@ -18,5 +18,6 @@
     <ProjectReference Include="..\..\src\MarkView.Avalonia.SyntaxHighlighting\MarkView.Avalonia.SyntaxHighlighting.csproj" />
     <ProjectReference Include="..\..\src\MarkView.Avalonia.Svg\MarkView.Avalonia.Svg.csproj" />
     <ProjectReference Include="..\..\src\MarkView.Avalonia.Mermaid\MarkView.Avalonia.Mermaid.csproj" />
+    <ProjectReference Include="..\..\src\MarkView.Avalonia.Math\MarkView.Avalonia.Math.csproj" />
   </ItemGroup>
 </Project>

--- a/samples/MarkView.Avalonia.Demo/packages.lock.json
+++ b/samples/MarkView.Avalonia.Demo/packages.lock.json
@@ -121,15 +121,23 @@
       },
       "CSharpMath": {
         "type": "Transitive",
-        "resolved": "1.0.0-pre.1",
-        "contentHash": "DxNiPY3GTeE873k5CFOz8b7DGn99qeBlX/9fBWMFJMrUMFKJq6Hr7Qf1WfN72kHUt9pzv081co4KOlWtbzzRCg=="
+        "resolved": "0.5.1",
+        "contentHash": "CBAtejk24icPQNJWPjUDGUqklNLpfglpRxQljiezn2MQrxL5cIVuouCVnw6ipU3cft9Tq8YfS6f/JPhSjhFtFA=="
+      },
+      "CSharpMath.Editor": {
+        "type": "Transitive",
+        "resolved": "0.5.1",
+        "contentHash": "q5MFAjI7TO41PtGFNHBFwOw3J3IS7Dnm7aJHEgPxMWE5wl1H5byOo0pJnGwXevjhoSRssGRJH2KCXgn0KbGJFQ==",
+        "dependencies": {
+          "CSharpMath": "0.5.1"
+        }
       },
       "CSharpMath.Rendering": {
         "type": "Transitive",
-        "resolved": "1.0.0-pre.1",
-        "contentHash": "Z7Pywza48XD9ygAtipuMDt+0SjHSUPLOdpT8xpA8QZqQ3j+HmXho54sFNPnRkMl7hIwBVmLbRObeQ1oN2rZJVg==",
+        "resolved": "0.5.1",
+        "contentHash": "H4tctQzgpQmLICON1QAJtfm3/dj4exoxEKTuF9oO5YkHXMANWNfOQKwVtAx6n78hcD6WidwF2v2pH8Z/cOw/gg==",
         "dependencies": {
-          "CSharpMath": "1.0.0-pre.1"
+          "CSharpMath.Editor": "0.5.1"
         }
       },
       "ExCSS": {
@@ -289,8 +297,9 @@
       "markview.avalonia.math": {
         "type": "Project",
         "dependencies": {
-          "CSharpMath.SkiaSharp": "[1.0.0-pre.1, )",
-          "MarkView.Avalonia": "[1.0.0, )"
+          "CSharpMath.SkiaSharp": "[0.5.1, )",
+          "MarkView.Avalonia": "[1.0.0, )",
+          "SkiaSharp": "[4.148.0, )"
         }
       },
       "markview.avalonia.mermaid": {
@@ -329,12 +338,12 @@
       },
       "CSharpMath.SkiaSharp": {
         "type": "CentralTransitive",
-        "requested": "[1.0.0-pre.1, )",
-        "resolved": "1.0.0-pre.1",
-        "contentHash": "iie1WLYYdo7w9vrz1a1qUZoLj1YNpLIVJ+8/wrdY7krqd/el9Elmy+6HioFtId9HDbP6NTHnAtS7xt+HFatfqQ==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "3SMI0o2EZi2/GskH6T5s9GDaBq9u0VBd/o8Geqd+FyPxEXCcmzECOZ3PdVdob/YNevl4okOTbqZrHZS2O28/ZQ==",
         "dependencies": {
-          "CSharpMath.Rendering": "1.0.0-pre.1",
-          "SkiaSharp": "3.119.1"
+          "CSharpMath.Rendering": "0.5.1",
+          "SkiaSharp": "2.80.1"
         }
       },
       "Markdig": {

--- a/samples/MarkView.Avalonia.Demo/packages.lock.json
+++ b/samples/MarkView.Avalonia.Demo/packages.lock.json
@@ -119,6 +119,19 @@
           "Avalonia.Skia": "12.1.1"
         }
       },
+      "CSharpMath": {
+        "type": "Transitive",
+        "resolved": "1.0.0-pre.1",
+        "contentHash": "DxNiPY3GTeE873k5CFOz8b7DGn99qeBlX/9fBWMFJMrUMFKJq6Hr7Qf1WfN72kHUt9pzv081co4KOlWtbzzRCg=="
+      },
+      "CSharpMath.Rendering": {
+        "type": "Transitive",
+        "resolved": "1.0.0-pre.1",
+        "contentHash": "Z7Pywza48XD9ygAtipuMDt+0SjHSUPLOdpT8xpA8QZqQ3j+HmXho54sFNPnRkMl7hIwBVmLbRObeQ1oN2rZJVg==",
+        "dependencies": {
+          "CSharpMath": "1.0.0-pre.1"
+        }
+      },
       "ExCSS": {
         "type": "Transitive",
         "resolved": "4.3.1",
@@ -273,6 +286,13 @@
           "Markdig": "[1.3.2, )"
         }
       },
+      "markview.avalonia.math": {
+        "type": "Project",
+        "dependencies": {
+          "CSharpMath.SkiaSharp": "[1.0.0-pre.1, )",
+          "MarkView.Avalonia": "[1.0.0, )"
+        }
+      },
       "markview.avalonia.mermaid": {
         "type": "Project",
         "dependencies": {
@@ -305,6 +325,16 @@
           "Avalonia.BuildServices": "11.3.2",
           "Avalonia.Remote.Protocol": "12.1.1",
           "MicroCom.Runtime": "0.11.6"
+        }
+      },
+      "CSharpMath.SkiaSharp": {
+        "type": "CentralTransitive",
+        "requested": "[1.0.0-pre.1, )",
+        "resolved": "1.0.0-pre.1",
+        "contentHash": "iie1WLYYdo7w9vrz1a1qUZoLj1YNpLIVJ+8/wrdY7krqd/el9Elmy+6HioFtId9HDbP6NTHnAtS7xt+HFatfqQ==",
+        "dependencies": {
+          "CSharpMath.Rendering": "1.0.0-pre.1",
+          "SkiaSharp": "3.119.1"
         }
       },
       "Markdig": {

--- a/src/MarkView.Avalonia.Math/MarkView.Avalonia.Math.csproj
+++ b/src/MarkView.Avalonia.Math/MarkView.Avalonia.Math.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>MarkView.Avalonia.Math</RootNamespace>
+    <IsPackable>true</IsPackable>
+    <PackageId>MarkView.Avalonia.Math</PackageId>
+    <Description>LaTeX math rendering extension for MarkView.Avalonia.</Description>
+    <PackageTags>avalonia;markdown;latex;math;csharpmath</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MarkView.Avalonia\MarkView.Avalonia.csproj" />
+    <PackageReference Include="CSharpMath.SkiaSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+</Project>

--- a/src/MarkView.Avalonia.Math/MarkView.Avalonia.Math.csproj
+++ b/src/MarkView.Avalonia.Math/MarkView.Avalonia.Math.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\MarkView.Avalonia\MarkView.Avalonia.csproj" />
     <PackageReference Include="CSharpMath.SkiaSharp" />
+    <PackageReference Include="SkiaSharp" VersionOverride="4.148.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="/" />

--- a/src/MarkView.Avalonia.Math/MarkdownViewerExtensions.cs
+++ b/src/MarkView.Avalonia.Math/MarkdownViewerExtensions.cs
@@ -35,11 +35,11 @@ public static class MarkdownViewerMathExtensions
     /// </summary>
     public static MarkdownViewer UseMath(this MarkdownViewer viewer)
     {
+        viewer.Extensions.AddMath();
         viewer.Pipeline = new MarkdownPipelineBuilder()
             .UseSupportedExtensions()
             .UseMathematics()
             .Build();
-        viewer.Extensions.AddMath();
         return viewer;
     }
 }

--- a/src/MarkView.Avalonia.Math/MarkdownViewerExtensions.cs
+++ b/src/MarkView.Avalonia.Math/MarkdownViewerExtensions.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Markdig;
+
+using MarkView.Avalonia.Extensions;
+
+namespace MarkView.Avalonia;
+
+/// <summary>
+/// Convenience extensions for attaching LaTeX math rendering to a <see cref="MarkdownViewer"/>.
+/// </summary>
+public static class MarkdownViewerMathExtensions
+{
+    /// <summary>
+    /// Adds <see cref="Math.MathExtension"/> to the extension list.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// // Global (App.axaml.cs)
+    /// MarkdownViewerDefaults.Extensions.AddMath();
+    /// // Per-instance
+    /// viewer.Extensions.AddMath();
+    /// </code>
+    /// </example>
+    public static void AddMath(this IList<IMarkViewExtension> extensions)
+    {
+        extensions.Add(new Math.MathExtension());
+    }
+
+    /// <summary>
+    /// Enables <c>$...$</c>/<c>$$...$$</c> LaTeX math parsing and rendering on the viewer.
+    /// Unlike <c>UseMermaid()</c>/<c>UseSvg()</c>, this also rebuilds the pipeline: the syntax
+    /// needs Markdig's <c>UseMathematics()</c> to even be parsed, not just a renderer.
+    /// </summary>
+    public static MarkdownViewer UseMath(this MarkdownViewer viewer)
+    {
+        viewer.Pipeline = new MarkdownPipelineBuilder()
+            .UseSupportedExtensions()
+            .UseMathematics()
+            .Build();
+        viewer.Extensions.AddMath();
+        return viewer;
+    }
+}

--- a/src/MarkView.Avalonia.Math/MathBlockRenderer.cs
+++ b/src/MarkView.Avalonia.Math/MathBlockRenderer.cs
@@ -37,7 +37,7 @@ public sealed class MathBlockRenderer : AvaloniaObjectRenderer<MathBlock>
             ApplyTheme();
         }
         Application.Current!.PropertyChanged += OnThemeChanged;
-        image.DetachedFromLogicalTree += (_, _) =>
+        border.DetachedFromLogicalTree += (_, _) =>
             Application.Current?.PropertyChanged -= OnThemeChanged;
 
         ApplyTheme();

--- a/src/MarkView.Avalonia.Math/MathBlockRenderer.cs
+++ b/src/MarkView.Avalonia.Math/MathBlockRenderer.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+
+using Markdig.Extensions.Mathematics;
+
+using MarkView.Avalonia.Rendering;
+
+namespace MarkView.Avalonia.Math;
+
+/// <summary>
+/// Renders Markdig <see cref="MathBlock"/> nodes (<c>$$...$$</c>) as a centred image
+/// produced by CSharpMath.SkiaSharp.
+/// </summary>
+public sealed class MathBlockRenderer : AvaloniaObjectRenderer<MathBlock>
+{
+    protected override void Write(AvaloniaRenderer renderer, MathBlock obj)
+    {
+        var source = ExtractSource(obj);
+
+        var image = new Image
+        {
+            Stretch = Stretch.None,
+            HorizontalAlignment = HorizontalAlignment.Center,
+        };
+
+        var border = new Border { Child = image };
+        border.Classes.Add("markdown-math-block");
+
+        void OnThemeChanged(object? s, AvaloniaPropertyChangedEventArgs e)
+        {
+            if (e.Property.Name != nameof(Application.ActualThemeVariant)) return;
+            ApplyTheme();
+        }
+        Application.Current!.PropertyChanged += OnThemeChanged;
+        image.DetachedFromLogicalTree += (_, _) =>
+            Application.Current?.PropertyChanged -= OnThemeChanged;
+
+        ApplyTheme();
+        renderer.WriteBlock(border);
+
+        void ApplyTheme()
+        {
+            try
+            {
+                image.Source = MathFormulaRenderer.Render(source, MathFormulaRenderer.GetThemeTextColor());
+            }
+            catch (Exception ex)
+            {
+                var panel = new StackPanel { Spacing = 4 };
+                panel.Children.Add(new TextBlock { Text = $"Math render error: {ex.Message}" });
+                panel.Children.Add(new TextBlock { Text = source });
+                border.Child = panel;
+                border.Classes.Clear();
+                border.Classes.Add("markdown-math-fallback");
+            }
+        }
+    }
+
+    private static string ExtractSource(MathBlock block)
+    {
+        if (block.Lines.Lines == null)
+            return string.Empty;
+
+        var lines = block.Lines;
+        var sb = new System.Text.StringBuilder();
+        for (int i = 0; i < lines.Count; i++)
+        {
+            if (i > 0) sb.Append('\n');
+            sb.Append(lines.Lines[i].Slice.AsSpan());
+        }
+        return sb.ToString();
+    }
+}

--- a/src/MarkView.Avalonia.Math/MathExtension.cs
+++ b/src/MarkView.Avalonia.Math/MathExtension.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Markdig.Extensions.Mathematics;
+
+using MarkView.Avalonia.Extensions;
+using MarkView.Avalonia.Rendering;
+
+namespace MarkView.Avalonia.Math;
+
+/// <summary>
+/// Registers <see cref="MathBlockRenderer"/> and <see cref="MathInlineRenderer"/>.
+/// <see cref="MathBlock"/> extends Markdig's <c>FencedCodeBlock</c>, the same type
+/// <c>MermaidBlockRenderer</c> broadly accepts — unlike a plain <c>Insert(0, ...)</c>
+/// (which would make whichever extension registers *last* win), this scans for the first
+/// renderer that would accept a <see cref="MathBlock"/> and inserts just before it, so
+/// <c>$$...$$</c> blocks are never swallowed by another extension regardless of the order
+/// <c>.UseMermaid()</c>/<c>.UseMath()</c> (or their <c>IMarkViewExtension</c> equivalents) were
+/// registered in.
+/// </summary>
+public sealed class MathExtension : IMarkViewExtension
+{
+    public void Register(AvaloniaRenderer renderer)
+    {
+        var insertAt = renderer.ObjectRenderers.Count;
+        for (var i = 0; i < renderer.ObjectRenderers.Count; i++)
+        {
+            if (renderer.ObjectRenderers[i].Accept(renderer, typeof(MathBlock)))
+            {
+                insertAt = i;
+                break;
+            }
+        }
+        renderer.ObjectRenderers.Insert(insertAt, new MathBlockRenderer());
+        renderer.ObjectRenderers.Add(new MathInlineRenderer()); // plain LeafInline — no precedence conflict
+    }
+}

--- a/src/MarkView.Avalonia.Math/MathFormulaRenderer.cs
+++ b/src/MarkView.Avalonia.Math/MathFormulaRenderer.cs
@@ -17,8 +17,13 @@ namespace MarkView.Avalonia.Math;
 /// </summary>
 internal static class MathFormulaRenderer
 {
+    private const int MaxLatexLength = 10_000;
+    private const int MaxBraceNestingDepth = 50;
+
     public static Bitmap Render(string latex, SKColor textColor, float fontSize = 16f)
     {
+        EnsureSafeToRender(latex);
+
         var painter = new MathPainter
         {
             LaTeX = latex,
@@ -27,9 +32,35 @@ internal static class MathFormulaRenderer
             DisplayErrorInline = true, // bad LaTeX renders its own error text instead of throwing
         };
 
+        // NOTE: DrawAsStream() has never returned null in empirical testing (even for "" or
+        // whitespace-only input) — this is defensive against a future CSharpMath prerelease
+        // behavior change, not a currently-reachable path.
         using var stream = painter.DrawAsStream()
             ?? throw new InvalidOperationException("CSharpMath failed to render the formula to a stream.");
         return new Bitmap(stream);
+    }
+
+    /// <summary>
+    /// CSharpMath.SkiaSharp's typesetter recurses per nesting level (confirmed: deeply nested
+    /// \frac/\sqrt overflow the stack). A StackOverflowException there is uncatchable and kills
+    /// the whole host process, not just this control — and MarkdownViewer.Source accepts http(s)
+    /// URLs, so rendering untrusted/remote markdown is a supported scenario. Reject pathological
+    /// input before it ever reaches CSharpMath, so the existing (catchable) fallback path handles
+    /// it instead.
+    /// </summary>
+    private static void EnsureSafeToRender(string latex)
+    {
+        if (latex.Length > MaxLatexLength)
+            throw new InvalidOperationException($"LaTeX source exceeds the {MaxLatexLength}-character safety limit.");
+
+        int depth = 0, maxDepth = 0;
+        foreach (var c in latex)
+        {
+            if (c == '{') { depth++; if (depth > maxDepth) maxDepth = depth; }
+            else if (c == '}') { depth--; }
+        }
+        if (maxDepth > MaxBraceNestingDepth)
+            throw new InvalidOperationException($"LaTeX source exceeds the {MaxBraceNestingDepth}-level brace-nesting safety limit.");
     }
 
     /// <summary>

--- a/src/MarkView.Avalonia.Math/MathFormulaRenderer.cs
+++ b/src/MarkView.Avalonia.Math/MathFormulaRenderer.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia;
+using Avalonia.Media.Imaging;
+using Avalonia.Styling;
+
+using CSharpMath.SkiaSharp;
+
+using SkiaSharp;
+
+namespace MarkView.Avalonia.Math;
+
+/// <summary>
+/// Renders a LaTeX formula to a bitmap via CSharpMath.SkiaSharp. Shared by
+/// <see cref="MathBlockRenderer"/> and <see cref="MathInlineRenderer"/>.
+/// </summary>
+internal static class MathFormulaRenderer
+{
+    public static Bitmap Render(string latex, SKColor textColor, float fontSize = 16f)
+    {
+        var painter = new MathPainter
+        {
+            LaTeX = latex,
+            FontSize = fontSize,
+            TextColor = textColor,
+            DisplayErrorInline = true, // bad LaTeX renders its own error text instead of throwing
+        };
+
+        using var stream = painter.DrawAsStream()
+            ?? throw new InvalidOperationException("CSharpMath failed to render the formula to a stream.");
+        return new Bitmap(stream);
+    }
+
+    /// <summary>
+    /// Matches MarkView.Avalonia.Mermaid's exact two-hardcoded-hex-per-theme convention.
+    /// </summary>
+    public static SKColor GetThemeTextColor() =>
+        Application.Current?.ActualThemeVariant == ThemeVariant.Dark
+            ? SKColor.Parse("#FAFAFA")
+            : SKColor.Parse("#27272A");
+}

--- a/src/MarkView.Avalonia.Math/MathFormulaRenderer.cs
+++ b/src/MarkView.Avalonia.Math/MathFormulaRenderer.cs
@@ -33,8 +33,8 @@ internal static class MathFormulaRenderer
         };
 
         // NOTE: DrawAsStream() has never returned null in empirical testing (even for "" or
-        // whitespace-only input) — this is defensive against a future CSharpMath prerelease
-        // behavior change, not a currently-reachable path.
+        // whitespace-only input) — this is defensive against a future CSharpMath behavior change,
+        // not a currently-reachable path.
         using var stream = painter.DrawAsStream()
             ?? throw new InvalidOperationException("CSharpMath failed to render the formula to a stream.");
         return new Bitmap(stream);

--- a/src/MarkView.Avalonia.Math/MathInlineRenderer.cs
+++ b/src/MarkView.Avalonia.Math/MathInlineRenderer.cs
@@ -3,6 +3,7 @@
 
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Documents;
 using Avalonia.Media;
 
 using Markdig.Extensions.Mathematics;
@@ -24,31 +25,49 @@ public sealed class MathInlineRenderer : AvaloniaObjectRenderer<MathInline>
         var image = new Image { Stretch = Stretch.None };
         image.Classes.Add("markdown-math-inline");
 
+        if (!ApplyTheme(isFirstRender: true))
+        {
+            // First render failed before the image was ever written to the renderer's inline
+            // stack — we're still inside the synchronous initial Write() call here, so writing a
+            // plain-text fallback instead is safe (unlike from the later theme-change callback,
+            // which must never re-enter the stack — see the comment inside ApplyTheme below).
+            // We deliberately haven't subscribed to theme-change notifications yet at this point:
+            // the discarded image is never attached to the visual tree, so DetachedFromLogicalTree
+            // would never fire and an earlier subscription would leak the handler on
+            // Application.Current forever.
+            renderer.WriteInline(new Run(source));
+            return;
+        }
+
         void OnThemeChanged(object? s, AvaloniaPropertyChangedEventArgs e)
         {
             if (e.Property.Name != nameof(Application.ActualThemeVariant)) return;
-            ApplyTheme();
+            ApplyTheme(isFirstRender: false);
         }
         Application.Current!.PropertyChanged += OnThemeChanged;
         image.DetachedFromLogicalTree += (_, _) =>
             Application.Current?.PropertyChanged -= OnThemeChanged;
 
-        ApplyTheme();
         renderer.WriteInline(image);
 
-        void ApplyTheme()
+        bool ApplyTheme(bool isFirstRender)
         {
             try
             {
                 image.Source = MathFormulaRenderer.Render(source, MathFormulaRenderer.GetThemeTextColor());
+                return true;
             }
             catch (Exception)
             {
-                // Inline context can't safely re-enter the renderer's inline stack from an
-                // async/theme-change callback the way the block renderer's Border can mutate
-                // its own Child — leave the image showing its last successfully rendered
-                // bitmap (or blank, on first-render failure) rather than risk corrupting
-                // whatever inline collection is active at callback time.
+                if (!isFirstRender)
+                {
+                    // Inline context can't safely re-enter the renderer's inline stack from this
+                    // async/theme-change callback — unlike the block renderer's Border, an inline
+                    // Image has no room for a fallback panel. Leave the image showing its last
+                    // successfully rendered bitmap rather than risk corrupting whatever inline
+                    // collection is active at callback time.
+                }
+                return false;
             }
         }
     }

--- a/src/MarkView.Avalonia.Math/MathInlineRenderer.cs
+++ b/src/MarkView.Avalonia.Math/MathInlineRenderer.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+
+using Markdig.Extensions.Mathematics;
+
+using MarkView.Avalonia.Rendering;
+
+namespace MarkView.Avalonia.Math;
+
+/// <summary>
+/// Renders Markdig <see cref="MathInline"/> nodes (<c>$...$</c>) as an inline image
+/// produced by CSharpMath.SkiaSharp.
+/// </summary>
+public sealed class MathInlineRenderer : AvaloniaObjectRenderer<MathInline>
+{
+    protected override void Write(AvaloniaRenderer renderer, MathInline obj)
+    {
+        var source = obj.Content.ToString();
+
+        var image = new Image { Stretch = Stretch.None };
+        image.Classes.Add("markdown-math-inline");
+
+        void OnThemeChanged(object? s, AvaloniaPropertyChangedEventArgs e)
+        {
+            if (e.Property.Name != nameof(Application.ActualThemeVariant)) return;
+            ApplyTheme();
+        }
+        Application.Current!.PropertyChanged += OnThemeChanged;
+        image.DetachedFromLogicalTree += (_, _) =>
+            Application.Current?.PropertyChanged -= OnThemeChanged;
+
+        ApplyTheme();
+        renderer.WriteInline(image);
+
+        void ApplyTheme()
+        {
+            try
+            {
+                image.Source = MathFormulaRenderer.Render(source, MathFormulaRenderer.GetThemeTextColor());
+            }
+            catch (Exception)
+            {
+                // Inline context can't safely re-enter the renderer's inline stack from an
+                // async/theme-change callback the way the block renderer's Border can mutate
+                // its own Child — leave the image showing its last successfully rendered
+                // bitmap (or blank, on first-render failure) rather than risk corrupting
+                // whatever inline collection is active at callback time.
+            }
+        }
+    }
+}

--- a/src/MarkView.Avalonia.Math/README.md
+++ b/src/MarkView.Avalonia.Math/README.md
@@ -10,8 +10,6 @@ LaTeX math rendering extension for [MarkView.Avalonia](https://www.nuget.org/pac
 
 Because `$` is common in ordinary prose (currency amounts, etc.), this parsing is opt-in only — enabling it changes how literal `$` characters are interpreted in your documents.
 
-> **Prerelease dependency:** this package currently pins `CSharpMath.SkiaSharp` to a `1.0.0-pre.1` prerelease build, since it's the version CSharpMath explicitly targets .NET 10 with. **This branch/package must not be merged or released until CSharpMath ships a stable 1.0.0** — re-pin the version at that point.
-
 ## Installation
 
 ```bash

--- a/src/MarkView.Avalonia.Math/README.md
+++ b/src/MarkView.Avalonia.Math/README.md
@@ -1,0 +1,73 @@
+# MarkView.Avalonia.Math
+
+[![NuGet Version](https://img.shields.io/nuget/v/MarkView.Avalonia.Math)](https://www.nuget.org/packages/MarkView.Avalonia.Math)
+[![NuGet Downloads](https://img.shields.io/nuget/dt/MarkView.Avalonia.Math)](https://www.nuget.org/packages/MarkView.Avalonia.Math)
+[![Avalonia](https://img.shields.io/badge/Avalonia-12-blue)](https://avaloniaui.net)
+[![CI](https://github.com/Kryptos-FR/MarkView.Avalonia/actions/workflows/ci.yml/badge.svg)](https://github.com/Kryptos-FR/MarkView.Avalonia/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/Kryptos-FR/MarkView.Avalonia)](../../LICENSE.md)
+
+LaTeX math rendering extension for [MarkView.Avalonia](https://www.nuget.org/packages/MarkView.Avalonia). Renders `$...$` (inline) and `$$...$$` (block) math using [CSharpMath](https://github.com/verybadcat/CSharpMath)'s SkiaSharp renderer — pure .NET, no browser, no WebView, no JavaScript runtime.
+
+> **Prerelease dependency:** this package currently pins `CSharpMath.SkiaSharp` to a `1.0.0-pre.1` prerelease build, since it's the version CSharpMath explicitly targets .NET 10 with. It will be re-pinned to a stable release once one ships.
+
+## Installation
+
+```bash
+dotnet add package MarkView.Avalonia.Math
+```
+
+## Quick Start
+
+Call `UseMath()` before setting `Markdown`:
+
+```csharp
+var viewer = new MarkdownViewer();
+viewer.UseMath();
+viewer.Markdown = markdownText;
+```
+
+Or activate globally at application startup:
+
+```csharp
+// App.axaml.cs
+MarkdownViewerDefaults.Extensions.AddMath();
+MarkdownViewerDefaults.Pipeline = new MarkdownPipelineBuilder()
+    .UseSupportedExtensions()
+    .UseMathematics()
+    .Build();
+```
+
+Unlike most opt-in extensions in this repo, math needs both a pipeline change (`.UseMathematics()`,
+so `$`/`$$` are even parsed) and a renderer registration — `UseMath()` does both for you.
+
+```markdown
+Inline: Einstein's famous equation is $E = mc^2$.
+
+Block:
+
+$$
+\left( \sum_{k=1}^n a_k b_k \right)^2 \leq \left( \sum_{k=1}^n a_k^2 \right) \left( \sum_{k=1}^n b_k^2 \right)
+$$
+```
+
+## Theme Awareness
+
+Formulas are rendered with colours matching the active Avalonia theme variant (dark `#FAFAFA`,
+light `#27272A` text), and are automatically re-rendered when the user switches between light and
+dark.
+
+## Combining with Mermaid
+
+`MathExtension` and `MermaidExtension` can both be registered in either order — each scans for
+(rather than assumes) its position in the renderer list, so `$$...$$` blocks are never mistaken
+for a Mermaid diagram or a plain code block regardless of registration order.
+
+## Error Handling
+
+Invalid LaTeX renders CSharpMath's own inline error text rather than throwing. Unexpected
+rendering failures fall back to a plain-text panel (block math) or leave the last successfully
+rendered formula in place (inline math).
+
+## License
+
+[MIT](../../LICENSE.md) © Nicolas Musset

--- a/src/MarkView.Avalonia.Math/README.md
+++ b/src/MarkView.Avalonia.Math/README.md
@@ -8,7 +8,9 @@
 
 LaTeX math rendering extension for [MarkView.Avalonia](https://www.nuget.org/packages/MarkView.Avalonia). Renders `$...$` (inline) and `$$...$$` (block) math using [CSharpMath](https://github.com/verybadcat/CSharpMath)'s SkiaSharp renderer — pure .NET, no browser, no WebView, no JavaScript runtime.
 
-> **Prerelease dependency:** this package currently pins `CSharpMath.SkiaSharp` to a `1.0.0-pre.1` prerelease build, since it's the version CSharpMath explicitly targets .NET 10 with. It will be re-pinned to a stable release once one ships.
+Because `$` is common in ordinary prose (currency amounts, etc.), this parsing is opt-in only — enabling it changes how literal `$` characters are interpreted in your documents.
+
+> **Prerelease dependency:** this package currently pins `CSharpMath.SkiaSharp` to a `1.0.0-pre.1` prerelease build, since it's the version CSharpMath explicitly targets .NET 10 with. **This branch/package must not be merged or released until CSharpMath ships a stable 1.0.0** — re-pin the version at that point.
 
 ## Installation
 

--- a/src/MarkView.Avalonia.Math/packages.lock.json
+++ b/src/MarkView.Avalonia.Math/packages.lock.json
@@ -1,0 +1,88 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "CSharpMath.SkiaSharp": {
+        "type": "Direct",
+        "requested": "[1.0.0-pre.1, )",
+        "resolved": "1.0.0-pre.1",
+        "contentHash": "iie1WLYYdo7w9vrz1a1qUZoLj1YNpLIVJ+8/wrdY7krqd/el9Elmy+6HioFtId9HDbP6NTHnAtS7xt+HFatfqQ==",
+        "dependencies": {
+          "CSharpMath.Rendering": "1.0.0-pre.1",
+          "SkiaSharp": "3.119.1"
+        }
+      },
+      "Avalonia.BuildServices": {
+        "type": "Transitive",
+        "resolved": "11.3.2",
+        "contentHash": "qHDToxto1e3hci5YqbG9n0Ty8mlp3zBUN5wT66wKqaDVzXyQ0do3EnRILd4Ke9jpvsktaPpgE0YjEk7hornryQ=="
+      },
+      "Avalonia.Remote.Protocol": {
+        "type": "Transitive",
+        "resolved": "12.1.1",
+        "contentHash": "0u77tnOwJnHtVLu+WBY7T56fN9W8n7++Uq9kHW6J+bfv5y13WZUMVS+PBzoBe32taYvz/oSomDGO1V41AHaFcQ=="
+      },
+      "CSharpMath": {
+        "type": "Transitive",
+        "resolved": "1.0.0-pre.1",
+        "contentHash": "DxNiPY3GTeE873k5CFOz8b7DGn99qeBlX/9fBWMFJMrUMFKJq6Hr7Qf1WfN72kHUt9pzv081co4KOlWtbzzRCg=="
+      },
+      "CSharpMath.Rendering": {
+        "type": "Transitive",
+        "resolved": "1.0.0-pre.1",
+        "contentHash": "Z7Pywza48XD9ygAtipuMDt+0SjHSUPLOdpT8xpA8QZqQ3j+HmXho54sFNPnRkMl7hIwBVmLbRObeQ1oN2rZJVg==",
+        "dependencies": {
+          "CSharpMath": "1.0.0-pre.1"
+        }
+      },
+      "MicroCom.Runtime": {
+        "type": "Transitive",
+        "resolved": "0.11.6",
+        "contentHash": "NdNWGDiZ6eS/Mf/9+QHR91cj1K7Hy+PX9yrHI/zM7xFYuj9IWT2uxtB6sCHjrnxAeLV9fut1R6zHDUGKX6f9lQ=="
+      },
+      "SkiaSharp": {
+        "type": "Transitive",
+        "resolved": "3.119.1",
+        "contentHash": "+Ru1BTSZQne3Vp+vbSb50Ke3Nlc3ZnItxx4+751J9WZ8YzLKAV/n+9DAo4zFTyeCI//ueT63c+VybmTTpYBEiw==",
+        "dependencies": {
+          "SkiaSharp.NativeAssets.Win32": "3.119.1",
+          "SkiaSharp.NativeAssets.macOS": "3.119.1"
+        }
+      },
+      "SkiaSharp.NativeAssets.macOS": {
+        "type": "Transitive",
+        "resolved": "3.119.1",
+        "contentHash": "6hR3BdLhApjDxR1bFrJ7/lMydPfI01s3K+3WjIXFUlfC0MFCFCwRzv+JtzIkW9bDXs7XUVQS+6EVf0uzCasnGQ=="
+      },
+      "SkiaSharp.NativeAssets.Win32": {
+        "type": "Transitive",
+        "resolved": "3.119.1",
+        "contentHash": "8C4GSXVJqSr0y3Tyyv5jz6MJSTVUyYkMjeKrzK+VyZPGLo89MNoUEclVuYahzOCDdtbfXrd2HtxXfDuvoSXrUw=="
+      },
+      "markview.avalonia": {
+        "type": "Project",
+        "dependencies": {
+          "Avalonia": "[12.1.1, )",
+          "Markdig": "[1.3.2, )"
+        }
+      },
+      "Avalonia": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "o8pZ1oE9AQ6gklpGM0lnOBp/JlVH0J/0mYszBf0GsSAcEnzHNCLM9NnrPZwKu4j2q9oNbVHYzzEPkszQeuqaKw==",
+        "dependencies": {
+          "Avalonia.BuildServices": "11.3.2",
+          "Avalonia.Remote.Protocol": "12.1.1",
+          "MicroCom.Runtime": "0.11.6"
+        }
+      },
+      "Markdig": {
+        "type": "CentralTransitive",
+        "requested": "[1.3.2, )",
+        "resolved": "1.3.2",
+        "contentHash": "fZgOC/3CswUrndjDTac70aQpYdtxbW5+5bRumR7vzvI2HJbkmgKisB1c9oT+GA6v0jB/JDR9BLa9FiPzQmaK6A=="
+      }
+    }
+  }
+}

--- a/src/MarkView.Avalonia.Math/packages.lock.json
+++ b/src/MarkView.Avalonia.Math/packages.lock.json
@@ -4,12 +4,22 @@
     "net10.0": {
       "CSharpMath.SkiaSharp": {
         "type": "Direct",
-        "requested": "[1.0.0-pre.1, )",
-        "resolved": "1.0.0-pre.1",
-        "contentHash": "iie1WLYYdo7w9vrz1a1qUZoLj1YNpLIVJ+8/wrdY7krqd/el9Elmy+6HioFtId9HDbP6NTHnAtS7xt+HFatfqQ==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "3SMI0o2EZi2/GskH6T5s9GDaBq9u0VBd/o8Geqd+FyPxEXCcmzECOZ3PdVdob/YNevl4okOTbqZrHZS2O28/ZQ==",
         "dependencies": {
-          "CSharpMath.Rendering": "1.0.0-pre.1",
-          "SkiaSharp": "3.119.1"
+          "CSharpMath.Rendering": "0.5.1",
+          "SkiaSharp": "2.80.1"
+        }
+      },
+      "SkiaSharp": {
+        "type": "Direct",
+        "requested": "[4.148.0, )",
+        "resolved": "4.148.0",
+        "contentHash": "t+oZDnzvi0en060BFDTmJ16C0zjsiXRrtOe70luIuIi/exVZtl1obrYh8D+IoHlGtp7bqzEBVncafbAl0ttmPQ==",
+        "dependencies": {
+          "SkiaSharp.NativeAssets.Win32": "4.148.0",
+          "SkiaSharp.NativeAssets.macOS": "4.148.0"
         }
       },
       "Avalonia.BuildServices": {
@@ -24,15 +34,23 @@
       },
       "CSharpMath": {
         "type": "Transitive",
-        "resolved": "1.0.0-pre.1",
-        "contentHash": "DxNiPY3GTeE873k5CFOz8b7DGn99qeBlX/9fBWMFJMrUMFKJq6Hr7Qf1WfN72kHUt9pzv081co4KOlWtbzzRCg=="
+        "resolved": "0.5.1",
+        "contentHash": "CBAtejk24icPQNJWPjUDGUqklNLpfglpRxQljiezn2MQrxL5cIVuouCVnw6ipU3cft9Tq8YfS6f/JPhSjhFtFA=="
+      },
+      "CSharpMath.Editor": {
+        "type": "Transitive",
+        "resolved": "0.5.1",
+        "contentHash": "q5MFAjI7TO41PtGFNHBFwOw3J3IS7Dnm7aJHEgPxMWE5wl1H5byOo0pJnGwXevjhoSRssGRJH2KCXgn0KbGJFQ==",
+        "dependencies": {
+          "CSharpMath": "0.5.1"
+        }
       },
       "CSharpMath.Rendering": {
         "type": "Transitive",
-        "resolved": "1.0.0-pre.1",
-        "contentHash": "Z7Pywza48XD9ygAtipuMDt+0SjHSUPLOdpT8xpA8QZqQ3j+HmXho54sFNPnRkMl7hIwBVmLbRObeQ1oN2rZJVg==",
+        "resolved": "0.5.1",
+        "contentHash": "H4tctQzgpQmLICON1QAJtfm3/dj4exoxEKTuF9oO5YkHXMANWNfOQKwVtAx6n78hcD6WidwF2v2pH8Z/cOw/gg==",
         "dependencies": {
-          "CSharpMath": "1.0.0-pre.1"
+          "CSharpMath.Editor": "0.5.1"
         }
       },
       "MicroCom.Runtime": {
@@ -40,24 +58,15 @@
         "resolved": "0.11.6",
         "contentHash": "NdNWGDiZ6eS/Mf/9+QHR91cj1K7Hy+PX9yrHI/zM7xFYuj9IWT2uxtB6sCHjrnxAeLV9fut1R6zHDUGKX6f9lQ=="
       },
-      "SkiaSharp": {
-        "type": "Transitive",
-        "resolved": "3.119.1",
-        "contentHash": "+Ru1BTSZQne3Vp+vbSb50Ke3Nlc3ZnItxx4+751J9WZ8YzLKAV/n+9DAo4zFTyeCI//ueT63c+VybmTTpYBEiw==",
-        "dependencies": {
-          "SkiaSharp.NativeAssets.Win32": "3.119.1",
-          "SkiaSharp.NativeAssets.macOS": "3.119.1"
-        }
-      },
       "SkiaSharp.NativeAssets.macOS": {
         "type": "Transitive",
-        "resolved": "3.119.1",
-        "contentHash": "6hR3BdLhApjDxR1bFrJ7/lMydPfI01s3K+3WjIXFUlfC0MFCFCwRzv+JtzIkW9bDXs7XUVQS+6EVf0uzCasnGQ=="
+        "resolved": "4.148.0",
+        "contentHash": "1iESVxlqNNbQUiFODuyQJ/5dYUNYwGzZBUyaKNU3pJRM8zPFUkdMW0UZcZPvd6xwrjn53HYklJyKvetXC6ri+A=="
       },
       "SkiaSharp.NativeAssets.Win32": {
         "type": "Transitive",
-        "resolved": "3.119.1",
-        "contentHash": "8C4GSXVJqSr0y3Tyyv5jz6MJSTVUyYkMjeKrzK+VyZPGLo89MNoUEclVuYahzOCDdtbfXrd2HtxXfDuvoSXrUw=="
+        "resolved": "4.148.0",
+        "contentHash": "LegvQ9zAi9Tmot2YOLv8mcK+g3wbEYfCWUoC5JtyHaN8QrxsaMvfJ8pFPvnEOVuY8qXxs8vVqrO/x42/YaFDRA=="
       },
       "markview.avalonia": {
         "type": "Project",

--- a/src/MarkView.Avalonia.Mermaid/MermaidExtension.cs
+++ b/src/MarkView.Avalonia.Mermaid/MermaidExtension.cs
@@ -1,19 +1,35 @@
 // Copyright (c) Nicolas Musset
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Markdig.Syntax;
+
 using MarkView.Avalonia.Extensions;
 using MarkView.Avalonia.Rendering;
 
 namespace MarkView.Avalonia.Mermaid;
 
 /// <summary>
-/// Registers <see cref="MermaidBlockRenderer"/> at the front of the renderer list
-/// so it intercepts <c>```mermaid</c> fences before <c>CodeBlockRenderer</c>.
+/// Registers <see cref="MermaidBlockRenderer"/> so it intercepts <c>```mermaid</c> fences
+/// before <c>CodeBlockRenderer</c>. Scans for the first renderer that would accept a
+/// <see cref="FencedCodeBlock"/> and inserts just before it, rather than a fixed
+/// <c>Insert(0, ...)</c> — that way a narrower, more specific fenced-block renderer
+/// (e.g. MarkView.Avalonia.Math's <c>MathBlockRenderer</c>, which only accepts its own
+/// <c>MathBlock</c> subtype) registered before or after this one is never displaced from the
+/// front of the list, regardless of registration order.
 /// </summary>
 public sealed class MermaidExtension : IMarkViewExtension
 {
     public void Register(AvaloniaRenderer renderer)
     {
-        renderer.ObjectRenderers.Insert(0, new MermaidBlockRenderer());
+        var insertAt = renderer.ObjectRenderers.Count;
+        for (var i = 0; i < renderer.ObjectRenderers.Count; i++)
+        {
+            if (renderer.ObjectRenderers[i].Accept(renderer, typeof(FencedCodeBlock)))
+            {
+                insertAt = i;
+                break;
+            }
+        }
+        renderer.ObjectRenderers.Insert(insertAt, new MermaidBlockRenderer());
     }
 }

--- a/src/MarkView.Avalonia.Mermaid/README.md
+++ b/src/MarkView.Avalonia.Mermaid/README.md
@@ -93,7 +93,7 @@ Mermaider renders diagrams in managed .NET code (no JavaScript runtime). If diag
 
 ## How It Works
 
-`UseMermaid()` registers a `MermaidExtension` which inserts `MermaidBlockRenderer` at index 0 of `renderer.ObjectRenderers`. Being first in the renderer list, it intercepts every `FencedCodeBlock` before the default `CodeBlockRenderer`.
+`UseMermaid()` registers a `MermaidExtension` which inserts `MermaidBlockRenderer` immediately before the first renderer that already accepts a `FencedCodeBlock` (not always at index 0 — this keeps registration order-independent when a sibling extension such as `MarkView.Avalonia.Math` is also registered), so it intercepts every `FencedCodeBlock` before the default `CodeBlockRenderer`.
 
 For mermaid blocks:
 1. Source lines are extracted from the fenced block.

--- a/tests/MarkView.Avalonia.Math.Tests/MarkView.Avalonia.Math.Tests.csproj
+++ b/tests/MarkView.Avalonia.Math.Tests/MarkView.Avalonia.Math.Tests.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MarkView.Avalonia.Math\MarkView.Avalonia.Math.csproj" />
+    <ProjectReference Include="..\..\src\MarkView.Avalonia.Mermaid\MarkView.Avalonia.Mermaid.csproj" />
     <ProjectReference Include="..\..\src\MarkView.Avalonia\MarkView.Avalonia.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/MarkView.Avalonia.Math.Tests/MarkView.Avalonia.Math.Tests.csproj
+++ b/tests/MarkView.Avalonia.Math.Tests/MarkView.Avalonia.Math.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <UseAppHost>true</UseAppHost>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Headless.XUnit" />
+    <PackageReference Include="Avalonia.Themes.Fluent" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MarkView.Avalonia.Math\MarkView.Avalonia.Math.csproj" />
+    <ProjectReference Include="..\..\src\MarkView.Avalonia\MarkView.Avalonia.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/MarkView.Avalonia.Math.Tests/MarkdownViewerDefaultsExtensionsTests.cs
+++ b/tests/MarkView.Avalonia.Math.Tests/MarkdownViewerDefaultsExtensionsTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Headless.XUnit;
+
+using Xunit;
+
+namespace MarkView.Avalonia.Math.Tests;
+
+public class MarkdownViewerDefaultsExtensionsTests
+{
+    [AvaloniaFact]
+    public void AddMath_adds_MathExtension_to_defaults()
+    {
+        using var _ = new MarkdownViewerDefaultsMathScope();
+
+        MarkdownViewerDefaults.Extensions.AddMath();
+
+        Assert.Single(MarkdownViewerDefaults.Extensions.OfType<MathExtension>());
+    }
+}
+
+// Save/restore scope for this test project (self-contained, no dependency on MarkView.Avalonia.Tests)
+internal sealed class MarkdownViewerDefaultsMathScope : IDisposable
+{
+    private readonly Markdig.MarkdownPipeline? _savedPipeline;
+    private readonly MarkView.Avalonia.Extensions.IMarkViewExtension[] _savedExtensions;
+
+    public MarkdownViewerDefaultsMathScope()
+    {
+        _savedPipeline = MarkdownViewerDefaults.Pipeline;
+        _savedExtensions = MarkdownViewerDefaults.Extensions.ToArray();
+    }
+
+    public void Dispose()
+    {
+        MarkdownViewerDefaults.Pipeline = _savedPipeline;
+        MarkdownViewerDefaults.Extensions.Clear();
+        foreach (var e in _savedExtensions)
+            MarkdownViewerDefaults.Extensions.Add(e);
+    }
+}

--- a/tests/MarkView.Avalonia.Math.Tests/MathBlockRendererTests.cs
+++ b/tests/MarkView.Avalonia.Math.Tests/MathBlockRendererTests.cs
@@ -49,4 +49,13 @@ public class MathBlockRendererTests
         var image = Assert.IsType<Image>(border.Child);
         Assert.NotNull(image.Source);
     }
+
+    [AvaloniaFact]
+    public void Math_block_with_pathologically_nested_braces_falls_back_instead_of_crashing()
+    {
+        var nested = new string('{', 60) + "x" + new string('}', 60); // 60 > MaxBraceNestingDepth (50) — throws before ever touching CSharpMath
+        var result = Render($"$$\n{nested}\n$$");
+        var border = Assert.IsType<Border>(Assert.Single(result.Children));
+        Assert.Contains("markdown-math-fallback", border.Classes);
+    }
 }

--- a/tests/MarkView.Avalonia.Math.Tests/MathBlockRendererTests.cs
+++ b/tests/MarkView.Avalonia.Math.Tests/MathBlockRendererTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+
+using Markdig;
+
+using MarkView.Avalonia.Rendering;
+
+using Xunit;
+
+namespace MarkView.Avalonia.Math.Tests;
+
+public class MathBlockRendererTests
+{
+    private static StackPanel Render(string markdown)
+    {
+        var pipeline = new MarkdownPipelineBuilder().UseMathematics().Build();
+        var document = Markdown.Parse(markdown, pipeline);
+        var renderer = new AvaloniaRenderer();
+        renderer.ObjectRenderers.Insert(0, new MathBlockRenderer());
+        pipeline.Setup(renderer);
+        renderer.Render(document);
+        return renderer.RootPanel;
+    }
+
+    [AvaloniaFact]
+    public void Math_block_renders_border_with_math_block_class()
+    {
+        var result = Render("$$\nx^2\n$$");
+        var border = Assert.IsType<Border>(Assert.Single(result.Children));
+        Assert.Contains("markdown-math-block", border.Classes);
+    }
+
+    [AvaloniaFact]
+    public void Math_block_border_contains_image()
+    {
+        var result = Render("$$\nx^2\n$$");
+        var border = Assert.IsType<Border>(Assert.Single(result.Children));
+        Assert.IsType<Image>(border.Child);
+    }
+
+    [AvaloniaFact]
+    public void Math_block_image_has_non_null_bitmap_source()
+    {
+        var result = Render("$$\nx^2\n$$");
+        var border = Assert.IsType<Border>(Assert.Single(result.Children));
+        var image = Assert.IsType<Image>(border.Child);
+        Assert.NotNull(image.Source);
+    }
+}

--- a/tests/MarkView.Avalonia.Math.Tests/MathExtensionTests.cs
+++ b/tests/MarkView.Avalonia.Math.Tests/MathExtensionTests.cs
@@ -82,4 +82,59 @@ public class MathExtensionTests
         viewer.UseMath();
         Assert.NotNull(viewer.Pipeline);
     }
+
+    [AvaloniaFact]
+    public void UseMath_renders_math_correctly_even_when_markdown_was_set_before_UseMath()
+    {
+        // Regression test: Markdown is set BEFORE UseMath() is called, so the viewer's initial
+        // render (triggered by the Markdown property changing) runs with neither the math
+        // pipeline extension nor MathExtension's renderer registered. UseMath() must still end
+        // up rendering the formula correctly once it runs — this ordering bug would not be
+        // caught by tests that only inspect viewer.Pipeline/viewer.Extensions state.
+        var viewer = new MarkdownViewer();
+        viewer.Markdown = "$$\nx^2\n$$";
+        viewer.UseMath();
+
+        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
+        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var panel = Assert.IsType<StackPanel>(contentGrid.Children[0]);
+        var border = Assert.IsType<Border>(Assert.Single(panel.Children));
+        Assert.Contains("markdown-math-block", border.Classes);
+        var image = Assert.IsType<Image>(border.Child);
+        Assert.NotNull(image.Source);
+    }
+
+    [AvaloniaTheory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void UseMath_and_UseMermaid_together_render_both_correctly_regardless_of_order(bool mathFirst)
+    {
+        var viewer = new MarkdownViewer();
+        if (mathFirst)
+        {
+            viewer.UseMath();
+            viewer.UseMermaid();
+        }
+        else
+        {
+            viewer.UseMermaid();
+            viewer.UseMath();
+        }
+
+        viewer.Markdown = "$$\nx^2\n$$\n\n```mermaid\ngraph TD;\nA-->B;\n```";
+
+        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
+        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var panel = Assert.IsType<StackPanel>(contentGrid.Children[0]);
+        Assert.Equal(2, panel.Children.Count);
+
+        var mathBorder = Assert.IsType<Border>(panel.Children[0]);
+        Assert.Contains("markdown-math-block", mathBorder.Classes);
+        var mathImage = Assert.IsType<Image>(mathBorder.Child);
+        Assert.NotNull(mathImage.Source);
+
+        var mermaidBorder = Assert.IsType<Border>(panel.Children[1]);
+        Assert.Contains("markdown-mermaid", mermaidBorder.Classes);
+        Assert.IsType<Image>(mermaidBorder.Child);
+    }
 }

--- a/tests/MarkView.Avalonia.Math.Tests/MathExtensionTests.cs
+++ b/tests/MarkView.Avalonia.Math.Tests/MathExtensionTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+
+using Markdig;
+
+using MarkView.Avalonia.Mermaid;
+using MarkView.Avalonia.Rendering;
+
+using Xunit;
+
+namespace MarkView.Avalonia.Math.Tests;
+
+public class MathExtensionTests
+{
+    [AvaloniaFact]
+    public void MathExtension_Register_inserts_MathBlockRenderer_before_default_CodeBlockRenderer()
+    {
+        var renderer = new AvaloniaRenderer();
+        new MathExtension().Register(renderer);
+
+        var pipeline = new MarkdownPipelineBuilder().UseMathematics().Build();
+        var document = Markdown.Parse("$$\nx^2\n$$", pipeline);
+        pipeline.Setup(renderer);
+        renderer.Render(document);
+
+        var border = Assert.IsType<Border>(Assert.Single(renderer.RootPanel.Children));
+        Assert.Contains("markdown-math-block", border.Classes);
+    }
+
+    [AvaloniaFact]
+    public void MathExtension_registers_before_MermaidExtension_regardless_of_call_order()
+    {
+        // Math registered first, Mermaid second — Mermaid's Insert(0, ...) must not
+        // steal $$ blocks away from MathBlockRenderer.
+        var renderer = new AvaloniaRenderer();
+        new MathExtension().Register(renderer);
+        new MermaidExtension().Register(renderer);
+
+        var pipeline = new MarkdownPipelineBuilder().UseMathematics().Build();
+        var document = Markdown.Parse("$$\nx^2\n$$", pipeline);
+        pipeline.Setup(renderer);
+        renderer.Render(document);
+
+        var border = Assert.IsType<Border>(Assert.Single(renderer.RootPanel.Children));
+        Assert.Contains("markdown-math-block", border.Classes);
+    }
+
+    [AvaloniaFact]
+    public void MermaidExtension_registers_before_MathExtension_regardless_of_call_order()
+    {
+        // Reverse order from the test above — must still be order-independent.
+        var renderer = new AvaloniaRenderer();
+        new MermaidExtension().Register(renderer);
+        new MathExtension().Register(renderer);
+
+        var pipeline = new MarkdownPipelineBuilder().UseMathematics().Build();
+        var document = Markdown.Parse("$$\nx^2\n$$", pipeline);
+        pipeline.Setup(renderer);
+        renderer.Render(document);
+
+        var border = Assert.IsType<Border>(Assert.Single(renderer.RootPanel.Children));
+        Assert.Contains("markdown-math-block", border.Classes);
+    }
+
+    [AvaloniaFact]
+    public void UseMath_adds_MathExtension_to_viewer()
+    {
+        var viewer = new MarkdownViewer();
+        var result = viewer.UseMath();
+        Assert.Same(viewer, result);
+        Assert.Single(viewer.Extensions);
+        Assert.IsType<MathExtension>(viewer.Extensions[0]);
+    }
+
+    [AvaloniaFact]
+    public void UseMath_sets_pipeline_on_viewer()
+    {
+        var viewer = new MarkdownViewer();
+        viewer.UseMath();
+        Assert.NotNull(viewer.Pipeline);
+    }
+}

--- a/tests/MarkView.Avalonia.Math.Tests/MathInlineRendererTests.cs
+++ b/tests/MarkView.Avalonia.Math.Tests/MathInlineRendererTests.cs
@@ -54,4 +54,14 @@ public class MathInlineRendererTests
         var image = Assert.IsType<Image>(container.Child);
         Assert.NotNull(image.Source);
     }
+
+    [AvaloniaFact]
+    public void Inline_math_first_render_failure_falls_back_to_source_text()
+    {
+        var nested = new string('{', 60) + "x" + new string('}', 60);
+        var result = Render($"${nested}$");
+        var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(result.Children));
+        var run = Assert.IsType<Run>(Assert.Single(textBlock.Inlines!));
+        Assert.Equal(nested, run.Text);
+    }
 }

--- a/tests/MarkView.Avalonia.Math.Tests/MathInlineRendererTests.cs
+++ b/tests/MarkView.Avalonia.Math.Tests/MathInlineRendererTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Headless.XUnit;
+
+using Markdig;
+
+using MarkView.Avalonia.Rendering;
+
+using Xunit;
+
+namespace MarkView.Avalonia.Math.Tests;
+
+public class MathInlineRendererTests
+{
+    private static StackPanel Render(string markdown)
+    {
+        var pipeline = new MarkdownPipelineBuilder().UseMathematics().Build();
+        var document = Markdown.Parse(markdown, pipeline);
+        var renderer = new AvaloniaRenderer();
+        renderer.ObjectRenderers.Add(new MathInlineRenderer());
+        pipeline.Setup(renderer);
+        renderer.Render(document);
+        return renderer.RootPanel;
+    }
+
+    [AvaloniaFact]
+    public void Inline_math_renders_inside_InlineUIContainer()
+    {
+        var result = Render("Einstein said $E=mc^2$ once.");
+        var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(result.Children));
+        var container = textBlock.Inlines!.OfType<InlineUIContainer>().Single();
+        Assert.IsType<Image>(container.Child);
+    }
+
+    [AvaloniaFact]
+    public void Inline_math_image_has_math_inline_class()
+    {
+        var result = Render("$x^2$");
+        var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(result.Children));
+        var container = textBlock.Inlines!.OfType<InlineUIContainer>().Single();
+        var image = Assert.IsType<Image>(container.Child);
+        Assert.Contains("markdown-math-inline", image.Classes);
+    }
+
+    [AvaloniaFact]
+    public void Inline_math_image_has_non_null_bitmap_source()
+    {
+        var result = Render("$x^2$");
+        var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(result.Children));
+        var container = textBlock.Inlines!.OfType<InlineUIContainer>().Single();
+        var image = Assert.IsType<Image>(container.Child);
+        Assert.NotNull(image.Source);
+    }
+}

--- a/tests/MarkView.Avalonia.Math.Tests/TestApp.cs
+++ b/tests/MarkView.Avalonia.Math.Tests/TestApp.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia;
+using Avalonia.Headless;
+using Avalonia.Themes.Fluent;
+
+[assembly: AvaloniaTestApplication(typeof(MarkView.Avalonia.Math.Tests.TestApp))]
+
+namespace MarkView.Avalonia.Math.Tests;
+
+public class TestApp : Application
+{
+    public override void Initialize()
+    {
+        Styles.Add(new FluentTheme());
+    }
+
+    public static AppBuilder BuildAvaloniaApp()
+        => AppBuilder.Configure<TestApp>()
+            .UseHeadless(new AvaloniaHeadlessPlatformOptions());
+}

--- a/tests/MarkView.Avalonia.Math.Tests/packages.lock.json
+++ b/tests/MarkView.Avalonia.Math.Tests/packages.lock.json
@@ -83,6 +83,20 @@
         "resolved": "12.1.1",
         "contentHash": "0u77tnOwJnHtVLu+WBY7T56fN9W8n7++Uq9kHW6J+bfv5y13WZUMVS+PBzoBe32taYvz/oSomDGO1V41AHaFcQ=="
       },
+      "Avalonia.Skia": {
+        "type": "Transitive",
+        "resolved": "12.0.0",
+        "contentHash": "IZM3kE0m8glk3wS1ygASkox08/knVXy05qCbtpFbp3Ochk5/5+89jJoe94ECCmptiVS6XP2h9R13N7t3EuSFlA==",
+        "dependencies": {
+          "Avalonia": "12.0.0",
+          "HarfBuzzSharp": "8.3.1.3",
+          "HarfBuzzSharp.NativeAssets.Linux": "8.3.1.3",
+          "HarfBuzzSharp.NativeAssets.WebAssembly": "8.3.1.3",
+          "SkiaSharp": "3.119.3-preview.1.1",
+          "SkiaSharp.NativeAssets.Linux": "3.119.3-preview.1.1",
+          "SkiaSharp.NativeAssets.WebAssembly": "3.119.3-preview.1.1"
+        }
+      },
       "CSharpMath": {
         "type": "Transitive",
         "resolved": "1.0.0-pre.1",
@@ -96,24 +110,29 @@
           "CSharpMath": "1.0.0-pre.1"
         }
       },
+      "ExCSS": {
+        "type": "Transitive",
+        "resolved": "4.3.1",
+        "contentHash": "A8UtcghHQlWxPJhJF5bsfEYO7068JHGTuJ7tzyyMjd5fE/N/xY1cVOUhzuLLFwMOCJVnM4mqSQc93W9fGfZ1kA=="
+      },
       "HarfBuzzSharp": {
         "type": "Transitive",
-        "resolved": "8.3.1.3",
-        "contentHash": "NGZ2+ZVNPM+NdHB/asW0/ykWngyHWwcqjrbN2nDeH1B/aptPGlCUl8wkQ2cSJxw5fdWgdmIPmNuTPWpLwNVXWg==",
+        "resolved": "14.2.0",
+        "contentHash": "B9zczdZELTKyJoNZXJLTgq+Ho2Z6H8oFcFbelvmHixkA8/2sH9acE589KvOa951g1aN262pOU5ThhZxw33bGSg==",
         "dependencies": {
-          "HarfBuzzSharp.NativeAssets.Win32": "8.3.1.3",
-          "HarfBuzzSharp.NativeAssets.macOS": "8.3.1.3"
+          "HarfBuzzSharp.NativeAssets.Win32": "14.2.0",
+          "HarfBuzzSharp.NativeAssets.macOS": "14.2.0"
         }
       },
       "HarfBuzzSharp.NativeAssets.Linux": {
         "type": "Transitive",
-        "resolved": "8.3.1.3",
-        "contentHash": "RI6A1LgmooU30+4QIyFt5rmBCzP0VzTR+587IJSGvYIsHHWlahFufihYxtraLfsIhW7I8dn6+xX+DZGygOPKWQ=="
+        "resolved": "14.2.0",
+        "contentHash": "KgdkGoqCoRPAdekskR9asBbY5tzfqRcYQ0/+hz8rvPMAmbQqX1g57xr6rbGUyIVY5j5ioExZWUZ10QocUVpgwQ=="
       },
       "HarfBuzzSharp.NativeAssets.macOS": {
         "type": "Transitive",
-        "resolved": "8.3.1.3",
-        "contentHash": "KPTq0xnslkI6nAo0jh3ptcQPJvZZr7MWYXa2jUe4SnHc9q+JlHElmNXp0sfFoiTgoCX7WOYpYsurypuH9Gehxw=="
+        "resolved": "14.2.0",
+        "contentHash": "v2AfGa0Q0aNRz7glbRTvkrR8w2pipUpyRHDNjOCPXnnHE3pjY0ycTY0L7dL/AByd53aQ0AGPwIEP1H9hZPPywg=="
       },
       "HarfBuzzSharp.NativeAssets.WebAssembly": {
         "type": "Transitive",
@@ -122,8 +141,8 @@
       },
       "HarfBuzzSharp.NativeAssets.Win32": {
         "type": "Transitive",
-        "resolved": "8.3.1.3",
-        "contentHash": "bx8CE8Js+XGX8PUxAHCBDEORt5aaBYtMN4Hr9QFs57Xithh6yjUyYqksizH6eRDhJkwsGI+SXWmPmMm8lZC9Pw=="
+        "resolved": "14.2.0",
+        "contentHash": "NCqaG3bJDl66JdmHeyOpRUf4eiGVwu8OSxGv6ukofBiukVyUpWj01btr/telMQLQ+XuQ83iDpi6NRDFoRIcojA=="
       },
       "MicroCom.Runtime": {
         "type": "Transitive",
@@ -144,6 +163,11 @@
         "type": "Transitive",
         "resolved": "18.8.1",
         "contentHash": "Eclse/ZZjr4lmWzZFNN9h/OluhKL+SK/QbUyKUewgX139aGeyMEO/DkMPwuFs2MixvanTnz6891rF8UHDg+W4Q=="
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.3",
+        "contentHash": "dQKlVXzqflsv5X8iDlAN5YmTL1GcLCrOLKo1s9PNdfjqxeu0S/jmWTfiLGno+8+o1qFL3+VFAH5/ftmypN+sPw=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -193,24 +217,98 @@
         "resolved": "5.0.0",
         "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
       },
+      "ShimSkiaSharp": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "mUPSMxfW+vjtwDPrbhK3ILQg8D7aud7JO7p2Y5cqPmKf+s2erTyfEWohlVHCjSSDPvpT5L4aKLqnW02JCfGvag=="
+      },
       "SkiaSharp": {
         "type": "Transitive",
-        "resolved": "3.119.1",
-        "contentHash": "+Ru1BTSZQne3Vp+vbSb50Ke3Nlc3ZnItxx4+751J9WZ8YzLKAV/n+9DAo4zFTyeCI//ueT63c+VybmTTpYBEiw==",
+        "resolved": "4.148.0",
+        "contentHash": "t+oZDnzvi0en060BFDTmJ16C0zjsiXRrtOe70luIuIi/exVZtl1obrYh8D+IoHlGtp7bqzEBVncafbAl0ttmPQ==",
         "dependencies": {
-          "SkiaSharp.NativeAssets.Win32": "3.119.1",
-          "SkiaSharp.NativeAssets.macOS": "3.119.1"
+          "SkiaSharp.NativeAssets.Win32": "4.148.0",
+          "SkiaSharp.NativeAssets.macOS": "4.148.0"
         }
+      },
+      "SkiaSharp.NativeAssets.Linux": {
+        "type": "Transitive",
+        "resolved": "4.148.0",
+        "contentHash": "diba2vLeoKmWVkVTdXYOG14c7+s5FsH/AQZ5UPiFLRwLKgrCQNJPLKw8q60HzfOcJt+t/blv+1xkinqd5ZjX5A=="
       },
       "SkiaSharp.NativeAssets.macOS": {
         "type": "Transitive",
-        "resolved": "3.119.1",
-        "contentHash": "6hR3BdLhApjDxR1bFrJ7/lMydPfI01s3K+3WjIXFUlfC0MFCFCwRzv+JtzIkW9bDXs7XUVQS+6EVf0uzCasnGQ=="
+        "resolved": "4.148.0",
+        "contentHash": "1iESVxlqNNbQUiFODuyQJ/5dYUNYwGzZBUyaKNU3pJRM8zPFUkdMW0UZcZPvd6xwrjn53HYklJyKvetXC6ri+A=="
+      },
+      "SkiaSharp.NativeAssets.WebAssembly": {
+        "type": "Transitive",
+        "resolved": "3.119.3-preview.1.1",
+        "contentHash": "Gzvr/fcJZODWNoLVBAIiM8NKudvZ9yL6WHb87fk7iadio9BWQR7GS0fUvWvE3kYaRAAutsjPdGAnkDR0ujlVDw=="
       },
       "SkiaSharp.NativeAssets.Win32": {
         "type": "Transitive",
-        "resolved": "3.119.1",
-        "contentHash": "8C4GSXVJqSr0y3Tyyv5jz6MJSTVUyYkMjeKrzK+VyZPGLo89MNoUEclVuYahzOCDdtbfXrd2HtxXfDuvoSXrUw=="
+        "resolved": "4.148.0",
+        "contentHash": "LegvQ9zAi9Tmot2YOLv8mcK+g3wbEYfCWUoC5JtyHaN8QrxsaMvfJ8pFPvnEOVuY8qXxs8vVqrO/x42/YaFDRA=="
+      },
+      "Sugiyama": {
+        "type": "Transitive",
+        "resolved": "0.12.2",
+        "contentHash": "zctOh0QNzLLzrkaV9WJO15bLCQ2Fvl4Lf/zEoFaMeoD244B9pTXiHEikM3PXkj+CniiOwJg6uYNL/ZDaNWAJ0w=="
+      },
+      "Svg.Animation": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "/WKtsXMKAGIoiNzETQvQQtwoO3V2gEonkxqwrEdiGPSXuTG9Q0c6K34P06HhVXnLaZjjvxja+vOIKVSUucXOug==",
+        "dependencies": {
+          "ShimSkiaSharp": "5.2.1",
+          "SkiaSharp": "4.148.0",
+          "Svg.Custom": "5.2.1",
+          "Svg.Model": "5.2.1"
+        }
+      },
+      "Svg.Custom": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "7qAG1I0FGlMwOJk0Js41TmvRJ0eLJPpz8Edd8DOzsotLikUhYGDZZlwXV+6sKvsApfIZEfarH0KwI38T9OHsmw==",
+        "dependencies": {
+          "ExCSS": "4.3.1"
+        }
+      },
+      "Svg.Model": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "0+fG1BFw3QoXj+4sxpaXpLDZXz+Snb289epyP3HKjEjUUoWVsErMZb6teo4dVj8KElRJIeXjX6jD1C0B1vLRXw==",
+        "dependencies": {
+          "ShimSkiaSharp": "5.2.1",
+          "Svg.Custom": "5.2.1"
+        }
+      },
+      "Svg.SceneGraph": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "vm2QxbPv5MraL7T2+1dh0m8lGQqtW37RK4iOHvBsJQHQzcuDlCR+uX/Oiun77kS2US2OC23zfaIFEYWGwocXLw==",
+        "dependencies": {
+          "ShimSkiaSharp": "5.2.1",
+          "Svg.Custom": "5.2.1",
+          "Svg.Model": "5.2.1"
+        }
+      },
+      "Svg.Skia": {
+        "type": "Transitive",
+        "resolved": "5.2.1",
+        "contentHash": "es8F7MSeJJgc30Dmi0ZsrPpGQmLTQuS3DCvHcJ9wYlNAt3oHEoEzg5ugX3bwMPFejrPNLNjPpr1VOiMrpFyvIA==",
+        "dependencies": {
+          "HarfBuzzSharp": "14.2.0",
+          "HarfBuzzSharp.NativeAssets.Linux": "14.2.0",
+          "HarfBuzzSharp.NativeAssets.Win32": "14.2.0",
+          "HarfBuzzSharp.NativeAssets.macOS": "14.2.0",
+          "SkiaSharp": "4.148.0",
+          "Svg.Animation": "5.2.1",
+          "Svg.Custom": "5.2.1",
+          "Svg.Model": "5.2.1",
+          "Svg.SceneGraph": "5.2.1"
+        }
       },
       "xunit.analyzers": {
         "type": "Transitive",
@@ -293,6 +391,14 @@
           "MarkView.Avalonia": "[1.0.0, )"
         }
       },
+      "markview.avalonia.mermaid": {
+        "type": "Project",
+        "dependencies": {
+          "MarkView.Avalonia": "[1.0.0, )",
+          "Mermaider": "[0.12.2, )",
+          "Svg.Controls.Skia.Avalonia": "[12.0.0.15, )"
+        }
+      },
       "Avalonia": {
         "type": "CentralTransitive",
         "requested": "[12.1.1, )",
@@ -328,6 +434,27 @@
         "requested": "[1.3.2, )",
         "resolved": "1.3.2",
         "contentHash": "fZgOC/3CswUrndjDTac70aQpYdtxbW5+5bRumR7vzvI2HJbkmgKisB1c9oT+GA6v0jB/JDR9BLa9FiPzQmaK6A=="
+      },
+      "Mermaider": {
+        "type": "CentralTransitive",
+        "requested": "[0.12.2, )",
+        "resolved": "0.12.2",
+        "contentHash": "GGTKdAUc22Sus45Rkf0oPQjrQq5yOTIaFjXZoo3IBY0HB7Nbn6MyXXrknmdy5YADZBRNK3awV6sw9QY1KXfpfQ==",
+        "dependencies": {
+          "Microsoft.Extensions.ObjectPool": "10.0.3",
+          "Sugiyama": "0.12.2"
+        }
+      },
+      "Svg.Controls.Skia.Avalonia": {
+        "type": "CentralTransitive",
+        "requested": "[12.0.0.15, )",
+        "resolved": "12.0.0.15",
+        "contentHash": "dpL8LvvKBkVB8oAOgou+aSQEfyWVMWY79UN7EZDcF1PHGoINhBDwGVoBLItA7SEdjpy3d+5LegABYGxeu0Ou1w==",
+        "dependencies": {
+          "Avalonia.Skia": "12.0.0",
+          "SkiaSharp.NativeAssets.Linux": "4.148.0",
+          "Svg.Skia": "5.2.1"
+        }
       }
     }
   }

--- a/tests/MarkView.Avalonia.Math.Tests/packages.lock.json
+++ b/tests/MarkView.Avalonia.Math.Tests/packages.lock.json
@@ -1,0 +1,334 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "Avalonia.Headless.XUnit": {
+        "type": "Direct",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "74CbU8pPHpJzVu84CiKtsDzd1jpt/aZHKVXQPp/EyHMOsWbe5IG1Q/od4LffJhilPFSFAvopxxMVeRau73ipNg==",
+        "dependencies": {
+          "Avalonia.Headless": "12.1.1",
+          "xunit.v3.extensibility.core": "3.2.2"
+        }
+      },
+      "Avalonia.Themes.Fluent": {
+        "type": "Direct",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "7vdtZsM9o8I8LpU9dyiB/Ah7WB8a5V3JHLsExe4T433ynn5x57F+DBskctZuNOxml8hbe1GmtNUNkBDsqSVKVg==",
+        "dependencies": {
+          "Avalonia": "12.1.1"
+        }
+      },
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "27jXSV/0DbVqF5jDrAxuQFZ9oaz6gmG03p8ttxAFk+X0M4woFYj7MoWDLCna5EGLb0CE6OE7X6ZH3Wt5smTtaA=="
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.8.1, )",
+        "resolved": "18.8.1",
+        "contentHash": "dknJL3/9Y3t4XuCBqnc0PevPxgLsUMmVhjwup/b1HNovA8zWcj3XsfIf7c6p05363DWcqL7X/YhDL9B+Zymv1w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.8.1",
+          "Microsoft.TestPlatform.TestHost": "18.8.1"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "xunit.v3": {
+        "type": "Direct",
+        "requested": "[3.2.2, )",
+        "resolved": "3.2.2",
+        "contentHash": "L+4/4y0Uqcg8/d6hfnxhnwh4j9FaeULvefTwrk30rr1o4n/vdPfyUQ8k0yzH8VJx7bmFEkDdcRfbtbjEHlaYcA==",
+        "dependencies": {
+          "xunit.v3.mtp-v1": "[3.2.2]"
+        }
+      },
+      "Avalonia.BuildServices": {
+        "type": "Transitive",
+        "resolved": "11.3.2",
+        "contentHash": "qHDToxto1e3hci5YqbG9n0Ty8mlp3zBUN5wT66wKqaDVzXyQ0do3EnRILd4Ke9jpvsktaPpgE0YjEk7hornryQ=="
+      },
+      "Avalonia.HarfBuzz": {
+        "type": "Transitive",
+        "resolved": "12.1.1",
+        "contentHash": "vgd/Fl4bIXgv3QtYk6WCd6iGAag4i3OOAozo6/DW3xPr5dWjpi1MmJaeE9MYoZBEDJ4egD0gfHz6nYhkDADz9g==",
+        "dependencies": {
+          "Avalonia": "12.1.1",
+          "HarfBuzzSharp": "8.3.1.3",
+          "HarfBuzzSharp.NativeAssets.Linux": "8.3.1.3",
+          "HarfBuzzSharp.NativeAssets.WebAssembly": "8.3.1.3"
+        }
+      },
+      "Avalonia.Headless": {
+        "type": "Transitive",
+        "resolved": "12.1.1",
+        "contentHash": "+iIeqFnh3/Z91hrQjlhpR6I72fV7q6zjAksQvenPblqgHvsF2PY63eXfBz7H7bmk0WHtuROiFQKLxx//AHInJQ==",
+        "dependencies": {
+          "Avalonia": "12.1.1",
+          "Avalonia.Fonts.Inter": "12.1.1",
+          "Avalonia.HarfBuzz": "12.1.1"
+        }
+      },
+      "Avalonia.Remote.Protocol": {
+        "type": "Transitive",
+        "resolved": "12.1.1",
+        "contentHash": "0u77tnOwJnHtVLu+WBY7T56fN9W8n7++Uq9kHW6J+bfv5y13WZUMVS+PBzoBe32taYvz/oSomDGO1V41AHaFcQ=="
+      },
+      "CSharpMath": {
+        "type": "Transitive",
+        "resolved": "1.0.0-pre.1",
+        "contentHash": "DxNiPY3GTeE873k5CFOz8b7DGn99qeBlX/9fBWMFJMrUMFKJq6Hr7Qf1WfN72kHUt9pzv081co4KOlWtbzzRCg=="
+      },
+      "CSharpMath.Rendering": {
+        "type": "Transitive",
+        "resolved": "1.0.0-pre.1",
+        "contentHash": "Z7Pywza48XD9ygAtipuMDt+0SjHSUPLOdpT8xpA8QZqQ3j+HmXho54sFNPnRkMl7hIwBVmLbRObeQ1oN2rZJVg==",
+        "dependencies": {
+          "CSharpMath": "1.0.0-pre.1"
+        }
+      },
+      "HarfBuzzSharp": {
+        "type": "Transitive",
+        "resolved": "8.3.1.3",
+        "contentHash": "NGZ2+ZVNPM+NdHB/asW0/ykWngyHWwcqjrbN2nDeH1B/aptPGlCUl8wkQ2cSJxw5fdWgdmIPmNuTPWpLwNVXWg==",
+        "dependencies": {
+          "HarfBuzzSharp.NativeAssets.Win32": "8.3.1.3",
+          "HarfBuzzSharp.NativeAssets.macOS": "8.3.1.3"
+        }
+      },
+      "HarfBuzzSharp.NativeAssets.Linux": {
+        "type": "Transitive",
+        "resolved": "8.3.1.3",
+        "contentHash": "RI6A1LgmooU30+4QIyFt5rmBCzP0VzTR+587IJSGvYIsHHWlahFufihYxtraLfsIhW7I8dn6+xX+DZGygOPKWQ=="
+      },
+      "HarfBuzzSharp.NativeAssets.macOS": {
+        "type": "Transitive",
+        "resolved": "8.3.1.3",
+        "contentHash": "KPTq0xnslkI6nAo0jh3ptcQPJvZZr7MWYXa2jUe4SnHc9q+JlHElmNXp0sfFoiTgoCX7WOYpYsurypuH9Gehxw=="
+      },
+      "HarfBuzzSharp.NativeAssets.WebAssembly": {
+        "type": "Transitive",
+        "resolved": "8.3.1.3",
+        "contentHash": "w2QfdNm9Uz/sUa0B5D+OnVQhyq3G/fBq6ibQMdWBlQqqwh0g0/5j3RFvYqZAmRZ5+RzvjVe8o8SFFnWYUSkuxA=="
+      },
+      "HarfBuzzSharp.NativeAssets.Win32": {
+        "type": "Transitive",
+        "resolved": "8.3.1.3",
+        "contentHash": "bx8CE8Js+XGX8PUxAHCBDEORt5aaBYtMN4Hr9QFs57Xithh6yjUyYqksizH6eRDhJkwsGI+SXWmPmMm8lZC9Pw=="
+      },
+      "MicroCom.Runtime": {
+        "type": "Transitive",
+        "resolved": "0.11.6",
+        "contentHash": "NdNWGDiZ6eS/Mf/9+QHR91cj1K7Hy+PX9yrHI/zM7xFYuj9IWT2uxtB6sCHjrnxAeLV9fut1R6zHDUGKX6f9lQ=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.8.1",
+        "contentHash": "Eclse/ZZjr4lmWzZFNN9h/OluhKL+SK/QbUyKUewgX139aGeyMEO/DkMPwuFs2MixvanTnz6891rF8UHDg+W4Q=="
+      },
+      "Microsoft.Testing.Extensions.Telemetry": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "No5AudZMmSb+uNXjlgL2y3/stHD2IT4uxqc5yHwkE+/nNux9jbKcaJMvcp9SwgP4DVD8L9/P3OUz8mmmcvEIdQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "AL46Xe1WBi85Ntd4mNPvat5ZSsZ2uejiVqoKCypr8J3wK0elA5xJ3AN4G/Q4GIwzUFnggZoH/DBjnr9J18IO/g==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "QafNtNSmEI0zazdebnsIkDKmFtTSpmx/5PLOjURWwozcPb3tvRxzosQSL8xwYNM1iPhhKiBksXZyRSE2COisrA=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "1.9.1",
+        "contentHash": "oTUtyR4X/s9ytuiNA29FGsNCCH0rNmY5Wdm14NCKLjTM1cT9edVSlA+rGS/mVmusPqcP0l/x9qOnMXg16v87RQ==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "1.9.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.8.1",
+        "contentHash": "qLbktNB1+b1XZLNJBTzaWVVJAd6PEzD7cgD406geMb6PcFZhp3EDNa1tctWx1+mtMU6MP/6ozVvFPC9vs2a9rw=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.8.1",
+        "contentHash": "FaQHPDTUOcE+SFTjssNPfrub2lT9Zyon4J2W/KLHt/efLJACb1TCeWXyOgh0D/4Q1e4n+S3E6mOKud+9nLZlEA==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.8.1"
+        }
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "dDoKi0PnDz31yAyETfRntsLArTlVAVzUzCIvvEDsDsucrl33Dl8pIJG06ePTJTI3tGpeyHS9Cq7Foc/s4EeKcg=="
+      },
+      "SkiaSharp": {
+        "type": "Transitive",
+        "resolved": "3.119.1",
+        "contentHash": "+Ru1BTSZQne3Vp+vbSb50Ke3Nlc3ZnItxx4+751J9WZ8YzLKAV/n+9DAo4zFTyeCI//ueT63c+VybmTTpYBEiw==",
+        "dependencies": {
+          "SkiaSharp.NativeAssets.Win32": "3.119.1",
+          "SkiaSharp.NativeAssets.macOS": "3.119.1"
+        }
+      },
+      "SkiaSharp.NativeAssets.macOS": {
+        "type": "Transitive",
+        "resolved": "3.119.1",
+        "contentHash": "6hR3BdLhApjDxR1bFrJ7/lMydPfI01s3K+3WjIXFUlfC0MFCFCwRzv+JtzIkW9bDXs7XUVQS+6EVf0uzCasnGQ=="
+      },
+      "SkiaSharp.NativeAssets.Win32": {
+        "type": "Transitive",
+        "resolved": "3.119.1",
+        "contentHash": "8C4GSXVJqSr0y3Tyyv5jz6MJSTVUyYkMjeKrzK+VyZPGLo89MNoUEclVuYahzOCDdtbfXrd2HtxXfDuvoSXrUw=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.27.0",
+        "contentHash": "y/pxIQaLvk/kxAoDkZW9GnHLCEqzwl5TW0vtX3pweyQpjizB9y3DXhb9pkw2dGeUqhLjsxvvJM1k89JowU6z3g=="
+      },
+      "xunit.v3.assert": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "BPciBghgEEaJN/JG00QfCYDfEfnLgQhfnYEy+j1izoeHVNYd5+3Wm8GJ6JgYysOhpBPYGE+sbf75JtrRc7jrdA=="
+      },
+      "xunit.v3.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Hj775PEH6GTbbg0wfKRvG2hNspDCvTH9irXhH4qIWgdrOSV1sQlqPie+DOvFeigsFg2fxSM3ZAaaCDQs+KreFA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit.v3.core.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "Ga5aA2Ca9ktz+5k3g5ukzwfexwoqwDUpV6z7atSEUvqtd6JuybU1XopHqg1oFd78QdTfZgZE9h5sHpO4qYIi5w==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.Telemetry": "1.9.1",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "1.9.1",
+          "Microsoft.Testing.Platform": "1.9.1",
+          "Microsoft.Testing.Platform.MSBuild": "1.9.1",
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.inproc.console": "[3.2.2]"
+        }
+      },
+      "xunit.v3.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "srY8z/oMPvh/t8axtO2DwrHajhFMH7tnqKildvYrVQIfICi8fOn3yIBWkVPAcrKmHMwvXRJ/XsQM3VMR6DOYfQ==",
+        "dependencies": {
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.mtp-v1": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "O41aAzYKBT5PWqATa1oEWVNCyEUypFQ4va6K0kz37dduV3EKzXNMaV2UnEhufzU4Cce1I33gg0oldS8tGL5I0A==",
+        "dependencies": {
+          "xunit.analyzers": "1.27.0",
+          "xunit.v3.assert": "[3.2.2]",
+          "xunit.v3.core.mtp-v1": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.common": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "/hkHkQCzGrugelOAehprm7RIWdsUFVmIVaD6jDH/8DNGCymTlKKPTbGokD5czbAfqfex47mBP0sb0zbHYwrO/g==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "[5.0.0]",
+          "xunit.v3.common": "[3.2.2]"
+        }
+      },
+      "xunit.v3.runner.inproc.console": {
+        "type": "Transitive",
+        "resolved": "3.2.2",
+        "contentHash": "ulWOdSvCk+bPXijJZ73bth9NyoOHsAs1ZOvamYbCkD4DNLX/Bd29Ve2ZNUwBbK0MqfIYWXHZViy/HKrdEC/izw==",
+        "dependencies": {
+          "xunit.v3.extensibility.core": "[3.2.2]",
+          "xunit.v3.runner.common": "[3.2.2]"
+        }
+      },
+      "markview.avalonia": {
+        "type": "Project",
+        "dependencies": {
+          "Avalonia": "[12.1.1, )",
+          "Markdig": "[1.3.2, )"
+        }
+      },
+      "markview.avalonia.math": {
+        "type": "Project",
+        "dependencies": {
+          "CSharpMath.SkiaSharp": "[1.0.0-pre.1, )",
+          "MarkView.Avalonia": "[1.0.0, )"
+        }
+      },
+      "Avalonia": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "o8pZ1oE9AQ6gklpGM0lnOBp/JlVH0J/0mYszBf0GsSAcEnzHNCLM9NnrPZwKu4j2q9oNbVHYzzEPkszQeuqaKw==",
+        "dependencies": {
+          "Avalonia.BuildServices": "11.3.2",
+          "Avalonia.Remote.Protocol": "12.1.1",
+          "MicroCom.Runtime": "0.11.6"
+        }
+      },
+      "Avalonia.Fonts.Inter": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "V2d7OM1jybcl31KThdhf8XSl5SjQ6Ll/tXIfwQ00kMeWuPegRcOx8DLVpECHOOEKO9JZelXW0enuUu1D7Svikg==",
+        "dependencies": {
+          "Avalonia": "12.1.1"
+        }
+      },
+      "CSharpMath.SkiaSharp": {
+        "type": "CentralTransitive",
+        "requested": "[1.0.0-pre.1, )",
+        "resolved": "1.0.0-pre.1",
+        "contentHash": "iie1WLYYdo7w9vrz1a1qUZoLj1YNpLIVJ+8/wrdY7krqd/el9Elmy+6HioFtId9HDbP6NTHnAtS7xt+HFatfqQ==",
+        "dependencies": {
+          "CSharpMath.Rendering": "1.0.0-pre.1",
+          "SkiaSharp": "3.119.1"
+        }
+      },
+      "Markdig": {
+        "type": "CentralTransitive",
+        "requested": "[1.3.2, )",
+        "resolved": "1.3.2",
+        "contentHash": "fZgOC/3CswUrndjDTac70aQpYdtxbW5+5bRumR7vzvI2HJbkmgKisB1c9oT+GA6v0jB/JDR9BLa9FiPzQmaK6A=="
+      }
+    }
+  }
+}

--- a/tests/MarkView.Avalonia.Math.Tests/packages.lock.json
+++ b/tests/MarkView.Avalonia.Math.Tests/packages.lock.json
@@ -99,15 +99,23 @@
       },
       "CSharpMath": {
         "type": "Transitive",
-        "resolved": "1.0.0-pre.1",
-        "contentHash": "DxNiPY3GTeE873k5CFOz8b7DGn99qeBlX/9fBWMFJMrUMFKJq6Hr7Qf1WfN72kHUt9pzv081co4KOlWtbzzRCg=="
+        "resolved": "0.5.1",
+        "contentHash": "CBAtejk24icPQNJWPjUDGUqklNLpfglpRxQljiezn2MQrxL5cIVuouCVnw6ipU3cft9Tq8YfS6f/JPhSjhFtFA=="
+      },
+      "CSharpMath.Editor": {
+        "type": "Transitive",
+        "resolved": "0.5.1",
+        "contentHash": "q5MFAjI7TO41PtGFNHBFwOw3J3IS7Dnm7aJHEgPxMWE5wl1H5byOo0pJnGwXevjhoSRssGRJH2KCXgn0KbGJFQ==",
+        "dependencies": {
+          "CSharpMath": "0.5.1"
+        }
       },
       "CSharpMath.Rendering": {
         "type": "Transitive",
-        "resolved": "1.0.0-pre.1",
-        "contentHash": "Z7Pywza48XD9ygAtipuMDt+0SjHSUPLOdpT8xpA8QZqQ3j+HmXho54sFNPnRkMl7hIwBVmLbRObeQ1oN2rZJVg==",
+        "resolved": "0.5.1",
+        "contentHash": "H4tctQzgpQmLICON1QAJtfm3/dj4exoxEKTuF9oO5YkHXMANWNfOQKwVtAx6n78hcD6WidwF2v2pH8Z/cOw/gg==",
         "dependencies": {
-          "CSharpMath": "1.0.0-pre.1"
+          "CSharpMath.Editor": "0.5.1"
         }
       },
       "ExCSS": {
@@ -387,8 +395,9 @@
       "markview.avalonia.math": {
         "type": "Project",
         "dependencies": {
-          "CSharpMath.SkiaSharp": "[1.0.0-pre.1, )",
-          "MarkView.Avalonia": "[1.0.0, )"
+          "CSharpMath.SkiaSharp": "[0.5.1, )",
+          "MarkView.Avalonia": "[1.0.0, )",
+          "SkiaSharp": "[4.148.0, )"
         }
       },
       "markview.avalonia.mermaid": {
@@ -421,12 +430,12 @@
       },
       "CSharpMath.SkiaSharp": {
         "type": "CentralTransitive",
-        "requested": "[1.0.0-pre.1, )",
-        "resolved": "1.0.0-pre.1",
-        "contentHash": "iie1WLYYdo7w9vrz1a1qUZoLj1YNpLIVJ+8/wrdY7krqd/el9Elmy+6HioFtId9HDbP6NTHnAtS7xt+HFatfqQ==",
+        "requested": "[0.5.1, )",
+        "resolved": "0.5.1",
+        "contentHash": "3SMI0o2EZi2/GskH6T5s9GDaBq9u0VBd/o8Geqd+FyPxEXCcmzECOZ3PdVdob/YNevl4okOTbqZrHZS2O28/ZQ==",
         "dependencies": {
-          "CSharpMath.Rendering": "1.0.0-pre.1",
-          "SkiaSharp": "3.119.1"
+          "CSharpMath.Rendering": "0.5.1",
+          "SkiaSharp": "2.80.1"
         }
       },
       "Markdig": {

--- a/tests/MarkView.Avalonia.Math.Tests/stryker-config.json
+++ b/tests/MarkView.Avalonia.Math.Tests/stryker-config.json
@@ -1,0 +1,16 @@
+{
+  "stryker-config": {
+    "project": "MarkView.Avalonia.Math.csproj",
+    "test-runner": "mtp",
+    "reporters": [
+      "html",
+      "progress",
+      "markdown"
+    ],
+    "thresholds": {
+      "high": 80,
+      "low": 60,
+      "break": 0
+    }
+  }
+}

--- a/tests/MarkView.Avalonia.Mermaid.Tests/MermaidBlockRendererTests.cs
+++ b/tests/MarkView.Avalonia.Mermaid.Tests/MermaidBlockRendererTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 using Markdig;
 using MarkView.Avalonia.Rendering;
+using MarkView.Avalonia.Rendering.Blocks;
 using Xunit;
 
 namespace MarkView.Avalonia.Mermaid.Tests;
@@ -56,11 +57,14 @@ public class MermaidBlockRendererTests
     }
 
     [AvaloniaFact]
-    public void MermaidExtension_Register_inserts_renderer_at_index_0()
+    public void MermaidExtension_Register_inserts_renderer_before_default_CodeBlockRenderer()
     {
         var renderer = new AvaloniaRenderer();
         new MermaidExtension().Register(renderer);
-        Assert.IsType<MermaidBlockRenderer>(renderer.ObjectRenderers[0]);
+        var renderers = renderer.ObjectRenderers.ToList();
+        var mermaidIndex = renderers.FindIndex(r => r is MermaidBlockRenderer);
+        var codeBlockIndex = renderers.FindIndex(r => r is CodeBlockRenderer);
+        Assert.True(mermaidIndex >= 0 && codeBlockIndex >= 0 && mermaidIndex < codeBlockIndex);
     }
 
     [AvaloniaFact]


### PR DESCRIPTION
## Summary

Add a new extension package that can be used to render math formulas using `CSharpMath.SkiaSharp`.

It relies on `Markdig`'s Math extension to be enabled, which parses `$...$` blocks.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [x] Documentation
- [x] CI / build

## Test plan

- [x] `dotnet test` — all tests pass
- [ ] Manual smoke-test in the demo app
