### PR TITLE
fix: don't resolve pure-fragment anchor links against BaseUri

### DIFF
--- a/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
+++ b/src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs
@@ -238,6 +238,9 @@ public class AvaloniaRenderer : RendererBase
     /// </summary>
     public string ResolveUrl(string url)
     {
+        if (url.StartsWith('#'))
+            return url; // same-document anchor: never resolve against BaseUri
+
         if (BaseUri != null && Uri.TryCreate(url, UriKind.Relative, out _))
         {
             // Separate path from fragment before combining to prevent '#' → '%23' encoding.

--- a/tests/MarkView.Avalonia.Tests/Rendering/AvaloniaRendererTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Rendering/AvaloniaRendererTests.cs
@@ -35,6 +35,14 @@ public class AvaloniaRendererTests
     }
 
     [AvaloniaFact]
+    public void ResolveUrl_pure_fragment_with_BaseUri_is_returned_unchanged()
+    {
+        var renderer = new AvaloniaRenderer { BaseUri = new Uri("https://example.com/docs/page.md") };
+        var result = renderer.ResolveUrl("#heading-1");
+        Assert.Equal("#heading-1", result);
+    }
+
+    [AvaloniaFact]
     public void ImageResizeMode_defaults_to_ScaleDownToFit()
     {
         var renderer = new AvaloniaRenderer();


### PR DESCRIPTION
## Summary

`ResolveUrl` was combining "#heading" links with `BaseUri`, turning them into absolute URLs (avares://..., https://...) before `OnLinkClicked` could recognize them as same-document anchors, so clicking a TOC link tried to open an external URL instead of scrolling.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [ ] Documentation
- [ ] CI / build

## Test plan

- [x] `dotnet test` — all tests pass
- [x] Manual smoke-test in the demo app
