### PR TITLE
feat: ship a theme file for MarkView.Avalonia.Mermaid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     uses: ./.github/workflows/build.yml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,5 +54,6 @@ ImageSizePreprocessor  ("![alt](url =WxH)" normalisation)
 ## Conventions
 
 - CSS-style class names: `markdown-*` (e.g. `markdown-h1`, `markdown-code-block`) — see [docs/theming.md](docs/theming.md) for the full list.
+- Each package that needs overridable colours ships its own `Themes/<Package>Theme.axaml` (`AvaloniaResource` glob in the `.csproj`), included via `StyleInclude` — standalone, does not import `MarkdownTheme.axaml`. Code paths that can't rely on `DynamicResource` (e.g. Mermaid's SVG baked at render time) read the brush via `Application.Current.TryGetResource` and fall back to a hardcoded literal if the theme isn't included.
 - File naming: `<Element>Renderer.cs`, `<Feature>Extension.cs`, `<Feature>Highlighter.cs`. Namespaces mirror folder structure.
 - `InternalsVisibleTo` in `src/MarkView.Avalonia/AssemblyInfo.cs` grants `MarkView.Avalonia.Tests` and `MarkView.Avalonia.Svg` access to internals — extend that list rather than making things `public` just to reach them from a new test/extension project.

--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ Include `MarkdownTheme.axaml` for default styles. Override any style class in yo
 | `markdown-footnote-group` | Footnote definition list | `StackPanel` |
 | `markdown-footnote-item` | Individual footnote row | `Grid` |
 
+Extension packages may ship their own theme file with additional overridable colours — check the extension's README for its `StyleInclude` path and resource keys.
+
 Example — increase heading size and add a bottom border:
 
 ```xml

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -13,6 +13,14 @@
 
 The theme uses `DynamicResource` throughout so it responds to Avalonia's `RequestedThemeVariant` changes automatically.
 
+Extension packages that need their own overridable colours ship a standalone theme file the same way — e.g. `MarkView.Avalonia.Mermaid` includes `MermaidTheme.axaml`:
+
+```xml
+<StyleInclude Source="avares://MarkView.Avalonia.Mermaid/Themes/MermaidTheme.axaml" />
+```
+
+Each extension theme is independent — it does not import the core `MarkdownTheme.axaml` — so including one, none, or several has no ordering requirement. If an extension theme isn't included, the extension falls back to built-in default colours rather than failing.
+
 ## Style class reference
 
 Every element rendered by `MarkdownViewer` is tagged with a CSS-style class name. Override any selector in your own `Styles` block to customise appearance.
@@ -91,6 +99,21 @@ Example — colour the NOTE variant:
 | `markdown-footnote-group` | `StackPanel` | Definition list at end of document |
 | `markdown-footnote-item` | `Grid` | Individual footnote row |
 
+### Mermaid (`MarkView.Avalonia.Mermaid`)
+
+| Class | Control | Element |
+|-------|---------|---------|
+| `markdown-mermaid` | `Border` | Rendered diagram container |
+| `markdown-mermaid-fallback` | `Border` | Container shown when a diagram fails to render |
+
+Diagram colours are baked into the generated SVG at render time, so they aren't `DynamicResource`-driven on the `Border` itself. Instead `MermaidTheme.axaml` exposes Dark/Light `SolidColorBrush` resources that `MermaidBlockRenderer` reads when building each diagram:
+
+| Resource key | Dark | Light |
+|---|---|---|
+| `MarkdownMermaidBackground` | `#18181B` | `#FFFFFF` |
+| `MarkdownMermaidForeground` | `#FAFAFA` | `#27272A` |
+| `MarkdownMermaidAccent` | `#60A5FA` | `#3B82F6` |
+
 ## Example customisations
 
 ### Larger headings
@@ -129,5 +152,5 @@ When the user switches between `Light` and `Dark` theme variants:
 
 - All `DynamicResource` references in `MarkdownTheme.axaml` update automatically.
 - `TextMateCodeBlockRenderer` rebuilds only the `TextBlock.Inlines` for each code block.
-- `MermaidBlockRenderer` re-renders diagrams with updated colour variables.
+- `MermaidBlockRenderer` re-renders diagrams, reading `MarkdownMermaid*` resources for the new variant.
 - The document scroll position is preserved in both cases.

--- a/samples/MarkView.Avalonia.Demo/App.axaml
+++ b/samples/MarkView.Avalonia.Demo/App.axaml
@@ -5,5 +5,6 @@
   <Application.Styles>
     <FluentTheme />
     <StyleInclude Source="avares://MarkView.Avalonia/Themes/MarkdownTheme.axaml" />
+    <StyleInclude Source="avares://MarkView.Avalonia.Mermaid/Themes/MermaidTheme.axaml" />
   </Application.Styles>
 </Application>

--- a/src/MarkView.Avalonia.Mermaid/MarkView.Avalonia.Mermaid.csproj
+++ b/src/MarkView.Avalonia.Mermaid/MarkView.Avalonia.Mermaid.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Svg.Controls.Skia.Avalonia" />
   </ItemGroup>
   <ItemGroup>
+    <AvaloniaResource Include="Themes\**" />
     <None Include="README.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 </Project>

--- a/src/MarkView.Avalonia.Mermaid/MermaidBlockRenderer.cs
+++ b/src/MarkView.Avalonia.Mermaid/MermaidBlockRenderer.cs
@@ -132,14 +132,33 @@ public sealed class MermaidBlockRenderer : AvaloniaObjectRenderer<FencedCodeBloc
     }
 
     /// <summary>
-    /// Builds render options matching the current Avalonia theme variant.
+    /// Builds render options matching the current Avalonia theme variant. Colours come from
+    /// MermaidTheme.axaml's <c>MarkdownMermaid*</c> brush resources so users can override them;
+    /// the literals here are only a fallback for apps that don't include that theme.
     /// </summary>
     private static MermaidRenderOptions GetRenderOptions()
     {
-        var isDark = Application.Current?.ActualThemeVariant == ThemeVariant.Dark;
-        return isDark
-            ? new MermaidRenderOptions { Bg = "#18181B", Fg = "#FAFAFA", Accent = "#60a5fa", Transparent = false }
-            : new MermaidRenderOptions { Bg = "#FFFFFF", Fg = "#27272A", Accent = "#3b82f6", Transparent = false };
+        var app = Application.Current;
+        var isDark = app?.ActualThemeVariant == ThemeVariant.Dark;
+        var theme = app?.ActualThemeVariant ?? ThemeVariant.Light;
+
+        return new MermaidRenderOptions
+        {
+            Bg = ResolveHex(app, theme, "MarkdownMermaidBackground", isDark ? "#18181B" : "#FFFFFF"),
+            Fg = ResolveHex(app, theme, "MarkdownMermaidForeground", isDark ? "#FAFAFA" : "#27272A"),
+            Accent = ResolveHex(app, theme, "MarkdownMermaidAccent", isDark ? "#60A5FA" : "#3B82F6"),
+            Transparent = false,
+        };
+    }
+
+    private static string ResolveHex(Application? app, ThemeVariant theme, string resourceKey, string fallback)
+    {
+        if (app != null && app.TryGetResource(resourceKey, theme, out var resource) && resource is ISolidColorBrush brush)
+        {
+            var c = brush.Color;
+            return $"#{c.R:X2}{c.G:X2}{c.B:X2}";
+        }
+        return fallback;
     }
 
     private readonly record struct Rgb(byte R, byte G, byte B);

--- a/src/MarkView.Avalonia.Mermaid/README.md
+++ b/src/MarkView.Avalonia.Mermaid/README.md
@@ -61,12 +61,22 @@ See the [Mermaid documentation](https://mermaid.js.org/intro/) for syntax refere
 
 ## Theme Awareness
 
-Diagrams are rendered with colours matching the active Avalonia theme variant:
+Diagram colours come from `MermaidTheme.axaml`, included the same way as the core package's theme:
 
-| Variant | Background | Foreground | Accent |
-|---------|-----------|-----------|--------|
-| Dark | `#18181B` | `#FAFAFA` | `#60a5fa` |
-| Light | `#FFFFFF` | `#27272A` | `#3b82f6` |
+```xml
+<!-- App.axaml -->
+<StyleInclude Source="avares://MarkView.Avalonia.Mermaid/Themes/MermaidTheme.axaml" />
+```
+
+It defines Dark/Light `SolidColorBrush` resources you can override in your own styles:
+
+| Resource key | Dark | Light |
+|---|---|---|
+| `MarkdownMermaidBackground` | `#18181B` | `#FFFFFF` |
+| `MarkdownMermaidForeground` | `#FAFAFA` | `#27272A` |
+| `MarkdownMermaidAccent` | `#60A5FA` | `#3B82F6` |
+
+If the theme isn't included, the same values are used as a built-in fallback — the extension works standalone.
 
 When the user switches between light and dark, the diagram is automatically re-rendered. The `Border` container stays in place — scroll position is preserved and other document elements are not affected.
 

--- a/src/MarkView.Avalonia.Mermaid/Themes/MermaidTheme.axaml
+++ b/src/MarkView.Avalonia.Mermaid/Themes/MermaidTheme.axaml
@@ -1,0 +1,25 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <Styles.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Dark">
+          <SolidColorBrush x:Key="MarkdownMermaidBackground">#18181B</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownMermaidForeground">#FAFAFA</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownMermaidAccent">#60A5FA</SolidColorBrush>
+        </ResourceDictionary>
+        <ResourceDictionary x:Key="Light">
+          <SolidColorBrush x:Key="MarkdownMermaidBackground">#FFFFFF</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownMermaidForeground">#27272A</SolidColorBrush>
+          <SolidColorBrush x:Key="MarkdownMermaidAccent">#3B82F6</SolidColorBrush>
+        </ResourceDictionary>
+      </ResourceDictionary.ThemeDictionaries>
+    </ResourceDictionary>
+  </Styles.Resources>
+
+  <Style Selector="Border.markdown-mermaid">
+    <Setter Property="Margin" Value="0,4" />
+  </Style>
+
+</Styles>


### PR DESCRIPTION
## Summary

Diagram colours were hardcoded in `MermaidBlockRenderer`; expose them as overridable Dark/Light brush resources (MarkdownMermaidBackground/Foreground/Accent) in a new `MermaidTheme.axaml`, mirroring the core package's theming convention. Falls back to the old literals if the theme isn't included, so the extension keeps working standalone.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [ ] Documentation
- [ ] CI / build

## Test plan

- [x] `dotnet test` — all tests pass
- [x] Manual smoke-test in the demo app