### PR TITLE
feat: LaTeX math (CSharpMath.Avalonia)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Markdig" Version="1.3.2" />
     <!-- Plugin dependencies -->
-    <PackageVersion Include="CSharpMath.SkiaSharp" Version="0.5.1" />
+    <PackageVersion Include="CSharpMath.Avalonia" Version="1.0.0-pre.2" />
     <PackageVersion Include="Mermaider" Version="0.12.2" />
     <PackageVersion Include="Svg.Controls.Skia.Avalonia" Version="12.0.0.15" />
     <PackageVersion Include="TextMateSharp" Version="2.0.4" />

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The extension inserts `SvgImageLoader` at the front of the image loader chain. R
 
 ### LaTeX Math (`MarkView.Avalonia.Math`)
 
-Renders `$...$` (inline) and `$$...$$` (block) LaTeX math using CSharpMath's SkiaSharp renderer — pure .NET, no browser or WebView required.
+Renders `$...$` (inline) and `$$...$$` (block) LaTeX math using CSharpMath's Avalonia renderer — a native vector `Control`, pure .NET, no browser or WebView required.
 
 ```bash
 dotnet add package MarkView.Avalonia.Math
@@ -205,6 +205,8 @@ dotnet add package MarkView.Avalonia.Math
 ```csharp
 viewer.UseMath();
 ```
+
+> **Do not merge/release with this dependency as-is** — currently pins a CSharpMath prerelease (`1.0.0-pre.2`); see the [package README](src/MarkView.Avalonia.Math/README.md) for the merge gate.
 
 ### Mermaid Diagrams (`MarkView.Avalonia.Mermaid`)
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -113,7 +113,8 @@ If rendering fails, the extension falls back to a plain-text block containing th
 **Package:** `MarkView.Avalonia.Math`
 **[README](../src/MarkView.Avalonia.Math/README.md)**
 
-Renders `$...$` (inline) and `$$...$$` (block) LaTeX math via CSharpMath's SkiaSharp renderer.
+Renders `$...$` (inline) and `$$...$$` (block) LaTeX math via CSharpMath's Avalonia renderer — a
+native `Control` drawn with vector primitives, not a rasterized bitmap.
 
 ### Activation
 
@@ -129,13 +130,13 @@ MarkdownViewerDefaults.Pipeline = new MarkdownPipelineBuilder()
 
 ### Theme awareness
 
-Formulas re-render automatically on light/dark theme switch, matching Mermaid's exact two-hex
-convention (dark `#FAFAFA`, light `#27272A` text).
+Each formula's `TextColor` property updates in place on light/dark theme switch — no re-typeset,
+no rebuild — matching Mermaid's exact two-hex convention (dark `#FAFAFA`, light `#27272A` text).
 
 ### Fallback
 
 Invalid LaTeX renders CSharpMath's own inline error text. Unexpected exceptions fall back to a
-plain-text panel for block math, or leave the last successful render in place for inline math.
+plain-text panel for block math, or plain source text for inline math.
 
 ---
 

--- a/samples/MarkView.Avalonia.Demo/Assets/showcase.md
+++ b/samples/MarkView.Avalonia.Demo/Assets/showcase.md
@@ -82,7 +82,7 @@ The `EmphasisExtras` Markdig extension unlocks four additional inline styles:
 | `MarkView.Avalonia.SyntaxHighlighting` | Code highlighting | ✅ Published | TextMate grammars |
 | `MarkView.Avalonia.Svg` | SVG images | ✅ Published | Avalonia.Svg |
 | `MarkView.Avalonia.Mermaid` | Mermaid diagrams | ✅ Published | Pure .NET |
-| `MarkView.Avalonia.Math` | LaTeX math | ✅ Published | CSharpMath.SkiaSharp |
+| `MarkView.Avalonia.Math` | LaTeX math | ⚠️ Prerelease dependency | CSharpMath.Avalonia |
 
 ---
 
@@ -182,8 +182,8 @@ flowchart LR
 ## Math
 
 LaTeX math is rendered by the `MarkView.Avalonia.Math` extension, via
-[CSharpMath](https://github.com/verybadcat/CSharpMath)'s SkiaSharp renderer — pure .NET, no
-browser or WebView required.
+[CSharpMath](https://github.com/verybadcat/CSharpMath)'s Avalonia renderer — a native vector
+`Control`, pure .NET, no browser or WebView required.
 
 Inline math sits within a sentence, e.g. mass–energy equivalence, $E = mc^2$, or the Pythagorean
 theorem, $a^2 + b^2 = c^2$.

--- a/samples/MarkView.Avalonia.Demo/packages.lock.json
+++ b/samples/MarkView.Avalonia.Demo/packages.lock.json
@@ -121,23 +121,15 @@
       },
       "CSharpMath": {
         "type": "Transitive",
-        "resolved": "0.5.1",
-        "contentHash": "CBAtejk24icPQNJWPjUDGUqklNLpfglpRxQljiezn2MQrxL5cIVuouCVnw6ipU3cft9Tq8YfS6f/JPhSjhFtFA=="
-      },
-      "CSharpMath.Editor": {
-        "type": "Transitive",
-        "resolved": "0.5.1",
-        "contentHash": "q5MFAjI7TO41PtGFNHBFwOw3J3IS7Dnm7aJHEgPxMWE5wl1H5byOo0pJnGwXevjhoSRssGRJH2KCXgn0KbGJFQ==",
-        "dependencies": {
-          "CSharpMath": "0.5.1"
-        }
+        "resolved": "1.0.0-pre.2",
+        "contentHash": "bz47Ascj0qrc4vZZgs6H60uHUk1vwe5R/6W9NTQsz2cjBzGcYQoBYjxTFbHly0iPlaQ2RLGcgJYlEgfC5KAf9A=="
       },
       "CSharpMath.Rendering": {
         "type": "Transitive",
-        "resolved": "0.5.1",
-        "contentHash": "H4tctQzgpQmLICON1QAJtfm3/dj4exoxEKTuF9oO5YkHXMANWNfOQKwVtAx6n78hcD6WidwF2v2pH8Z/cOw/gg==",
+        "resolved": "1.0.0-pre.2",
+        "contentHash": "l/+Gzf0Nop2QrFMCsutmYA9iXM/+AjKGHXFCN6y+Y12yqmXZoX/m75rgj5M5y7ZTNmchUj4fRnaa7EEDA+fgJA==",
         "dependencies": {
-          "CSharpMath.Editor": "0.5.1"
+          "CSharpMath": "1.0.0-pre.2"
         }
       },
       "ExCSS": {
@@ -297,9 +289,8 @@
       "markview.avalonia.math": {
         "type": "Project",
         "dependencies": {
-          "CSharpMath.SkiaSharp": "[0.5.1, )",
-          "MarkView.Avalonia": "[1.0.0, )",
-          "SkiaSharp": "[4.148.0, )"
+          "CSharpMath.Avalonia": "[1.0.0-pre.2, )",
+          "MarkView.Avalonia": "[1.0.0, )"
         }
       },
       "markview.avalonia.mermaid": {
@@ -336,14 +327,14 @@
           "MicroCom.Runtime": "0.11.6"
         }
       },
-      "CSharpMath.SkiaSharp": {
+      "CSharpMath.Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[0.5.1, )",
-        "resolved": "0.5.1",
-        "contentHash": "3SMI0o2EZi2/GskH6T5s9GDaBq9u0VBd/o8Geqd+FyPxEXCcmzECOZ3PdVdob/YNevl4okOTbqZrHZS2O28/ZQ==",
+        "requested": "[1.0.0-pre.2, )",
+        "resolved": "1.0.0-pre.2",
+        "contentHash": "iVGnfKyv5rpupNKXtdstGV9vYWg3zLMkDfkpSkfLRzE6yG9MD5JdqKTJdb0zO2IOeIYodKSmfPavJiM2YZpj3g==",
         "dependencies": {
-          "CSharpMath.Rendering": "0.5.1",
-          "SkiaSharp": "2.80.1"
+          "Avalonia": "12.0.4",
+          "CSharpMath.Rendering": "1.0.0-pre.2"
         }
       },
       "Markdig": {

--- a/src/MarkView.Avalonia.Math/MarkView.Avalonia.Math.csproj
+++ b/src/MarkView.Avalonia.Math/MarkView.Avalonia.Math.csproj
@@ -9,8 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\MarkView.Avalonia\MarkView.Avalonia.csproj" />
-    <PackageReference Include="CSharpMath.SkiaSharp" />
-    <PackageReference Include="SkiaSharp" VersionOverride="4.148.0" />
+    <PackageReference Include="CSharpMath.Avalonia" />
   </ItemGroup>
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="/" />

--- a/src/MarkView.Avalonia.Math/MathBlockRenderer.cs
+++ b/src/MarkView.Avalonia.Math/MathBlockRenderer.cs
@@ -4,7 +4,8 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Layout;
-using Avalonia.Media;
+
+using CSharpMath.Avalonia;
 
 using Markdig.Extensions.Mathematics;
 
@@ -13,8 +14,8 @@ using MarkView.Avalonia.Rendering;
 namespace MarkView.Avalonia.Math;
 
 /// <summary>
-/// Renders Markdig <see cref="MathBlock"/> nodes (<c>$$...$$</c>) as a centred image
-/// produced by CSharpMath.SkiaSharp.
+/// Renders Markdig <see cref="MathBlock"/> nodes (<c>$$...$$</c>) as a centred
+/// <see cref="MathView"/> produced by CSharpMath.Avalonia.
 /// </summary>
 public sealed class MathBlockRenderer : AvaloniaObjectRenderer<MathBlock>
 {
@@ -22,42 +23,41 @@ public sealed class MathBlockRenderer : AvaloniaObjectRenderer<MathBlock>
     {
         var source = ExtractSource(obj);
 
-        var image = new Image
+        try
         {
-            Stretch = Stretch.None,
-            HorizontalAlignment = HorizontalAlignment.Center,
-        };
+            MathFormulaRenderer.EnsureSafeToRender(source);
 
-        var border = new Border { Child = image };
-        border.Classes.Add("markdown-math-block");
+            var mathView = new MathView
+            {
+                FontSize = 16f,
+                DisplayErrorInline = true,
+                TextColor = MathFormulaRenderer.GetThemeTextColor(),
+                LaTeX = source,
+                HorizontalAlignment = HorizontalAlignment.Center,
+            };
 
-        void OnThemeChanged(object? s, AvaloniaPropertyChangedEventArgs e)
-        {
-            if (e.Property.Name != nameof(Application.ActualThemeVariant)) return;
-            ApplyTheme();
+            var border = new Border { Child = mathView };
+            border.Classes.Add("markdown-math-block");
+
+            void OnThemeChanged(object? s, AvaloniaPropertyChangedEventArgs e)
+            {
+                if (e.Property.Name != nameof(Application.ActualThemeVariant)) return;
+                mathView.TextColor = MathFormulaRenderer.GetThemeTextColor();
+            }
+            Application.Current!.PropertyChanged += OnThemeChanged;
+            border.DetachedFromLogicalTree += (_, _) =>
+                Application.Current?.PropertyChanged -= OnThemeChanged;
+
+            renderer.WriteBlock(border);
         }
-        Application.Current!.PropertyChanged += OnThemeChanged;
-        border.DetachedFromLogicalTree += (_, _) =>
-            Application.Current?.PropertyChanged -= OnThemeChanged;
-
-        ApplyTheme();
-        renderer.WriteBlock(border);
-
-        void ApplyTheme()
+        catch (Exception ex)
         {
-            try
-            {
-                image.Source = MathFormulaRenderer.Render(source, MathFormulaRenderer.GetThemeTextColor());
-            }
-            catch (Exception ex)
-            {
-                var panel = new StackPanel { Spacing = 4 };
-                panel.Children.Add(new TextBlock { Text = $"Math render error: {ex.Message}" });
-                panel.Children.Add(new TextBlock { Text = source });
-                border.Child = panel;
-                border.Classes.Clear();
-                border.Classes.Add("markdown-math-fallback");
-            }
+            var panel = new StackPanel { Spacing = 4 };
+            panel.Children.Add(new TextBlock { Text = $"Math render error: {ex.Message}" });
+            panel.Children.Add(new TextBlock { Text = source });
+            var fallback = new Border { Child = panel };
+            fallback.Classes.Add("markdown-math-fallback");
+            renderer.WriteBlock(fallback);
         }
     }
 

--- a/src/MarkView.Avalonia.Math/MathFormulaRenderer.cs
+++ b/src/MarkView.Avalonia.Math/MathFormulaRenderer.cs
@@ -2,53 +2,29 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Avalonia;
-using Avalonia.Media.Imaging;
+using Avalonia.Media;
 using Avalonia.Styling;
-
-using CSharpMath.SkiaSharp;
-
-using SkiaSharp;
 
 namespace MarkView.Avalonia.Math;
 
 /// <summary>
-/// Renders a LaTeX formula to a bitmap via CSharpMath.SkiaSharp. Shared by
-/// <see cref="MathBlockRenderer"/> and <see cref="MathInlineRenderer"/>.
+/// Safety checks and theme colour lookup shared by <see cref="MathBlockRenderer"/> and
+/// <see cref="MathInlineRenderer"/>.
 /// </summary>
 internal static class MathFormulaRenderer
 {
     private const int MaxLatexLength = 10_000;
     private const int MaxBraceNestingDepth = 50;
 
-    public static Bitmap Render(string latex, SKColor textColor, float fontSize = 16f)
-    {
-        EnsureSafeToRender(latex);
-
-        var painter = new MathPainter
-        {
-            LaTeX = latex,
-            FontSize = fontSize,
-            TextColor = textColor,
-            DisplayErrorInline = true, // bad LaTeX renders its own error text instead of throwing
-        };
-
-        // NOTE: DrawAsStream() has never returned null in empirical testing (even for "" or
-        // whitespace-only input) — this is defensive against a future CSharpMath behavior change,
-        // not a currently-reachable path.
-        using var stream = painter.DrawAsStream()
-            ?? throw new InvalidOperationException("CSharpMath failed to render the formula to a stream.");
-        return new Bitmap(stream);
-    }
-
     /// <summary>
-    /// CSharpMath.SkiaSharp's typesetter recurses per nesting level (confirmed: deeply nested
-    /// \frac/\sqrt overflow the stack). A StackOverflowException there is uncatchable and kills
-    /// the whole host process, not just this control — and MarkdownViewer.Source accepts http(s)
-    /// URLs, so rendering untrusted/remote markdown is a supported scenario. Reject pathological
-    /// input before it ever reaches CSharpMath, so the existing (catchable) fallback path handles
-    /// it instead.
+    /// CSharpMath's typesetter (shared by every front end, including CSharpMath.Avalonia)
+    /// recurses per nesting level (confirmed: deeply nested \frac/\sqrt overflow the stack). A
+    /// StackOverflowException there is uncatchable and kills the whole host process, not just
+    /// this control — and MarkdownViewer.Source accepts http(s) URLs, so rendering
+    /// untrusted/remote markdown is a supported scenario. Reject pathological input before it
+    /// ever reaches CSharpMath, so the existing (catchable) fallback path handles it instead.
     /// </summary>
-    private static void EnsureSafeToRender(string latex)
+    public static void EnsureSafeToRender(string latex)
     {
         if (latex.Length > MaxLatexLength)
             throw new InvalidOperationException($"LaTeX source exceeds the {MaxLatexLength}-character safety limit.");
@@ -66,8 +42,8 @@ internal static class MathFormulaRenderer
     /// <summary>
     /// Matches MarkView.Avalonia.Mermaid's exact two-hardcoded-hex-per-theme convention.
     /// </summary>
-    public static SKColor GetThemeTextColor() =>
+    public static Color GetThemeTextColor() =>
         Application.Current?.ActualThemeVariant == ThemeVariant.Dark
-            ? SKColor.Parse("#FAFAFA")
-            : SKColor.Parse("#27272A");
+            ? Color.Parse("#FAFAFA")
+            : Color.Parse("#27272A");
 }

--- a/src/MarkView.Avalonia.Math/MathInlineRenderer.cs
+++ b/src/MarkView.Avalonia.Math/MathInlineRenderer.cs
@@ -2,9 +2,9 @@
 // Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Avalonia;
-using Avalonia.Controls;
 using Avalonia.Controls.Documents;
-using Avalonia.Media;
+
+using CSharpMath.Avalonia;
 
 using Markdig.Extensions.Mathematics;
 
@@ -13,8 +13,8 @@ using MarkView.Avalonia.Rendering;
 namespace MarkView.Avalonia.Math;
 
 /// <summary>
-/// Renders Markdig <see cref="MathInline"/> nodes (<c>$...$</c>) as an inline image
-/// produced by CSharpMath.SkiaSharp.
+/// Renders Markdig <see cref="MathInline"/> nodes (<c>$...$</c>) as an inline
+/// <see cref="MathView"/> produced by CSharpMath.Avalonia.
 /// </summary>
 public sealed class MathInlineRenderer : AvaloniaObjectRenderer<MathInline>
 {
@@ -22,53 +22,35 @@ public sealed class MathInlineRenderer : AvaloniaObjectRenderer<MathInline>
     {
         var source = obj.Content.ToString();
 
-        var image = new Image { Stretch = Stretch.None };
-        image.Classes.Add("markdown-math-inline");
-
-        if (!ApplyTheme(isFirstRender: true))
+        MathView mathView;
+        try
         {
-            // First render failed before the image was ever written to the renderer's inline
-            // stack — we're still inside the synchronous initial Write() call here, so writing a
-            // plain-text fallback instead is safe (unlike from the later theme-change callback,
-            // which must never re-enter the stack — see the comment inside ApplyTheme below).
-            // We deliberately haven't subscribed to theme-change notifications yet at this point:
-            // the discarded image is never attached to the visual tree, so DetachedFromLogicalTree
-            // would never fire and an earlier subscription would leak the handler on
-            // Application.Current forever.
+            MathFormulaRenderer.EnsureSafeToRender(source);
+
+            mathView = new MathView
+            {
+                FontSize = 16f,
+                DisplayErrorInline = true,
+                TextColor = MathFormulaRenderer.GetThemeTextColor(),
+                LaTeX = source,
+            };
+        }
+        catch (Exception)
+        {
             renderer.WriteInline(new Run(source));
             return;
         }
+        mathView.Classes.Add("markdown-math-inline");
 
         void OnThemeChanged(object? s, AvaloniaPropertyChangedEventArgs e)
         {
             if (e.Property.Name != nameof(Application.ActualThemeVariant)) return;
-            ApplyTheme(isFirstRender: false);
+            mathView.TextColor = MathFormulaRenderer.GetThemeTextColor();
         }
         Application.Current!.PropertyChanged += OnThemeChanged;
-        image.DetachedFromLogicalTree += (_, _) =>
+        mathView.DetachedFromLogicalTree += (_, _) =>
             Application.Current?.PropertyChanged -= OnThemeChanged;
 
-        renderer.WriteInline(image);
-
-        bool ApplyTheme(bool isFirstRender)
-        {
-            try
-            {
-                image.Source = MathFormulaRenderer.Render(source, MathFormulaRenderer.GetThemeTextColor());
-                return true;
-            }
-            catch (Exception)
-            {
-                if (!isFirstRender)
-                {
-                    // Inline context can't safely re-enter the renderer's inline stack from this
-                    // async/theme-change callback — unlike the block renderer's Border, an inline
-                    // Image has no room for a fallback panel. Leave the image showing its last
-                    // successfully rendered bitmap rather than risk corrupting whatever inline
-                    // collection is active at callback time.
-                }
-                return false;
-            }
-        }
+        renderer.WriteInline(mathView);
     }
 }

--- a/src/MarkView.Avalonia.Math/README.md
+++ b/src/MarkView.Avalonia.Math/README.md
@@ -6,9 +6,11 @@
 [![CI](https://github.com/Kryptos-FR/MarkView.Avalonia/actions/workflows/ci.yml/badge.svg)](https://github.com/Kryptos-FR/MarkView.Avalonia/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/Kryptos-FR/MarkView.Avalonia)](../../LICENSE.md)
 
-LaTeX math rendering extension for [MarkView.Avalonia](https://www.nuget.org/packages/MarkView.Avalonia). Renders `$...$` (inline) and `$$...$$` (block) math using [CSharpMath](https://github.com/verybadcat/CSharpMath)'s SkiaSharp renderer — pure .NET, no browser, no WebView, no JavaScript runtime.
+LaTeX math rendering extension for [MarkView.Avalonia](https://www.nuget.org/packages/MarkView.Avalonia). Renders `$...$` (inline) and `$$...$$` (block) math using [CSharpMath](https://github.com/verybadcat/CSharpMath)'s Avalonia renderer — a native `Control` drawn with vector primitives directly into Avalonia's `DrawingContext`, pure .NET, no browser, no WebView, no JavaScript runtime.
 
 Because `$` is common in ordinary prose (currency amounts, etc.), this parsing is opt-in only — enabling it changes how literal `$` characters are interpreted in your documents.
+
+> **Prerelease dependency:** this package currently pins `CSharpMath.Avalonia` to a `1.0.0-pre.2` prerelease build, since it's the version CSharpMath explicitly targets Avalonia 12/.NET 10 with. **This branch/package must not be merged or released until CSharpMath ships a stable 1.0.0** — re-pin the version at that point.
 
 ## Installation
 
@@ -53,8 +55,8 @@ $$
 ## Theme Awareness
 
 Formulas are rendered with colours matching the active Avalonia theme variant (dark `#FAFAFA`,
-light `#27272A` text), and are automatically re-rendered when the user switches between light and
-dark.
+light `#27272A` text). Each formula's `TextColor` property updates in place when the user switches
+between light and dark — no re-typeset, no rebuild.
 
 ## Combining with Mermaid
 
@@ -65,8 +67,8 @@ for a Mermaid diagram or a plain code block regardless of registration order.
 ## Error Handling
 
 Invalid LaTeX renders CSharpMath's own inline error text rather than throwing. Unexpected
-rendering failures fall back to a plain-text panel (block math) or leave the last successfully
-rendered formula in place (inline math).
+rendering failures fall back to a plain-text panel (block math) or plain source text (inline
+math).
 
 ## License
 

--- a/src/MarkView.Avalonia.Math/packages.lock.json
+++ b/src/MarkView.Avalonia.Math/packages.lock.json
@@ -2,24 +2,14 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
-      "CSharpMath.SkiaSharp": {
+      "CSharpMath.Avalonia": {
         "type": "Direct",
-        "requested": "[0.5.1, )",
-        "resolved": "0.5.1",
-        "contentHash": "3SMI0o2EZi2/GskH6T5s9GDaBq9u0VBd/o8Geqd+FyPxEXCcmzECOZ3PdVdob/YNevl4okOTbqZrHZS2O28/ZQ==",
+        "requested": "[1.0.0-pre.2, )",
+        "resolved": "1.0.0-pre.2",
+        "contentHash": "iVGnfKyv5rpupNKXtdstGV9vYWg3zLMkDfkpSkfLRzE6yG9MD5JdqKTJdb0zO2IOeIYodKSmfPavJiM2YZpj3g==",
         "dependencies": {
-          "CSharpMath.Rendering": "0.5.1",
-          "SkiaSharp": "2.80.1"
-        }
-      },
-      "SkiaSharp": {
-        "type": "Direct",
-        "requested": "[4.148.0, )",
-        "resolved": "4.148.0",
-        "contentHash": "t+oZDnzvi0en060BFDTmJ16C0zjsiXRrtOe70luIuIi/exVZtl1obrYh8D+IoHlGtp7bqzEBVncafbAl0ttmPQ==",
-        "dependencies": {
-          "SkiaSharp.NativeAssets.Win32": "4.148.0",
-          "SkiaSharp.NativeAssets.macOS": "4.148.0"
+          "Avalonia": "12.0.4",
+          "CSharpMath.Rendering": "1.0.0-pre.2"
         }
       },
       "Avalonia.BuildServices": {
@@ -34,39 +24,21 @@
       },
       "CSharpMath": {
         "type": "Transitive",
-        "resolved": "0.5.1",
-        "contentHash": "CBAtejk24icPQNJWPjUDGUqklNLpfglpRxQljiezn2MQrxL5cIVuouCVnw6ipU3cft9Tq8YfS6f/JPhSjhFtFA=="
-      },
-      "CSharpMath.Editor": {
-        "type": "Transitive",
-        "resolved": "0.5.1",
-        "contentHash": "q5MFAjI7TO41PtGFNHBFwOw3J3IS7Dnm7aJHEgPxMWE5wl1H5byOo0pJnGwXevjhoSRssGRJH2KCXgn0KbGJFQ==",
-        "dependencies": {
-          "CSharpMath": "0.5.1"
-        }
+        "resolved": "1.0.0-pre.2",
+        "contentHash": "bz47Ascj0qrc4vZZgs6H60uHUk1vwe5R/6W9NTQsz2cjBzGcYQoBYjxTFbHly0iPlaQ2RLGcgJYlEgfC5KAf9A=="
       },
       "CSharpMath.Rendering": {
         "type": "Transitive",
-        "resolved": "0.5.1",
-        "contentHash": "H4tctQzgpQmLICON1QAJtfm3/dj4exoxEKTuF9oO5YkHXMANWNfOQKwVtAx6n78hcD6WidwF2v2pH8Z/cOw/gg==",
+        "resolved": "1.0.0-pre.2",
+        "contentHash": "l/+Gzf0Nop2QrFMCsutmYA9iXM/+AjKGHXFCN6y+Y12yqmXZoX/m75rgj5M5y7ZTNmchUj4fRnaa7EEDA+fgJA==",
         "dependencies": {
-          "CSharpMath.Editor": "0.5.1"
+          "CSharpMath": "1.0.0-pre.2"
         }
       },
       "MicroCom.Runtime": {
         "type": "Transitive",
         "resolved": "0.11.6",
         "contentHash": "NdNWGDiZ6eS/Mf/9+QHR91cj1K7Hy+PX9yrHI/zM7xFYuj9IWT2uxtB6sCHjrnxAeLV9fut1R6zHDUGKX6f9lQ=="
-      },
-      "SkiaSharp.NativeAssets.macOS": {
-        "type": "Transitive",
-        "resolved": "4.148.0",
-        "contentHash": "1iESVxlqNNbQUiFODuyQJ/5dYUNYwGzZBUyaKNU3pJRM8zPFUkdMW0UZcZPvd6xwrjn53HYklJyKvetXC6ri+A=="
-      },
-      "SkiaSharp.NativeAssets.Win32": {
-        "type": "Transitive",
-        "resolved": "4.148.0",
-        "contentHash": "LegvQ9zAi9Tmot2YOLv8mcK+g3wbEYfCWUoC5JtyHaN8QrxsaMvfJ8pFPvnEOVuY8qXxs8vVqrO/x42/YaFDRA=="
       },
       "markview.avalonia": {
         "type": "Project",

--- a/tests/MarkView.Avalonia.Math.Tests/MathBlockRendererTests.cs
+++ b/tests/MarkView.Avalonia.Math.Tests/MathBlockRendererTests.cs
@@ -4,6 +4,8 @@
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 
+using CSharpMath.Avalonia;
+
 using Markdig;
 
 using MarkView.Avalonia.Rendering;
@@ -34,20 +36,20 @@ public class MathBlockRendererTests
     }
 
     [AvaloniaFact]
-    public void Math_block_border_contains_image()
+    public void Math_block_border_contains_math_view()
     {
         var result = Render("$$\nx^2\n$$");
         var border = Assert.IsType<Border>(Assert.Single(result.Children));
-        Assert.IsType<Image>(border.Child);
+        Assert.IsType<MathView>(border.Child);
     }
 
     [AvaloniaFact]
-    public void Math_block_image_has_non_null_bitmap_source()
+    public void Math_block_math_view_has_expected_latex()
     {
         var result = Render("$$\nx^2\n$$");
         var border = Assert.IsType<Border>(Assert.Single(result.Children));
-        var image = Assert.IsType<Image>(border.Child);
-        Assert.NotNull(image.Source);
+        var mathView = Assert.IsType<MathView>(border.Child);
+        Assert.Equal("x^2", mathView.LaTeX);
     }
 
     [AvaloniaFact]

--- a/tests/MarkView.Avalonia.Math.Tests/MathExtensionTests.cs
+++ b/tests/MarkView.Avalonia.Math.Tests/MathExtensionTests.cs
@@ -4,6 +4,8 @@
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
 
+using CSharpMath.Avalonia;
+
 using Markdig;
 
 using MarkView.Avalonia.Mermaid;
@@ -99,8 +101,8 @@ public class MathExtensionTests
         var panel = Assert.IsType<StackPanel>(contentGrid.Children[0]);
         var border = Assert.IsType<Border>(Assert.Single(panel.Children));
         Assert.Contains("markdown-math-block", border.Classes);
-        var image = Assert.IsType<Image>(border.Child);
-        Assert.NotNull(image.Source);
+        var mathView = Assert.IsType<MathView>(border.Child);
+        Assert.Equal("x^2", mathView.LaTeX);
     }
 
     [AvaloniaTheory]
@@ -128,8 +130,8 @@ public class MathExtensionTests
 
         var mathBorder = Assert.IsType<Border>(panel.Children[0]);
         Assert.Contains("markdown-math-block", mathBorder.Classes);
-        var mathImage = Assert.IsType<Image>(mathBorder.Child);
-        Assert.NotNull(mathImage.Source);
+        var mathView = Assert.IsType<MathView>(mathBorder.Child);
+        Assert.Equal("x^2", mathView.LaTeX);
 
         var mermaidBorder = Assert.IsType<Border>(panel.Children[1]);
         Assert.Contains("markdown-mermaid", mermaidBorder.Classes);

--- a/tests/MarkView.Avalonia.Math.Tests/MathInlineRendererTests.cs
+++ b/tests/MarkView.Avalonia.Math.Tests/MathInlineRendererTests.cs
@@ -5,6 +5,8 @@ using Avalonia.Controls;
 using Avalonia.Controls.Documents;
 using Avalonia.Headless.XUnit;
 
+using CSharpMath.Avalonia;
+
 using Markdig;
 
 using MarkView.Avalonia.Rendering;
@@ -32,27 +34,27 @@ public class MathInlineRendererTests
         var result = Render("Einstein said $E=mc^2$ once.");
         var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(result.Children));
         var container = textBlock.Inlines!.OfType<InlineUIContainer>().Single();
-        Assert.IsType<Image>(container.Child);
+        Assert.IsType<MathView>(container.Child);
     }
 
     [AvaloniaFact]
-    public void Inline_math_image_has_math_inline_class()
+    public void Inline_math_view_has_math_inline_class()
     {
         var result = Render("$x^2$");
         var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(result.Children));
         var container = textBlock.Inlines!.OfType<InlineUIContainer>().Single();
-        var image = Assert.IsType<Image>(container.Child);
-        Assert.Contains("markdown-math-inline", image.Classes);
+        var mathView = Assert.IsType<MathView>(container.Child);
+        Assert.Contains("markdown-math-inline", mathView.Classes);
     }
 
     [AvaloniaFact]
-    public void Inline_math_image_has_non_null_bitmap_source()
+    public void Inline_math_view_has_expected_latex()
     {
         var result = Render("$x^2$");
         var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(result.Children));
         var container = textBlock.Inlines!.OfType<InlineUIContainer>().Single();
-        var image = Assert.IsType<Image>(container.Child);
-        Assert.NotNull(image.Source);
+        var mathView = Assert.IsType<MathView>(container.Child);
+        Assert.Equal("x^2", mathView.LaTeX);
     }
 
     [AvaloniaFact]

--- a/tests/MarkView.Avalonia.Math.Tests/packages.lock.json
+++ b/tests/MarkView.Avalonia.Math.Tests/packages.lock.json
@@ -99,23 +99,15 @@
       },
       "CSharpMath": {
         "type": "Transitive",
-        "resolved": "0.5.1",
-        "contentHash": "CBAtejk24icPQNJWPjUDGUqklNLpfglpRxQljiezn2MQrxL5cIVuouCVnw6ipU3cft9Tq8YfS6f/JPhSjhFtFA=="
-      },
-      "CSharpMath.Editor": {
-        "type": "Transitive",
-        "resolved": "0.5.1",
-        "contentHash": "q5MFAjI7TO41PtGFNHBFwOw3J3IS7Dnm7aJHEgPxMWE5wl1H5byOo0pJnGwXevjhoSRssGRJH2KCXgn0KbGJFQ==",
-        "dependencies": {
-          "CSharpMath": "0.5.1"
-        }
+        "resolved": "1.0.0-pre.2",
+        "contentHash": "bz47Ascj0qrc4vZZgs6H60uHUk1vwe5R/6W9NTQsz2cjBzGcYQoBYjxTFbHly0iPlaQ2RLGcgJYlEgfC5KAf9A=="
       },
       "CSharpMath.Rendering": {
         "type": "Transitive",
-        "resolved": "0.5.1",
-        "contentHash": "H4tctQzgpQmLICON1QAJtfm3/dj4exoxEKTuF9oO5YkHXMANWNfOQKwVtAx6n78hcD6WidwF2v2pH8Z/cOw/gg==",
+        "resolved": "1.0.0-pre.2",
+        "contentHash": "l/+Gzf0Nop2QrFMCsutmYA9iXM/+AjKGHXFCN6y+Y12yqmXZoX/m75rgj5M5y7ZTNmchUj4fRnaa7EEDA+fgJA==",
         "dependencies": {
-          "CSharpMath.Editor": "0.5.1"
+          "CSharpMath": "1.0.0-pre.2"
         }
       },
       "ExCSS": {
@@ -395,9 +387,8 @@
       "markview.avalonia.math": {
         "type": "Project",
         "dependencies": {
-          "CSharpMath.SkiaSharp": "[0.5.1, )",
-          "MarkView.Avalonia": "[1.0.0, )",
-          "SkiaSharp": "[4.148.0, )"
+          "CSharpMath.Avalonia": "[1.0.0-pre.2, )",
+          "MarkView.Avalonia": "[1.0.0, )"
         }
       },
       "markview.avalonia.mermaid": {
@@ -428,14 +419,14 @@
           "Avalonia": "12.1.1"
         }
       },
-      "CSharpMath.SkiaSharp": {
+      "CSharpMath.Avalonia": {
         "type": "CentralTransitive",
-        "requested": "[0.5.1, )",
-        "resolved": "0.5.1",
-        "contentHash": "3SMI0o2EZi2/GskH6T5s9GDaBq9u0VBd/o8Geqd+FyPxEXCcmzECOZ3PdVdob/YNevl4okOTbqZrHZS2O28/ZQ==",
+        "requested": "[1.0.0-pre.2, )",
+        "resolved": "1.0.0-pre.2",
+        "contentHash": "iVGnfKyv5rpupNKXtdstGV9vYWg3zLMkDfkpSkfLRzE6yG9MD5JdqKTJdb0zO2IOeIYodKSmfPavJiM2YZpj3g==",
         "dependencies": {
-          "CSharpMath.Rendering": "0.5.1",
-          "SkiaSharp": "2.80.1"
+          "Avalonia": "12.0.4",
+          "CSharpMath.Rendering": "1.0.0-pre.2"
         }
       },
       "Markdig": {


### PR DESCRIPTION
## Summary

Following #51, replace `CSharpMath.SkiaSharp` with `CSharpMath.Avalonia` (see https://github.com/verybadcat/CSharpMath/pull/259).

> [!WARNING]
> **Prerelease dependency:** this PR currently pins `CSharpMath.Avalonia` to a `1.0.0-pre.2` prerelease build, since it's the version CSharpMath explicitly targets Avalonia 12/.NET 10 with.
>
> **This branch/package must not be merged or released until CSharpMath ships a stable 1.0.0** — re-pin the version at that point.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [ ] Documentation
- [ ] CI / build

## Test plan

- [x] `dotnet test` — all tests pass
- [x] Manual smoke-test in the demo app