### PR TITLE
feat: add Custom Styling and Color Extension demo pages

### DIFF
--- a/docs/custom-extensions.md
+++ b/docs/custom-extensions.md
@@ -181,3 +181,135 @@ public class AdmonitionBlockRenderer : AvaloniaObjectRenderer<AdmonitionBlock>
     }
 }
 ```
+
+## Full example — a complete inline extension (Markdig parser + node + renderer)
+
+The example above renders an `AdmonitionBlock` but doesn't show how that block gets parsed
+in the first place — writing a `MarkView.Avalonia` renderer is only half of a real
+extension. The other half is a Markdig `IMarkdownExtension` that parses your syntax into a
+syntax tree node.
+
+This example implements `%[color:red]text%` inline colour spans end to end. It ships as a
+runnable, documented demo page in `samples/MarkView.Avalonia.Demo/ColorExtension/` — open
+that folder (and `Assets/color-extension.md`, which the page renders) for the full
+tutorial; this section covers the shape of the five pieces involved.
+
+### 1. The syntax tree node
+
+A leaf node holding whatever your parser extracts — here, a colour name and literal text
+content:
+
+```csharp
+public sealed class ColorSpanInline : LeafInline
+{
+    public string Color { get; }
+    public string Content { get; }
+
+    public ColorSpanInline(string color, string content)
+    {
+        Color = color;
+        Content = content;
+    }
+}
+```
+
+### 2. The Markdig parser
+
+Extend `Markdig.Parsers.InlineParser`, set `OpeningCharacters` to the character(s) that
+trigger it, and implement `Match`. Returning `false` leaves the input `slice` untouched and
+lets Markdig fall through to the next parser (plain text) — every built-in inline parser
+follows this same graceful-degradation contract, so a malformed `%[color:...]` just renders
+as literal text instead of breaking the document:
+
+```csharp
+public sealed class ColorSpanParser : InlineParser
+{
+    public ColorSpanParser() => OpeningCharacters = ['%'];
+
+    public override bool Match(InlineProcessor processor, ref StringSlice slice)
+    {
+        // ... match "[color:NAME]", scan ahead for the closing '%' ...
+        // On success:
+        processor.Inline = new ColorSpanInline(color, content)
+        {
+            Span = new SourceSpan(
+                processor.GetSourcePosition(startPosition, out var line, out var column),
+                processor.GetSourcePosition(slice.Start - 1)),
+            Line = line,
+            Column = column,
+        };
+        return true;
+    }
+}
+```
+
+Setting `Span`/`Line`/`Column` via `InlineProcessor.GetSourcePosition` matters beyond
+bookkeeping — `MarkView.Avalonia`'s cross-block text selection (see
+[docs/text-selection.md](text-selection.md)) relies on accurate source spans to map screen
+selections back to document positions.
+
+### 3. Registering the parser — a Markdig `IMarkdownExtension`
+
+This half is pure Markdig and knows nothing about Avalonia:
+
+```csharp
+public sealed class ColorMarkdownExtension : IMarkdownExtension
+{
+    public void Setup(MarkdownPipelineBuilder pipeline) =>
+        pipeline.InlineParsers.AddIfNotAlready<ColorSpanParser>();
+
+    public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer) { }
+}
+
+public static class ColorMarkdownExtensions
+{
+    public static MarkdownPipelineBuilder UseColorSpans(this MarkdownPipelineBuilder builder) =>
+        builder.Use<ColorMarkdownExtension>();
+}
+```
+
+### 4. The renderer + its `IMarkViewExtension`
+
+The `MarkView.Avalonia` half turns the parsed node into a control, following the same
+`AvaloniaObjectRenderer<T>` / `IMarkViewExtension` shape as every example earlier in this
+document:
+
+```csharp
+public sealed class ColorSpanRenderer : AvaloniaObjectRenderer<ColorSpanInline>
+{
+    protected override void Write(AvaloniaRenderer renderer, ColorSpanInline obj)
+    {
+        var run = new Run(obj.Content);
+        if (Color.TryParse(obj.Color, out var color))
+            run.Foreground = new SolidColorBrush(color);
+        renderer.WriteInline(run);
+    }
+}
+
+public sealed class ColorSpanExtension : IMarkViewExtension
+{
+    public void Register(AvaloniaRenderer renderer) =>
+        renderer.ObjectRenderers.Add(new ColorSpanRenderer());
+}
+```
+
+An unparseable colour name is treated the same way as a parse failure anywhere else in this
+document's examples: fall back to a sane default (here, the inherited foreground) rather
+than throwing.
+
+### 5. Wiring both halves together
+
+```csharp
+viewer.Pipeline = new MarkdownPipelineBuilder()
+    .UseSupportedExtensions()
+    .UseColorSpans()
+    .Build();
+viewer.Extensions.Add(new ColorSpanExtension());
+```
+
+Note the asymmetry if you set `Pipeline` on a `MarkdownViewer` instance instead of (or in
+addition to) `MarkdownViewerDefaults.Pipeline`: an instance `Pipeline` fully **replaces**
+the global default — none of `MarkdownViewerDefaults.Pipeline`'s extensions apply unless
+you add them again yourself. `Extensions`, by contrast, is **additive** — an instance's
+`Extensions` list is combined with `MarkdownViewerDefaults.Extensions`, not a replacement
+for it. See [docs/configuration.md](configuration.md) for the full precedence rules.

--- a/samples/MarkView.Avalonia.Demo/App.axaml
+++ b/samples/MarkView.Avalonia.Demo/App.axaml
@@ -1,11 +1,30 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mv="using:MarkView.Avalonia"
              x:Class="MarkView.Avalonia.Demo.App"
              RequestedThemeVariant="Dark">
   <Application.Styles>
     <FluentTheme />
     <StyleInclude Source="avares://MarkView.Avalonia/Themes/MarkdownTheme.axaml" />
     <StyleInclude Source="avares://MarkView.Avalonia.Mermaid/Themes/MermaidTheme.axaml" />
+
+    <!-- "Custom Styling" demo page: scoped override of a few markdown-* classes, proving they
+         can be restyled per-instance without touching the app's global theme. -->
+    <Style Selector="mv|MarkdownViewer.custom-styled TextBlock.markdown-h1">
+      <Setter Property="Foreground" Value="#a855f7" />
+      <Setter Property="FontFamily" Value="Georgia,Times New Roman,serif" />
+    </Style>
+    <Style Selector="mv|MarkdownViewer.custom-styled TextBlock.markdown-h2">
+      <Setter Property="Foreground" Value="#a855f7" />
+      <Setter Property="FontFamily" Value="Georgia,Times New Roman,serif" />
+    </Style>
+    <Style Selector="mv|MarkdownViewer.custom-styled Border.markdown-blockquote">
+      <Setter Property="BorderBrush" Value="#f59e0b" />
+      <Setter Property="Background" Value="#1af59e0b" />
+    </Style>
+    <Style Selector="mv|MarkdownViewer.custom-styled Border.markdown-code-block">
+      <Setter Property="Background" Value="#2d1b4d" />
+    </Style>
   </Application.Styles>
   <Application.Resources>
     <StreamGeometry x:Key="text_bullet_list_tree_regular">

--- a/samples/MarkView.Avalonia.Demo/Assets/color-extension.md
+++ b/samples/MarkView.Avalonia.Demo/Assets/color-extension.md
@@ -1,0 +1,124 @@
+# Writing a Custom Extension: Colour Spans
+
+Markdown has no syntax for colouring text. This page implements one — `%[color:red]text%` —
+as a worked example of the two extension points a real Markdig + MarkView extension needs:
+a **Markdig** parser (turns text into a syntax tree node) and a **MarkView** renderer
+(turns that node into an Avalonia control).
+
+---
+
+## Live result
+
+%[color:red]This text is red%, %[color:#22c55e]this one is a hex green%,
+and %[color:not-a-real-color]this one falls back to the default foreground%
+because the colour name doesn't parse.
+
+---
+
+## 1. The syntax tree node — `ColorSpanInline`
+
+A `LeafInline` (like Markdig's own `CodeInline`) holding the parsed colour name and literal
+text content. It deliberately does not support nested markdown inside the span, the same way
+code spans don't:
+
+```csharp
+public sealed class ColorSpanInline : LeafInline
+{
+    public string Color { get; }
+    public string Content { get; }
+
+    public ColorSpanInline(string color, string content)
+    {
+        Color = color;
+        Content = content;
+    }
+}
+```
+
+## 2. The parser — `ColorSpanParser`
+
+An `InlineParser` triggered on `%`. It matches `[color:NAME]`, then scans forward for the
+closing `%`, bailing out (returning `false`, leaving the text untouched) if the span crosses
+a line break or never closes — exactly how Markdig's built-in parsers degrade gracefully.
+
+```csharp
+public sealed class ColorSpanParser : InlineParser
+{
+    public ColorSpanParser() => OpeningCharacters = ['%'];
+
+    public override bool Match(InlineProcessor processor, ref StringSlice slice)
+    {
+        // ... match "[color:NAME]", scan to the closing '%' ...
+        processor.Inline = new ColorSpanInline(color, content) { /* Span, Line, Column */ };
+        return true;
+    }
+}
+```
+
+## 3. Registering the parser — `ColorMarkdownExtension`
+
+Markdig extensions implement `IMarkdownExtension` and register into the pipeline being built.
+This is the Markdig-only half — it knows nothing about Avalonia:
+
+```csharp
+public sealed class ColorMarkdownExtension : IMarkdownExtension
+{
+    public void Setup(MarkdownPipelineBuilder pipeline) =>
+        pipeline.InlineParsers.AddIfNotAlready<ColorSpanParser>();
+
+    public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer) { }
+}
+
+public static class ColorMarkdownExtensions
+{
+    public static MarkdownPipelineBuilder UseColorSpans(this MarkdownPipelineBuilder builder) =>
+        builder.Use<ColorMarkdownExtension>();
+}
+```
+
+## 4. Rendering the node — `ColorSpanRenderer`
+
+The MarkView-side renderer turns a `ColorSpanInline` into a `Run` with its `Foreground` set:
+
+```csharp
+public sealed class ColorSpanRenderer : AvaloniaObjectRenderer<ColorSpanInline>
+{
+    protected override void Write(AvaloniaRenderer renderer, ColorSpanInline obj)
+    {
+        var run = new Run(obj.Content);
+        if (Color.TryParse(obj.Color, out var color))
+            run.Foreground = new SolidColorBrush(color);
+        renderer.WriteInline(run);
+    }
+}
+```
+
+## 5. Registering the renderer — `ColorSpanExtension`
+
+```csharp
+public sealed class ColorSpanExtension : IMarkViewExtension
+{
+    public void Register(AvaloniaRenderer renderer) =>
+        renderer.ObjectRenderers.Add(new ColorSpanRenderer());
+}
+```
+
+## Wiring it up on this page
+
+This view's `MarkdownViewer` sets `Pipeline` and `Extensions` directly, bypassing
+`MarkdownViewerDefaults` for parsing entirely:
+
+```csharp
+Viewer.Pipeline = new MarkdownPipelineBuilder()
+    .UseSupportedExtensions()
+    .UseColorSpans()
+    .Build();
+Viewer.Extensions.Add(new ColorSpanExtension());
+```
+
+`Pipeline` fully replaces the global default when set on an instance — this page's other
+views (footnotes, alert blocks, …) are intentionally unavailable here. `Extensions`
+(the rendering side) is additive instead: this page still benefits from the app's global
+syntax-highlighting extension for the code fences above, on top of `ColorSpanExtension`.
+
+See [docs/custom-extensions.md](../../../docs/custom-extensions.md) for the full write-up.

--- a/samples/MarkView.Avalonia.Demo/ColorExtension/ColorExtensionView.axaml
+++ b/samples/MarkView.Avalonia.Demo/ColorExtension/ColorExtensionView.axaml
@@ -1,0 +1,6 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mv="using:MarkView.Avalonia"
+             x:Class="MarkView.Avalonia.Demo.ColorExtension.ColorExtensionView">
+  <mv:MarkdownViewer x:Name="Viewer" Padding="4" />
+</UserControl>

--- a/samples/MarkView.Avalonia.Demo/ColorExtension/ColorExtensionView.axaml.cs
+++ b/samples/MarkView.Avalonia.Demo/ColorExtension/ColorExtensionView.axaml.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Controls;
+
+using Markdig;
+
+namespace MarkView.Avalonia.Demo.ColorExtension;
+
+/// <summary>
+/// Hosts a <see cref="MarkdownViewer"/> configured with its own <see cref="MarkdownViewer.Pipeline"/>
+/// and <see cref="MarkdownViewer.Extensions"/> instead of <see cref="MarkdownViewerDefaults"/> — the
+/// markdown content below walks through how <c>%[color:NAME]text%</c> spans are parsed and rendered.
+/// </summary>
+public partial class ColorExtensionView : UserControl
+{
+    private static readonly Uri TutorialSource =
+        new("avares://MarkView.Avalonia.Demo/Assets/color-extension.md");
+
+    public ColorExtensionView()
+    {
+        InitializeComponent();
+
+        Viewer.Pipeline = new MarkdownPipelineBuilder()
+            .UseSupportedExtensions()
+            .UseColorSpans()
+            .Build();
+        Viewer.Extensions.Add(new ColorSpanExtension());
+        Viewer.Source = TutorialSource;
+    }
+}

--- a/samples/MarkView.Avalonia.Demo/ColorExtension/ColorMarkdownExtension.cs
+++ b/samples/MarkView.Avalonia.Demo/ColorExtension/ColorMarkdownExtension.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Markdig;
+using Markdig.Renderers;
+
+namespace MarkView.Avalonia.Demo.ColorExtension;
+
+/// <summary>
+/// Markdig-side half of the colour span extension: registers <see cref="ColorSpanParser"/>
+/// so <c>%[color:NAME]text%</c> parses into a <see cref="ColorSpanInline"/>.
+/// Rendering that node is a separate concern, handled by <see cref="ColorSpanExtension"/>.
+/// </summary>
+public sealed class ColorMarkdownExtension : IMarkdownExtension
+{
+    public void Setup(MarkdownPipelineBuilder pipeline)
+    {
+        pipeline.InlineParsers.AddIfNotAlready<ColorSpanParser>();
+    }
+
+    public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
+    {
+    }
+}
+
+public static class ColorMarkdownExtensions
+{
+    /// <summary>
+    /// Enables <c>%[color:NAME]text%</c> colour span parsing.
+    /// Pair with <c>renderer.Extensions.Add(new ColorSpanExtension())</c> to render the result.
+    /// </summary>
+    public static MarkdownPipelineBuilder UseColorSpans(this MarkdownPipelineBuilder builder)
+    {
+        return builder.Use<ColorMarkdownExtension>();
+    }
+}

--- a/samples/MarkView.Avalonia.Demo/ColorExtension/ColorSpanExtension.cs
+++ b/samples/MarkView.Avalonia.Demo/ColorExtension/ColorSpanExtension.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using MarkView.Avalonia.Extensions;
+using MarkView.Avalonia.Rendering;
+
+namespace MarkView.Avalonia.Demo.ColorExtension;
+
+/// <summary>
+/// MarkView-side half of the colour span extension: registers <see cref="ColorSpanRenderer"/>
+/// so a <see cref="ColorSpanInline"/> node (produced by <see cref="ColorMarkdownExtension"/>) renders.
+/// </summary>
+public sealed class ColorSpanExtension : IMarkViewExtension
+{
+    public void Register(AvaloniaRenderer renderer)
+    {
+        renderer.ObjectRenderers.Add(new ColorSpanRenderer());
+    }
+}

--- a/samples/MarkView.Avalonia.Demo/ColorExtension/ColorSpanInline.cs
+++ b/samples/MarkView.Avalonia.Demo/ColorExtension/ColorSpanInline.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Markdig.Syntax.Inlines;
+
+namespace MarkView.Avalonia.Demo.ColorExtension;
+
+/// <summary>
+/// A leaf inline produced by <see cref="ColorSpanParser"/> for <c>%[color:NAME]text%</c> spans.
+/// Content is literal — like <see cref="CodeInline"/>, it does not support nested markdown.
+/// </summary>
+public sealed class ColorSpanInline : LeafInline
+{
+    public string Color { get; }
+
+    public string Content { get; }
+
+    public ColorSpanInline(string color, string content)
+    {
+        Color = color;
+        Content = content;
+    }
+}

--- a/samples/MarkView.Avalonia.Demo/ColorExtension/ColorSpanParser.cs
+++ b/samples/MarkView.Avalonia.Demo/ColorExtension/ColorSpanParser.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Markdig.Helpers;
+using Markdig.Parsers;
+using Markdig.Syntax;
+
+namespace MarkView.Avalonia.Demo.ColorExtension;
+
+/// <summary>
+/// Parses <c>%[color:NAME]text%</c> spans into a <see cref="ColorSpanInline"/>.
+/// <c>NAME</c> is anything Avalonia's <c>Color.TryParse</c> accepts (named colour or hex);
+/// the content between the closing <c>]</c> and the next <c>%</c> is taken literally and must
+/// not span multiple lines — either constraint failing leaves the input as plain text.
+/// </summary>
+public sealed class ColorSpanParser : InlineParser
+{
+    private const string Prefix = "[color:";
+
+    public ColorSpanParser()
+    {
+        OpeningCharacters = ['%'];
+    }
+
+    public override bool Match(InlineProcessor processor, ref StringSlice slice)
+    {
+        var span = slice.AsSpan();
+        if (span.Length < Prefix.Length + 1 || !span.Slice(1).StartsWith(Prefix))
+            return false;
+
+        var nameStart = 1 + Prefix.Length;
+        var closeBracket = span.Slice(nameStart).IndexOf(']');
+        if (closeBracket < 0)
+            return false;
+        closeBracket += nameStart;
+
+        var color = span.Slice(nameStart, closeBracket - nameStart).ToString();
+        if (color.Length == 0)
+            return false;
+
+        var contentStart = closeBracket + 1;
+        var rest = span.Slice(contentStart);
+        var closingPercent = rest.IndexOfAny('%', '\r', '\n');
+        if (closingPercent < 0 || rest[closingPercent] != '%')
+            return false;
+
+        var content = rest.Slice(0, closingPercent).ToString();
+
+        var startPosition = slice.Start;
+        var consumedLength = contentStart + closingPercent + 1;
+        slice.Start = startPosition + consumedLength;
+
+        var colorSpan = new ColorSpanInline(color, content)
+        {
+            Span = new SourceSpan(
+                processor.GetSourcePosition(startPosition, out var line, out var column),
+                processor.GetSourcePosition(slice.Start - 1)),
+            Line = line,
+            Column = column,
+        };
+
+        processor.Inline = colorSpan;
+        return true;
+    }
+}

--- a/samples/MarkView.Avalonia.Demo/ColorExtension/ColorSpanRenderer.cs
+++ b/samples/MarkView.Avalonia.Demo/ColorExtension/ColorSpanRenderer.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Nicolas Musset
+// Distributed under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Avalonia.Controls.Documents;
+using Avalonia.Media;
+
+using MarkView.Avalonia.Rendering;
+
+namespace MarkView.Avalonia.Demo.ColorExtension;
+
+/// <summary>
+/// Renders a <see cref="ColorSpanInline"/> as a <see cref="Run"/> with <see cref="Run.Foreground"/>
+/// set from <see cref="ColorSpanInline.Color"/>. An unparseable colour name falls back to the
+/// inherited foreground instead of throwing.
+/// </summary>
+public sealed class ColorSpanRenderer : AvaloniaObjectRenderer<ColorSpanInline>
+{
+    protected override void Write(AvaloniaRenderer renderer, ColorSpanInline obj)
+    {
+        var run = new Run(obj.Content);
+        if (Color.TryParse(obj.Color, out var color))
+            run.Foreground = new SolidColorBrush(color);
+
+        renderer.WriteInline(run);
+    }
+}

--- a/samples/MarkView.Avalonia.Demo/MainViewModel.cs
+++ b/samples/MarkView.Avalonia.Demo/MainViewModel.cs
@@ -115,7 +115,29 @@ public sealed class MainViewModel : INotifyPropertyChanged
         ![Big Buck Bunny trailer](https://youtu.be/aqz-KE-bpKQ)
         """;
 
-    private readonly List<(Uri? Source, string? Markdown)> _history = [];
+    private const string CustomStylingMarkdown = """
+        # Custom Styling
+
+        This page is rendered by the same `MarkdownViewer` as the other views. The window applies a
+        style block scoped to `MarkdownViewer.custom-styled` (see `App.axaml`) that overrides a few
+        of the library's `markdown-*` classes for this page only, without touching the global theme.
+
+        ## Heading Two
+
+        Every `markdown-h1` / `markdown-h2` element still carries its usual class; only the setter
+        values differ here.
+
+        > Blockquotes (`markdown-blockquote`) pick up a different accent colour and background on
+        > this page.
+
+        ```text
+        Code blocks (markdown-code-block) get a different background here too.
+        ```
+
+        Switch back to **Feature Showcase** to compare against the default look for the same elements.
+        """;
+
+    private readonly List<(int SelectedIndex, Uri? Source, string? Markdown)> _history = [];
     private int _historyIndex = -1;
     private bool _navigating;
 
@@ -123,8 +145,8 @@ public sealed class MainViewModel : INotifyPropertyChanged
     private string? _markdown;
     private int _selectedIndex;
     private bool _isLightTheme;
-
-    public string[] Views { get; } = ["Feature Showcase", "Extensions Showcase", "README"];
+    private bool _isCustomStyled;
+    private bool _isColorExtensionSelected;
 
     public int SelectedIndex
     {
@@ -144,6 +166,18 @@ public sealed class MainViewModel : INotifyPropertyChanged
             if (!SetField(ref _isLightTheme, value)) return;
             Application.Current!.RequestedThemeVariant = value ? ThemeVariant.Light : ThemeVariant.Dark;
         }
+    }
+
+    public bool IsCustomStyled
+    {
+        get => _isCustomStyled;
+        private set => SetField(ref _isCustomStyled, value);
+    }
+
+    public bool IsColorExtensionSelected
+    {
+        get => _isColorExtensionSelected;
+        private set => SetField(ref _isColorExtensionSelected, value);
     }
 
     public Uri? Source
@@ -175,12 +209,16 @@ public sealed class MainViewModel : INotifyPropertyChanged
         RestoreEntry(_history[_historyIndex]);
     }
 
-    private void RestoreEntry((Uri? Source, string? Markdown) entry)
+    private void RestoreEntry((int SelectedIndex, Uri? Source, string? Markdown) entry)
     {
         _navigating = true;
+        _selectedIndex = entry.SelectedIndex;
         Source = entry.Source;
         Markdown = entry.Markdown;
+        IsCustomStyled = entry.SelectedIndex == 2;
+        IsColorExtensionSelected = entry.SelectedIndex == 3;
         _navigating = false;
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(SelectedIndex)));
         NotifyNavigation();
     }
 
@@ -190,7 +228,7 @@ public sealed class MainViewModel : INotifyPropertyChanged
         // Discard any forward entries
         if (_historyIndex < _history.Count - 1)
             _history.RemoveRange(_historyIndex + 1, _history.Count - _historyIndex - 1);
-        _history.Add((source, markdown));
+        _history.Add((_selectedIndex, source, markdown));
         _historyIndex = _history.Count - 1;
         NotifyNavigation();
     }
@@ -208,6 +246,9 @@ public sealed class MainViewModel : INotifyPropertyChanged
 
     private void LoadContent()
     {
+        IsCustomStyled = _selectedIndex == 2;
+        IsColorExtensionSelected = _selectedIndex == 3;
+
         switch (_selectedIndex)
         {
             case 0:
@@ -217,6 +258,15 @@ public sealed class MainViewModel : INotifyPropertyChanged
             case 1:
                 Source = null;
                 Markdown = ExtensionsShowcaseMarkdown;
+                break;
+            case 2:
+                Source = null;
+                Markdown = CustomStylingMarkdown;
+                break;
+            case 3:
+                // Content is supplied by the dedicated ColorExtensionView control, not this Markdown/Source pair.
+                Source = null;
+                Markdown = null;
                 break;
             default:
                 Source = ReadmeSource;

--- a/samples/MarkView.Avalonia.Demo/MainWindow.axaml
+++ b/samples/MarkView.Avalonia.Demo/MainWindow.axaml
@@ -2,6 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:mv="using:MarkView.Avalonia"
         xmlns:local="using:MarkView.Avalonia.Demo"
+        xmlns:ce="using:MarkView.Avalonia.Demo.ColorExtension"
         x:Class="MarkView.Avalonia.Demo.MainWindow"
         x:DataType="local:MainViewModel"
         Title="MarkView.Avalonia Demo"
@@ -12,6 +13,15 @@
   </Window.Resources>
 
   <DockPanel>
+    <!-- Page tabs -->
+    <TabControl DockPanel.Dock="Top" SelectedIndex="{Binding SelectedIndex}">
+      <TabItem Header="Feature Showcase" />
+      <TabItem Header="Extensions Showcase" />
+      <TabItem Header="Custom Styling" />
+      <TabItem Header="Color Extension" />
+      <TabItem Header="README" />
+    </TabControl>
+
     <!-- Top bar -->
     <Border DockPanel.Dock="Top" Padding="12,8">
       <StackPanel Orientation="Horizontal" Spacing="8">
@@ -52,10 +62,6 @@
             </DockPanel>
           </Border>
         </Popup>
-        <TextBlock Text="View:" VerticalAlignment="Center" />
-        <ComboBox ItemsSource="{Binding Views}"
-                  SelectedIndex="{Binding SelectedIndex}"
-                  MinWidth="120" />
         <Button Content="←"
                 Click="OnGoBackClicked"
                 IsEnabled="{Binding CanGoBack}"
@@ -75,10 +81,15 @@
       </StackPanel>
     </Border>
 
-    <!-- Markdown content -->
-    <mv:MarkdownViewer x:Name="MarkdownView"
-                       Source="{Binding Source}" Markdown="{Binding Markdown}"
-                       Padding="4" />
+    <!-- Page content -->
+    <Grid>
+      <mv:MarkdownViewer x:Name="MarkdownView"
+                         Source="{Binding Source}" Markdown="{Binding Markdown}"
+                         Classes.custom-styled="{Binding IsCustomStyled}"
+                         IsVisible="{Binding !IsColorExtensionSelected}"
+                         Padding="4" />
+      <ce:ColorExtensionView IsVisible="{Binding IsColorExtensionSelected}" />
+    </Grid>
   </DockPanel>
 
 </Window>

--- a/samples/MarkView.Avalonia.Demo/README.md
+++ b/samples/MarkView.Avalonia.Demo/README.md
@@ -11,7 +11,7 @@ dotnet run
 
 ## What the Demo Shows
 
-The demo window contains a top toolbar and a full-screen `MarkdownViewer`. Use the **View** dropdown to switch between three built-in documents; use **Open file…** to load any local `.md` file.
+The demo window contains a page tab strip, a toolbar, and a full-screen content area. Use the **tabs** to switch between five built-in pages; use **Open file…** to load any local `.md` file.
 
 ### Built-in Views
 
@@ -19,6 +19,8 @@ The demo window contains a top toolbar and a full-screen `MarkdownViewer`. Use t
 |------|---------|
 | **Feature Showcase** | Core markdown: headings, text formatting (strikethrough, subscript, superscript, underline, highlight), blockquotes, task lists, tables, code blocks (multi-language), bitmap image, SVG image, Mermaid diagram |
 | **Extensions Showcase** | Opt-in extensions: footnotes, GitHub alert blocks, abbreviations with tooltips, figures with captions, YouTube thumbnail embeds |
+| **Custom Styling** | Same shared `MarkdownViewer` as the pages above, with a `custom-styled` class toggled on it; `App.axaml` scopes a handful of `markdown-*` class overrides to that class, showing that theming can be done per-instance, not only globally |
+| **Color Extension** | A dedicated `ColorExtensionView` control hosting its own `MarkdownViewer`, configured with its own `Pipeline`/`Extensions` instead of `MarkdownViewerDefaults`. Demonstrates writing a complete custom Markdig + MarkView extension (`%[color:red]text%` colour spans) — see `ColorExtension/` and [docs/custom-extensions.md](../../docs/custom-extensions.md) |
 | **README** | The project's own `README.md` loaded from disk (relative to the solution root) |
 
 ### Navigation and History
@@ -33,7 +35,7 @@ The **Light theme** toggle button switches the entire application between Avalon
 
 ## How the Demo Is Configured
 
-All configuration is done once in `App.axaml.cs` and applies globally to every `MarkdownViewer` instance:
+Most configuration is done once in `App.axaml.cs` and applies globally to every `MarkdownViewer` instance. The **Color Extension** page is the exception: its dedicated control sets `Pipeline` and `Extensions` on its own `MarkdownViewer` instance instead, bypassing these app-wide defaults for parsing (see [docs/configuration.md](../../docs/configuration.md#markdig-pipeline) for the precedence rules, and [docs/custom-extensions.md](../../docs/custom-extensions.md) for the extension itself).
 
 ```csharp
 // Global pipeline — includes all opt-in extensions for the full showcase
@@ -63,11 +65,22 @@ The `OnLinkClicked` handler intercepts absolute `file://` links to `.md` / `.mar
 
 ```
 MarkView.Avalonia.Demo/
-├── App.axaml            — Application XAML (styles, resources)
-├── App.axaml.cs         — Startup: global pipeline, extensions, link handler
-├── MainWindow.axaml     — Single-window layout (toolbar + MarkdownViewer)
-├── MainWindow.axaml.cs  — Back/forward buttons, file picker
-├── MainViewModel.cs     — MVVM view model: history stack, built-in content, LoadFile()
+├── App.axaml               — Application XAML (styles, resources, Custom Styling overrides)
+├── App.axaml.cs            — Startup: global pipeline, extensions, link handler
+├── MainWindow.axaml        — Window layout: page tabs, toolbar, MarkdownViewer/ColorExtensionView
+├── MainWindow.axaml.cs     — Back/forward buttons, file picker, outline popup
+├── MainViewModel.cs        — MVVM view model: history stack, built-in content, LoadFile()
+├── Converters/
+│   └── OutlineFilterConverter.cs — Flattens TableOfContents for the outline popup
+├── ColorExtension/
+│   ├── ColorSpanInline.cs        — Markdig leaf inline node
+│   ├── ColorSpanParser.cs        — Markdig inline parser
+│   ├── ColorMarkdownExtension.cs — Markdig IMarkdownExtension + UseColorSpans()
+│   ├── ColorSpanRenderer.cs      — MarkView.Avalonia renderer
+│   ├── ColorSpanExtension.cs     — MarkView.Avalonia IMarkViewExtension
+│   └── ColorExtensionView.axaml(.cs) — Dedicated control with its own Pipeline/Extensions
 └── Assets/
-    └── avalonia-logo.png
+    ├── avalonia-logo.png
+    ├── showcase.md
+    └── color-extension.md        — Tutorial content for the Color Extension page
 ```


### PR DESCRIPTION
## Summary

Adds an example of a custom Markdig + MarkView inline extension (`%[color:red]text%` colour spans) with its own dedicated MarkdownViewer pipeline, and a Custom Styling page showing per-instance `markdown-*` class overrides.

Replaces the demo's page `ComboBox` with a `TabControl` and fixes history restore to track the selected tab.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [x] Documentation
- [ ] CI / build

## Test plan

- [x] `dotnet test` — all tests pass
- [x] Manual smoke-test in the demo app