### PR TITLE
feat: template MarkdownViewer's ScrollViewer as an overridable ControlTemplate part

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,8 +33,10 @@ Markdown string
   → IMarkViewExtension[].Register(renderer)   ← extensions plug in here
   → pipeline.Setup(renderer)
   → AvaloniaRenderer.Render(document)
-  → ScrollViewer { StackPanel (root) }
+  → Grid { StackPanel (root), DocumentSelectionLayer }   ← this becomes MarkdownViewer.Content
 ```
+
+`Content` is hosted by `PART_ScrollViewer`, the named part inside `MarkdownViewer`'s default `ControlTemplate` (shipped in `MarkdownTheme.axaml`); `viewer.Content` itself is the `Grid`, not a `ScrollViewer`.
 
 - **`AvaloniaRenderer`** extends `RendererBase`; manages a push/pop stack of `IContainer` (either `Panel` or `InlineCollection`).
 - Block renderers live in `Rendering/Blocks/`, inline renderers in `Rendering/Inlines/`.
@@ -78,7 +80,7 @@ Dark/light dictionaries use `DynamicResource`; monospace stack: Cascadia Code �
 ## Testing Patterns
 
 - Inherit `RenderTestBase` and call `Render(markdown)` to get the root `StackPanel`.
-- Traverse the control tree: `ScrollViewer → StackPanel → children`.
+- When testing through a full `MarkdownViewer` instead, traverse `viewer.Content` (a `Grid`) directly: `Grid → StackPanel → children`. The `ScrollViewer` (`PART_ScrollViewer`) lives in the control's `ControlTemplate`, not in `Content` — reach it via `OnApplyTemplate` or `GetVisualDescendants()` once a template (e.g. `MarkdownTheme.axaml`) is applied.
 - Use `Assert.IsType<T>()`, `.OfType<T>()`, `Assert.Single()` for structural assertions.
 - `TestApp.cs` bootstraps `FluentTheme` and `AvaloniaHeadlessPlatformOptions`; copy this pattern for new test projects.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ dotnet test --filter "FullyQualifiedName~MarkdownViewer"   # run a single class/
 - Test runner: xUnit v3 + `Avalonia.Headless.XUnit`. **Any test that constructs an Avalonia object must use `[AvaloniaFact]`/`[AvaloniaTheory]`**, not `[Fact]`/`[Theory]` — even a bare property set on `TextBlock`/`StackPanel`/`Run` touches `AvaloniaPropertyDictionaryPool` and throws `IndexOutOfRangeException` without platform init. Plain `[Fact]` is only safe when a test constructs zero Avalonia objects (e.g. `SlugGeneratorTests`, `TextMateHighlighterTests`).
 - Known upstream flake: `AvaloniaUI/Avalonia#20664` — headless test session cleanup can resume on a different thread, causing sporadic `Dispatcher.VerifyAccess()` failures in `[AvaloniaFact]` tests.
 - Coverage via coverlet (`coverlet.runsettings`), reported by `.github/workflows/coverage.yml`.
-- Test project pattern: inherit `RenderTestBase`, call `Render(markdown)`, and traverse `ScrollViewer → StackPanel → children` with `Assert.IsType<T>()` / `.OfType<T>()`. `TestApp.cs` bootstraps `FluentTheme` + `AvaloniaHeadlessPlatformOptions` — copy it when adding a new test project.
+- Test project pattern: inherit `RenderTestBase`, call `Render(markdown)`, and traverse the returned root `StackPanel → children` with `Assert.IsType<T>()` / `.OfType<T>()`. When testing through a full `MarkdownViewer` instead, `viewer.Content` is the rendered `Grid` directly — traverse `Grid → StackPanel → children`; the `ScrollViewer` (`PART_ScrollViewer`) lives in the control's `ControlTemplate`, not in `Content`, and is only reachable via `OnApplyTemplate`/`GetVisualDescendants()` once the control has a template applied (e.g. the `MarkdownTheme.axaml` include). `TestApp.cs` bootstraps `FluentTheme` + `AvaloniaHeadlessPlatformOptions` — copy it when adding a new test project.
 
 ## Architecture
 
@@ -41,8 +41,10 @@ ImageSizePreprocessor  ("![alt](url =WxH)" normalisation)
   → IMarkViewExtension[].Register(renderer)   ← extension packages plug in here
   → pipeline.Setup(renderer)
   → AvaloniaRenderer.Render(document)
-  → ScrollViewer { StackPanel (root) }
+  → Grid { StackPanel (root), DocumentSelectionLayer }   ← this becomes MarkdownViewer.Content
 ```
+
+`Content` is hosted by `PART_ScrollViewer`, the named part inside `MarkdownViewer`'s default `ControlTemplate` (shipped in `MarkdownTheme.axaml`); `viewer.Content` itself is the `Grid`, not a `ScrollViewer`.
 
 - `AvaloniaRenderer` (`src/MarkView.Avalonia/Rendering/AvaloniaRenderer.cs`) extends Markdig's `RendererBase` and owns a push/pop stack of `IContainer` — either a `BlockContainer` (wraps a `Panel`) or an `InlineContainer` (wraps an `InlineCollection`). Block renderers call `WriteBlock`, inline renderers call `WriteInline`.
 - Block renderers live in `Rendering/Blocks/`, inline renderers in `Rendering/Inlines/`. Registration order in `AvaloniaRenderer.LoadRenderers()` matters when one Markdig type extends another — e.g. `AlertBlockRenderer` must precede `QuoteBlockRenderer` because `AlertBlock` extends `QuoteBlock` and Markdig dispatches to the first renderer whose `Accept()` matches.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -171,6 +171,15 @@ the viewer's width:
 | `Natural` | No scaling — renders at native pixel size. May appear cropped if the image is wider than the viewer, since horizontal scrolling is disabled by default. |
 | `Fill` | Always fills the container width, enlarging small images if necessary. |
 
+`Fill` and `ScaleDownToFit` scale images against the nearest width-constraining
+ancestor in the control's template. The default template provides this via
+`PART_ScrollViewer`'s `HorizontalScrollBarVisibility`, which defaults to
+`Disabled` and constrains width without permitting horizontal scroll. Setting
+`ScrollViewer.HorizontalScrollBarVisibility="Auto"` (or `Visible`) directly on
+a `MarkdownViewer` instance — or a custom `Template` that drops
+`PART_ScrollViewer` entirely — removes that constraint; those modes may then
+behave like `Natural`. `Natural` itself is unaffected, since it never scales.
+
 ```csharp
 viewer.ImageResizeMode = MarkView.Avalonia.ImageResizeMode.Natural;
 ```

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -146,6 +146,42 @@ Diagram colours are baked into the generated SVG at render time, so they aren't 
 </Style>
 ```
 
+## Template customisation
+
+`MarkdownViewer`'s default `ControlTemplate` (in `MarkdownTheme.axaml`) wraps
+the rendered document in a named `ScrollViewer`:
+
+```
+Border → ScrollViewer (Name="PART_ScrollViewer") → ContentPresenter
+```
+
+**Lightweight tweaks — no template override needed.** Scrollbar behavior is
+exposed via the same attached `ScrollViewer.*` properties Avalonia's own
+`ListBox` supports, and flows through to `PART_ScrollViewer` automatically:
+
+```xml
+<mv:MarkdownViewer ScrollViewer.VerticalScrollBarVisibility="Hidden" />
+```
+
+**Full override.** Set `Template` to replace the whole structure. `PART_ScrollViewer`
+is optional — a template without it still works, but `ScrollToAnchor()` falls
+back to a plain `BringIntoView()` instead of a precise scroll offset, and
+`ImageResizeMode.Fill`/`ScaleDownToFit` lose their width-clamp guarantee
+unless the replacement template provides an equivalent width-constraining
+ancestor:
+
+```xml
+<Style Selector="mv|MarkdownViewer">
+  <Setter Property="Template">
+    <ControlTemplate>
+      <ScrollViewer Name="PART_ScrollViewer">
+        <ContentPresenter Content="{TemplateBinding Content}" />
+      </ScrollViewer>
+    </ControlTemplate>
+  </Setter>
+</Style>
+```
+
 ## Live theme switching
 
 When the user switches between `Light` and `Dark` theme variants:

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -11,7 +11,7 @@
 </Application.Styles>
 ```
 
-The theme uses `DynamicResource` throughout so it responds to Avalonia's `RequestedThemeVariant` changes automatically.
+The theme uses `DynamicResource` throughout so it responds to Avalonia's `RequestedThemeVariant` changes automatically. This include is not purely cosmetic: it also supplies `MarkdownViewer`'s default `ControlTemplate`, which is what provides the `PART_ScrollViewer` that makes the control scrollable — without it, content renders but cannot scroll and `ScrollToAnchor()` silently no-ops.
 
 Extension packages that need their own overridable colours ship a standalone theme file the same way — e.g. `MarkView.Avalonia.Mermaid` includes `MermaidTheme.axaml`:
 
@@ -175,7 +175,7 @@ ancestor:
   <Setter Property="Template">
     <ControlTemplate>
       <ScrollViewer Name="PART_ScrollViewer">
-        <ContentPresenter Content="{TemplateBinding Content}" />
+        <ContentPresenter Name="PART_ContentPresenter" Content="{TemplateBinding Content}" />
       </ScrollViewer>
     </ControlTemplate>
   </Setter>

--- a/src/MarkView.Avalonia/MarkdownViewer.cs
+++ b/src/MarkView.Avalonia/MarkdownViewer.cs
@@ -302,6 +302,12 @@ public partial class MarkdownViewer : ContentControl
             OnContentPointerReleased, RoutingStrategies.Tunnel);
 
         Content = contentGrid;
+
+        // Every new render is treated as a fresh document — reset scroll position to the
+        // top, since PART_ScrollViewer now persists across renders (it lives in the
+        // template, not rebuilt per-render) and would otherwise keep its old offset.
+        if (_scrollViewer is not null)
+            _scrollViewer.Offset = default;
     }
 
     // ── Block registration ────────────────────────────────────────────────────
@@ -591,13 +597,19 @@ public partial class MarkdownViewer : ContentControl
         if (!_anchors.TryGetValue(anchorId, out var control))
             return;
 
-        if (_scrollViewer is null || Content is not Visual rootPanel)
+        if (_scrollViewer is null)
         {
             control.BringIntoView();
             return;
         }
 
-        var point = control.TranslatePoint(new Point(0, 0), rootPanel);
+        // Translating to the ScrollViewer itself (rather than to Content) gives a
+        // viewport-relative point that already accounts for Padding — Padding is applied
+        // as the ContentPresenter's Margin *inside* the ScrollViewer, so Content's origin
+        // is offset from the scrollable extent's origin by Padding.Top. Adding the current
+        // Offset.Y back converts the viewport-relative point to absolute content-space
+        // coordinates, which is what the new Offset value must be expressed in.
+        var point = control.TranslatePoint(new Point(0, 0), _scrollViewer);
         if (point is null)
         {
             control.BringIntoView();
@@ -605,6 +617,7 @@ public partial class MarkdownViewer : ContentControl
         }
 
         const double topMargin = 16;
-        _scrollViewer.Offset = new Vector(_scrollViewer.Offset.X, Math.Max(0, point.Value.Y - topMargin));
+        var desiredY = _scrollViewer.Offset.Y + point.Value.Y - topMargin;
+        _scrollViewer.Offset = new Vector(_scrollViewer.Offset.X, Math.Max(0, desiredY));
     }
 }

--- a/src/MarkView.Avalonia/MarkdownViewer.cs
+++ b/src/MarkView.Avalonia/MarkdownViewer.cs
@@ -299,7 +299,7 @@ public partial class MarkdownViewer : ContentControl
         contentGrid.AddHandler(InputElement.PointerReleasedEvent,
             OnContentPointerReleased, RoutingStrategies.Tunnel);
 
-        Content = new ScrollViewer { Content = contentGrid };
+        Content = contentGrid;
     }
 
     // ── Block registration ────────────────────────────────────────────────────
@@ -392,7 +392,7 @@ public partial class MarkdownViewer : ContentControl
         }
     }
 
-    private void RegisterTableRows(DocumentSelectionLayer layer, Grid tableGrid)
+    private static void RegisterTableRows(DocumentSelectionLayer layer, Grid tableGrid)
     {
         // TableRenderer adds cells in row-major order (rowIndex / colIndex ascending),
         // so iterating Children directly avoids the O(N log N) SortedDictionary sort.
@@ -600,4 +600,3 @@ public partial class MarkdownViewer : ContentControl
         scrollViewer.Offset = new Vector(scrollViewer.Offset.X, Math.Max(0, point.Value.Y - topMargin));
     }
 }
-

--- a/src/MarkView.Avalonia/MarkdownViewer.cs
+++ b/src/MarkView.Avalonia/MarkdownViewer.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Platform;
@@ -33,6 +34,7 @@ public partial class MarkdownViewer : ContentControl
 
     private Dictionary<string, Control> _anchors = new(StringComparer.OrdinalIgnoreCase);
     private DocumentSelectionLayer? _selectionLayer;
+    private ScrollViewer? _scrollViewer;
     private bool _isDragging;
     private Point _dragStart;
     private const double DragThreshold = 3.0;
@@ -578,12 +580,18 @@ public partial class MarkdownViewer : ContentControl
         RaiseEvent(e);
     }
 
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        base.OnApplyTemplate(e);
+        _scrollViewer = e.NameScope.Find<ScrollViewer>("PART_ScrollViewer");
+    }
+
     public void ScrollToAnchor(string anchorId)
     {
         if (!_anchors.TryGetValue(anchorId, out var control))
             return;
 
-        if (Content is not ScrollViewer scrollViewer || scrollViewer.Content is not Visual rootPanel)
+        if (_scrollViewer is null || Content is not Visual rootPanel)
         {
             control.BringIntoView();
             return;
@@ -597,6 +605,6 @@ public partial class MarkdownViewer : ContentControl
         }
 
         const double topMargin = 16;
-        scrollViewer.Offset = new Vector(scrollViewer.Offset.X, Math.Max(0, point.Value.Y - topMargin));
+        _scrollViewer.Offset = new Vector(_scrollViewer.Offset.X, Math.Max(0, point.Value.Y - topMargin));
     }
 }

--- a/src/MarkView.Avalonia/Themes/MarkdownTheme.axaml
+++ b/src/MarkView.Avalonia/Themes/MarkdownTheme.axaml
@@ -46,7 +46,8 @@
     </ResourceDictionary>
   </Styles.Resources>
 
-  <Style Selector="mv|MarkdownViewer">
+  <!-- Use :is() so subclasses of MarkdownViewer also get the default template (and thus PART_ScrollViewer) -->
+  <Style Selector=":is(mv|MarkdownViewer)">
     <Setter Property="Background" Value="Transparent" />
     <Setter Property="Template">
       <ControlTemplate>

--- a/src/MarkView.Avalonia/Themes/MarkdownTheme.axaml
+++ b/src/MarkView.Avalonia/Themes/MarkdownTheme.axaml
@@ -46,6 +46,35 @@
     </ResourceDictionary>
   </Styles.Resources>
 
+  <Style Selector="mv|MarkdownViewer">
+    <Setter Property="Background" Value="Transparent" />
+    <Setter Property="Template">
+      <ControlTemplate>
+        <Border BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}">
+          <ScrollViewer Name="PART_ScrollViewer"
+                        Background="{TemplateBinding Background}"
+                        AllowAutoHide="{TemplateBinding (ScrollViewer.AllowAutoHide)}"
+                        BringIntoViewOnFocusChange="{TemplateBinding (ScrollViewer.BringIntoViewOnFocusChange)}"
+                        HorizontalScrollBarVisibility="{TemplateBinding (ScrollViewer.HorizontalScrollBarVisibility)}"
+                        VerticalScrollBarVisibility="{TemplateBinding (ScrollViewer.VerticalScrollBarVisibility)}"
+                        IsScrollChainingEnabled="{TemplateBinding (ScrollViewer.IsScrollChainingEnabled)}"
+                        IsDeferredScrollingEnabled="{TemplateBinding (ScrollViewer.IsDeferredScrollingEnabled)}"
+                        VerticalSnapPointsType="{TemplateBinding (ScrollViewer.VerticalSnapPointsType)}"
+                        HorizontalSnapPointsType="{TemplateBinding (ScrollViewer.HorizontalSnapPointsType)}">
+            <ContentPresenter Name="PART_ContentPresenter"
+                              Content="{TemplateBinding Content}"
+                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                              Margin="{TemplateBinding Padding}"
+                              HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                              VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+          </ScrollViewer>
+        </Border>
+      </ControlTemplate>
+    </Setter>
+  </Style>
+
   <!-- Headings — use :is() to match MarkdownSelectableTextBlock (a TextBlock subclass) -->
   <Style Selector=":is(TextBlock).markdown-h1">
     <Setter Property="FontSize" Value="28" />

--- a/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Inlines/ImageTests.cs
@@ -86,8 +86,7 @@ public class ImageTests : RenderTestBase
         var viewer = new MarkdownViewer();
         viewer.Markdown = "![logo](https://example.com/logo.png =200x100)";
 
-        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
-        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var contentGrid = Assert.IsType<Grid>(viewer.Content);
         var panel = Assert.IsType<StackPanel>(contentGrid.Children[0]);
         var image = FindFirst<Image>(panel);
         Assert.NotNull(image);

--- a/tests/MarkView.Avalonia.Tests/MarkdownViewerDefaultsTests.cs
+++ b/tests/MarkView.Avalonia.Tests/MarkdownViewerDefaultsTests.cs
@@ -23,8 +23,7 @@ public class MarkdownViewerDefaultsTests
 
         var viewer = new MarkdownViewer { Markdown = "- [ ] item" };
 
-        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
-        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var contentGrid = Assert.IsType<Grid>(viewer.Content);
         var rootPanel = contentGrid.Children.OfType<StackPanel>().First();
 
         // Built-in default uses UseSupportedExtensions which includes UseTaskLists.
@@ -42,8 +41,7 @@ public class MarkdownViewerDefaultsTests
 
         var viewer = new MarkdownViewer { Markdown = "- [ ] item" };
 
-        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
-        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var contentGrid = Assert.IsType<Grid>(viewer.Content);
         var rootPanel = contentGrid.Children.OfType<StackPanel>().First();
 
         // Without UseTaskLists, no task marker is rendered — task list item renders as plain text.
@@ -65,8 +63,7 @@ public class MarkdownViewerDefaultsTests
             Markdown = "- [ ] item"
         };
 
-        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
-        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var contentGrid = Assert.IsType<Grid>(viewer.Content);
         var rootPanel = contentGrid.Children.OfType<StackPanel>().First();
 
         // Instance pipeline (no task lists) wins over global — no task marker rendered.

--- a/tests/MarkView.Avalonia.Tests/MarkdownViewerExtensionsTests.cs
+++ b/tests/MarkView.Avalonia.Tests/MarkdownViewerExtensionsTests.cs
@@ -80,8 +80,7 @@ public class MarkdownViewerExtensionsTests
         viewer.UseFootnotes();
         viewer.Markdown = "Text[^1]\n\n[^1]: Definition";
 
-        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
-        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var contentGrid = Assert.IsType<Grid>(viewer.Content);
         var panel = Assert.IsType<StackPanel>(contentGrid.Children[0]);
         // Footnote group should be the last child
         Assert.True(panel.Children.Count >= 2, "Expected content + footnote group");
@@ -94,8 +93,7 @@ public class MarkdownViewerExtensionsTests
         viewer.UseAlertBlocks();
         viewer.Markdown = "> [!NOTE]\n> Hello";
 
-        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
-        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var contentGrid = Assert.IsType<Grid>(viewer.Content);
         var panel = Assert.IsType<StackPanel>(contentGrid.Children[0]);
         var border = Assert.IsType<Border>(Assert.Single(panel.Children));
         Assert.Contains("markdown-alert", border.Classes);

--- a/tests/MarkView.Avalonia.Tests/MarkdownViewerSourceTests.cs
+++ b/tests/MarkView.Avalonia.Tests/MarkdownViewerSourceTests.cs
@@ -18,8 +18,7 @@ public class MarkdownViewerSourceTests
 
     private static StackPanel GetRootPanel(MarkdownViewer viewer)
     {
-        var sv = Assert.IsType<ScrollViewer>(viewer.Content);
-        var grid = Assert.IsType<Grid>(sv.Content);
+        var grid = Assert.IsType<Grid>(viewer.Content);
         return Assert.IsType<StackPanel>(grid.Children[0]);
     }
 

--- a/tests/MarkView.Avalonia.Tests/MarkdownViewerTemplateTests.cs
+++ b/tests/MarkView.Avalonia.Tests/MarkdownViewerTemplateTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using Avalonia.Headless.XUnit;
+using Avalonia.Markup.Xaml.Styling;
+using Avalonia.VisualTree;
+using Xunit;
+
+namespace MarkView.Avalonia.Tests;
+
+public class MarkdownViewerTemplateTests
+{
+    private static StyleInclude MarkdownThemeInclude() => new((Uri?)null)
+    {
+        Source = new Uri("avares://MarkView.Avalonia/Themes/MarkdownTheme.axaml")
+    };
+
+    [AvaloniaFact]
+    public void ScrollToAnchor_moves_PART_ScrollViewer_offset_with_default_template()
+    {
+        var viewer = new MarkdownViewer();
+        viewer.Styles.Add(MarkdownThemeInclude());
+        viewer.Markdown = string.Join("\n\n", Enumerable.Range(0, 40).Select(i => $"Paragraph {i}"))
+            + "\n\n## Target Heading\n\n"
+            + string.Join("\n\n", Enumerable.Range(0, 40).Select(i => $"Trailing paragraph {i}"));
+
+        var window = new Window { Width = 400, Height = 200, Content = viewer };
+        window.Show();
+
+        var scrollViewer = viewer.GetVisualDescendants().OfType<ScrollViewer>().Single();
+        Assert.Equal(0, scrollViewer.Offset.Y);
+
+        var heading = viewer.GetVisualDescendants().OfType<TextBlock>()
+            .Single(tb => tb.Classes.Contains("markdown-h2"));
+        var expectedPoint = heading.TranslatePoint(new Point(0, 0), (Visual)viewer.Content!);
+        Assert.NotNull(expectedPoint);
+        var expectedY = Math.Max(0, expectedPoint.Value.Y - 16);
+
+        viewer.ScrollToAnchor("target-heading");
+
+        // Exact match against the anchor's own translated position (minus the 16px top
+        // margin ScrollToAnchor applies) — not just "some scroll happened". A generic
+        // Control.BringIntoView() (today's fallback, still reachable through the ancestor
+        // PART_ScrollViewer via the bubbling RequestBringIntoViewEvent) also produces a
+        // nonzero offset here, but not this exact one, so this assertion only passes once
+        // ScrollToAnchor is actually driven by the cached PART_ScrollViewer reference.
+        Assert.Equal(expectedY, scrollViewer.Offset.Y, 3);
+    }
+
+    [AvaloniaFact]
+    public void ScrollToAnchor_does_not_throw_when_template_has_no_PART_ScrollViewer()
+    {
+        var viewer = new MarkdownViewer
+        {
+            Template = new FuncControlTemplate((_, ns) => new TextBlock()),
+            Markdown = "# Target Heading\n\nBody."
+        };
+
+        var window = new Window { Width = 400, Height = 200, Content = viewer };
+        window.Show();
+
+        Assert.Empty(viewer.GetVisualDescendants().OfType<ScrollViewer>());
+
+        var exception = Record.Exception(() => viewer.ScrollToAnchor("target-heading"));
+        Assert.Null(exception);
+    }
+
+    [AvaloniaFact]
+    public void ScrollViewer_attached_properties_pass_through_to_PART_ScrollViewer()
+    {
+        var viewer = new MarkdownViewer { Markdown = "Hello" };
+        viewer.Styles.Add(MarkdownThemeInclude());
+        ScrollViewer.SetVerticalScrollBarVisibility(viewer, ScrollBarVisibility.Hidden);
+
+        var window = new Window { Width = 400, Height = 200, Content = viewer };
+        window.Show();
+
+        var scrollViewer = viewer.GetVisualDescendants().OfType<ScrollViewer>().Single();
+        Assert.Equal(ScrollBarVisibility.Hidden, scrollViewer.VerticalScrollBarVisibility);
+    }
+}

--- a/tests/MarkView.Avalonia.Tests/MarkdownViewerTemplateTests.cs
+++ b/tests/MarkView.Avalonia.Tests/MarkdownViewerTemplateTests.cs
@@ -7,6 +7,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Controls.Templates;
 using Avalonia.Headless.XUnit;
 using Avalonia.Markup.Xaml.Styling;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Xunit;
 
@@ -67,6 +68,58 @@ public class MarkdownViewerTemplateTests
 
         var exception = Record.Exception(() => viewer.ScrollToAnchor("target-heading"));
         Assert.Null(exception);
+    }
+
+    [AvaloniaFact]
+    public void RenderMarkdown_resets_PART_ScrollViewer_offset_to_top_on_new_document()
+    {
+        var viewer = new MarkdownViewer();
+        viewer.Styles.Add(MarkdownThemeInclude());
+        viewer.Markdown = string.Join("\n\n", Enumerable.Range(0, 40).Select(i => $"Paragraph {i}"))
+            + "\n\n## Target Heading\n\n"
+            + string.Join("\n\n", Enumerable.Range(0, 40).Select(i => $"Trailing paragraph {i}"));
+
+        var window = new Window { Width = 400, Height = 200, Content = viewer };
+        window.Show();
+
+        viewer.ScrollToAnchor("target-heading");
+        var scrollViewer = viewer.GetVisualDescendants().OfType<ScrollViewer>().Single();
+        Assert.True(scrollViewer.Offset.Y > 0);
+
+        viewer.Markdown = "# New Document\n\nBrand new content.";
+
+        Assert.Equal(0, scrollViewer.Offset.Y);
+        Assert.Equal(0, scrollViewer.Offset.X);
+    }
+
+    [AvaloniaFact]
+    public void ScrollToAnchor_lands_at_top_margin_when_viewer_has_non_default_padding()
+    {
+        // Regression test: Padding is applied as PART_ContentPresenter's Margin *inside*
+        // PART_ScrollViewer, so Content's origin is offset from the scrollable extent's
+        // origin by Padding.Top. ScrollToAnchor must account for that offset, or it
+        // undershoots by exactly Padding.Top.
+        var viewer = new MarkdownViewer { Padding = new Thickness(0, 100, 0, 0) };
+        viewer.Styles.Add(MarkdownThemeInclude());
+        viewer.Markdown = string.Join("\n\n", Enumerable.Range(0, 40).Select(i => $"Paragraph {i}"))
+            + "\n\n## Target Heading\n\n"
+            + string.Join("\n\n", Enumerable.Range(0, 40).Select(i => $"Trailing paragraph {i}"));
+
+        var window = new Window { Width = 400, Height = 200, Content = viewer };
+        window.Show();
+
+        viewer.ScrollToAnchor("target-heading");
+        Dispatcher.UIThread.RunJobs();
+
+        var scrollViewer = viewer.GetVisualDescendants().OfType<ScrollViewer>().Single();
+        var heading = viewer.GetVisualDescendants().OfType<TextBlock>()
+            .Single(tb => tb.Classes.Contains("markdown-h2"));
+
+        // The heading lands ~16px below the viewport top (the intended top margin),
+        // independent of Padding.
+        var headingInViewport = heading.TranslatePoint(new Point(0, 0), scrollViewer);
+        Assert.NotNull(headingInViewport);
+        Assert.Equal(16, headingInViewport.Value.Y, 3);
     }
 
     [AvaloniaFact]

--- a/tests/MarkView.Avalonia.Tests/MarkdownViewerTests.cs
+++ b/tests/MarkView.Avalonia.Tests/MarkdownViewerTests.cs
@@ -22,8 +22,7 @@ public class MarkdownViewerTests
             Markdown = "# Hello\n\nWorld"
         };
         Assert.NotNull(viewer.Content);
-        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
-        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var contentGrid = Assert.IsType<Grid>(viewer.Content);
         var panel = Assert.IsType<StackPanel>(contentGrid.Children[0]);
         Assert.Equal(2, panel.Children.Count);
     }
@@ -33,8 +32,7 @@ public class MarkdownViewerTests
     {
         var viewer = new MarkdownViewer { Markdown = "First" };
         viewer.Markdown = "# Second";
-        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
-        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var contentGrid = Assert.IsType<Grid>(viewer.Content);
         var panel = Assert.IsType<StackPanel>(contentGrid.Children[0]);
         var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(panel.Children));
         Assert.Contains("markdown-h1", textBlock.Classes);
@@ -56,8 +54,7 @@ public class MarkdownViewerTests
             BaseUri = new Uri("https://example.com/docs/"),
             Markdown = "![img](image.png)"
         };
-        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
-        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var contentGrid = Assert.IsType<Grid>(viewer.Content);
         var panel = Assert.IsType<StackPanel>(contentGrid.Children[0]);
         var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(panel.Children));
         var uiContainer = textBlock.Inlines!.OfType<InlineUIContainer>().Single();
@@ -87,8 +84,7 @@ public class MarkdownViewerTests
             Pipeline = pipeline,
             Markdown = "| A | B |\n|---|---|\n| 1 | 2 |"
         };
-        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
-        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var contentGrid = Assert.IsType<Grid>(viewer.Content);
         var panel = Assert.IsType<StackPanel>(contentGrid.Children[0]);
         Assert.DoesNotContain(panel.Children, c => c is Grid);
     }
@@ -101,8 +97,7 @@ public class MarkdownViewerTests
         string? clickedUrl = null;
         viewer.LinkClicked += (_, e) => clickedUrl = e.Url;
 
-        var scrollViewer = Assert.IsType<ScrollViewer>(viewer.Content);
-        var contentGrid = Assert.IsType<Grid>(scrollViewer.Content);
+        var contentGrid = Assert.IsType<Grid>(viewer.Content);
         var panel = Assert.IsType<StackPanel>(contentGrid.Children[0]);
         var textBlock = Assert.IsType<MarkdownSelectableTextBlock>(Assert.Single(panel.Children));
         var uiContainer = textBlock.Inlines!.OfType<InlineUIContainer>().Single();

--- a/tests/MarkView.Avalonia.Tests/Rendering/MarkdownThemeTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Rendering/MarkdownThemeTests.cs
@@ -40,4 +40,30 @@ public class MarkdownThemeTests
             .FirstOrDefault(s => (string?)s.Attribute("Property") == "MaxWidth");
         Assert.Null(maxWidthSetter);
     }
+
+    [Fact]
+    public void MarkdownViewer_style_defines_a_template_with_named_PART_ScrollViewer()
+    {
+        var themePath = Path.Combine(FindRepoRoot(), "src", "MarkView.Avalonia", "Themes", "MarkdownTheme.axaml");
+        var doc = XDocument.Load(themePath);
+        XNamespace avalonia = "https://github.com/avaloniaui";
+
+        var style = doc.Descendants(avalonia + "Style")
+            .FirstOrDefault(s => (string?)s.Attribute("Selector") == "mv|MarkdownViewer");
+        Assert.NotNull(style);
+
+        var templateSetter = style!.Elements(avalonia + "Setter")
+            .FirstOrDefault(s => (string?)s.Attribute("Property") == "Template");
+        Assert.NotNull(templateSetter);
+
+        var controlTemplate = templateSetter!.Descendants(avalonia + "ControlTemplate").FirstOrDefault();
+        Assert.NotNull(controlTemplate);
+
+        var scrollViewer = controlTemplate!.Descendants(avalonia + "ScrollViewer").FirstOrDefault();
+        Assert.NotNull(scrollViewer);
+        Assert.Equal("PART_ScrollViewer", (string?)scrollViewer!.Attribute("Name"));
+
+        var contentPresenter = controlTemplate.Descendants(avalonia + "ContentPresenter").FirstOrDefault();
+        Assert.NotNull(contentPresenter);
+    }
 }

--- a/tests/MarkView.Avalonia.Tests/Rendering/MarkdownThemeTests.cs
+++ b/tests/MarkView.Avalonia.Tests/Rendering/MarkdownThemeTests.cs
@@ -49,7 +49,7 @@ public class MarkdownThemeTests
         XNamespace avalonia = "https://github.com/avaloniaui";
 
         var style = doc.Descendants(avalonia + "Style")
-            .FirstOrDefault(s => (string?)s.Attribute("Selector") == "mv|MarkdownViewer");
+            .FirstOrDefault(s => (string?)s.Attribute("Selector") == ":is(mv|MarkdownViewer)");
         Assert.NotNull(style);
 
         var templateSetter = style!.Elements(avalonia + "Setter")


### PR DESCRIPTION
## Summary

`MarkdownViewer` built its `ScrollViewer` directly in code, so a consumer could never customize scroll bar behaviour or replace it without bypassing the control entirely. Move it into a real, named `ControlTemplate` part instead:

- Default `ControlTemplate` in `MarkdownTheme.axaml`: `Border → ScrollViewer (PART_ScrollViewer) → ContentPresenter`, modeled on Avalonia's own `ListBox` template. Selector uses `:is(mv|MarkdownViewer)` so subclasses inherit it too.
- `ScrollViewer.*` attached properties (e.g. `ScrollViewer.VerticalScrollBarVisibility`) pass through to `PART_ScrollViewer`, same pattern as `ListBox` — no `Template` override needed for simple scroll-bar tweaks.
- `MarkdownViewer.Content` is now the rendered `Grid` directly (previously a `ScrollViewer` wrapping it). `ScrollToAnchor()` finds `PART_ScrollViewer` via `OnApplyTemplate` and falls back to `BringIntoView()` if a custom `Template` omits the part.
- `ScrollToAnchor()`'s offset math is `Padding`-agnostic (translates into `PART_ScrollViewer`'s own coordinate space instead of `Content`'s).
- Scroll position resets to the top on every new `Markdown`/`Source` render, matching the previous behaviour now that the same `ScrollViewer` instance persists across renders instead of being rebuilt each time.
- `ImageResizeMode.Fill`/`ScaleDownToFit`'s width-clamp still relies on `PART_ScrollViewer`'s `HorizontalScrollBarVisibility="Disabled"` default — documented as a template contract rather than a hard guarantee.

Docs updated: `docs/theming.md` (template part + passthrough), `docs/configuration.md` (image-resize caveat), `CLAUDE.md`/`.github/copilot-instructions.md` (pipeline diagram + test-traversal guidance).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [x] Documentation
- [ ] CI / build

## Test plan

- [x] `dotnet test` — all tests pass
- [x] Manual smoke-test in the demo app