### PR TITLE
feat: test coverage mutation using Stryker

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-stryker": {
+      "version": "4.16.0",
+      "commands": [
+        "dotnet-stryker"
+      ]
+    }
+  }
+}

--- a/.github/scripts/Merge-MutationReports.ps1
+++ b/.github/scripts/Merge-MutationReports.ps1
@@ -1,0 +1,131 @@
+<#
+.SYNOPSIS
+Aggregates per-project Stryker `mutation-report.md` files into a single combined
+markdown report, mirroring the structure ReportGenerator produces for coverage
+(overall summary block, then one collapsible per-project section).
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ReportsRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$reportFiles = Get-ChildItem -Path $ReportsRoot -Filter 'mutation-report.md' -Recurse -File
+if (-not $reportFiles) {
+    Write-Error "No mutation-report.md files found under: $ReportsRoot"
+    exit 1
+}
+
+$rootFullPath = (Resolve-Path -Path $ReportsRoot).Path
+
+$totals = [ordered]@{
+    Killed          = 0
+    Survived        = 0
+    Timeout         = 0
+    NoCoverage      = 0
+    Ignored         = 0
+    CompileErrors   = 0
+    RuntimeErrors   = 0
+    TotalDetected   = 0
+    TotalUndetected = 0
+    TotalMutants    = 0
+}
+
+$projects = @()
+
+foreach ($file in $reportFiles) {
+    $relativePath = $file.FullName.Substring($rootFullPath.Length).TrimStart('\', '/')
+    $artifactFolder = ($relativePath -split '[\\/]')[0]
+    $projectName = $artifactFolder -replace '^mutation-report-', '' -replace '\.Tests$', ''
+
+    $lines = Get-Content -Path $file.FullName
+
+    $headerIndex = [array]::FindIndex($lines, [Predicate[string]] { param($line) $line.TrimStart().StartsWith('| File') })
+    if ($headerIndex -lt 0) {
+        Write-Error "Could not find file table header in: $($file.FullName)"
+        exit 1
+    }
+
+    $tableLines = @()
+    $i = $headerIndex
+    while ($i -lt $lines.Count -and $lines[$i].TrimStart().StartsWith('|')) {
+        $tableLines += $lines[$i]
+        $i++
+    }
+
+    foreach ($row in $tableLines[2..($tableLines.Count - 1)]) {
+        $cells = ($row.Trim() -replace '^\|', '' -replace '\|$', '') -split '\|' | ForEach-Object { $_.Trim() }
+        $totals.Killed += [int]$cells[2]
+        $totals.Survived += [int]$cells[3]
+        $totals.Timeout += [int]$cells[4]
+        $totals.NoCoverage += [int]$cells[5]
+        $totals.Ignored += [int]$cells[6]
+        $totals.CompileErrors += [int]$cells[7]
+        $totals.RuntimeErrors += [int]$cells[8]
+        $totals.TotalDetected += [int]$cells[9]
+        $totals.TotalUndetected += [int]$cells[10]
+        $totals.TotalMutants += [int]$cells[11]
+    }
+
+    $finalScoreMatch = $lines | Select-String -Pattern 'The final mutation score is ([\d.]+)%'
+    $finalScore = if ($finalScoreMatch) { $finalScoreMatch.Matches[0].Groups[1].Value } else { 'N/A' }
+
+    $projects += [PSCustomObject]@{
+        Name       = $projectName
+        FinalScore = $finalScore
+        Table      = ($tableLines -join "`n")
+    }
+}
+
+$projects = $projects | Sort-Object Name
+
+$overallDetectedPlusUndetected = $totals.TotalDetected + $totals.TotalUndetected
+$overallScoreText = if ($overallDetectedPlusUndetected -eq 0) {
+    'N/A'
+} else {
+    '{0:N2}%' -f (100.0 * $totals.TotalDetected / $overallDetectedPlusUndetected)
+}
+
+$sb = [System.Text.StringBuilder]::new()
+[void]$sb.AppendLine('# Mutation Testing Summary')
+[void]$sb.AppendLine('<details open><summary>Summary</summary>')
+[void]$sb.AppendLine()
+[void]$sb.AppendLine('|||')
+[void]$sb.AppendLine('|:---|:---|')
+[void]$sb.AppendLine("| Generated on: | $(Get-Date -Format 'MM/dd/yyyy - HH:mm:ss') |")
+[void]$sb.AppendLine("| Projects: | $($projects.Count) |")
+[void]$sb.AppendLine("| **Mutation score:** | $overallScoreText ($($totals.TotalDetected) of $overallDetectedPlusUndetected) |")
+[void]$sb.AppendLine("| Killed: | $($totals.Killed) |")
+[void]$sb.AppendLine("| Survived: | $($totals.Survived) |")
+[void]$sb.AppendLine("| Timeout: | $($totals.Timeout) |")
+[void]$sb.AppendLine("| No Coverage: | $($totals.NoCoverage) |")
+[void]$sb.AppendLine("| Ignored: | $($totals.Ignored) |")
+[void]$sb.AppendLine("| Compile Errors: | $($totals.CompileErrors) |")
+[void]$sb.AppendLine("| Runtime Errors: | $($totals.RuntimeErrors) |")
+[void]$sb.AppendLine("| Total Detected: | $($totals.TotalDetected) |")
+[void]$sb.AppendLine("| Total Undetected: | $($totals.TotalUndetected) |")
+[void]$sb.AppendLine("| Total Mutants: | $($totals.TotalMutants) |")
+[void]$sb.AppendLine()
+[void]$sb.AppendLine('</details>')
+[void]$sb.AppendLine()
+[void]$sb.AppendLine('## Mutation score')
+
+foreach ($project in $projects) {
+    [void]$sb.AppendLine("<details><summary>$($project.Name) - $($project.FinalScore)%</summary>")
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine($project.Table)
+    [void]$sb.AppendLine()
+    [void]$sb.AppendLine('</details>')
+}
+
+$outputDir = Split-Path -Path $OutputPath -Parent
+if ($outputDir -and -not (Test-Path $outputDir)) {
+    New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+}
+
+Set-Content -Path $OutputPath -Value $sb.ToString() -NoNewline
+Write-Output "Combined mutation report written to: $OutputPath"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,15 @@ jobs:
 
   coverage:
     permissions:
+      contents: read
       pull-requests: write
     uses: ./.github/workflows/coverage.yml
+
+  mutation:
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ./.github/workflows/mutation.yml
 
   aot-publish:
     strategy:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -78,5 +78,6 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v3
         if: always() && github.event_name == 'pull_request'
         with:
+          header: coverage
           recreate: true
           path: coveragereport/SummaryGithub.md

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,6 +4,10 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -37,3 +37,39 @@ jobs:
         with:
           name: mutation-report-${{ matrix.test-project }}
           path: tests/${{ matrix.test-project }}/StrykerOutput/**/reports/
+
+  aggregate:
+    needs: mutate
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download mutation reports
+        uses: actions/download-artifact@v6
+        with:
+          pattern: mutation-report-*
+          path: mutation-reports
+
+      - name: Merge mutation reports
+        shell: pwsh
+        run: |
+          ./.github/scripts/Merge-MutationReports.ps1 `
+            -ReportsRoot mutation-reports `
+            -OutputPath mutation-reports/CombinedMutationReport.md
+
+      - name: Upload combined mutation report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: combined-mutation-report
+          path: mutation-reports/CombinedMutationReport.md
+
+      - name: Post mutation summary to PR
+        uses: marocchino/sticky-pull-request-comment@v3
+        if: always() && github.event_name == 'pull_request'
+        with:
+          recreate: true
+          path: mutation-reports/CombinedMutationReport.md

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,39 @@
+name: Mutation Testing
+
+on:
+  workflow_dispatch:
+
+jobs:
+  mutate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test-project:
+          - MarkView.Avalonia.Tests
+          - MarkView.Avalonia.Svg.Tests
+          - MarkView.Avalonia.SyntaxHighlighting.Tests
+          - MarkView.Avalonia.Mermaid.Tests
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.x'
+
+      - name: Restore .NET tools
+        run: dotnet tool restore
+
+      - name: Restore solution
+        run: dotnet restore
+
+      - name: Run Stryker
+        working-directory: tests/${{ matrix.test-project }}
+        run: dotnet stryker
+
+      - name: Upload mutation report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: mutation-report-${{ matrix.test-project }}
+          path: tests/${{ matrix.test-project }}/StrykerOutput/**/reports/

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,7 +1,12 @@
 name: Mutation Testing
 
 on:
+  workflow_call:
   workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   mutate:

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -76,5 +76,6 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v3
         if: always() && github.event_name == 'pull_request'
         with:
+          header: mutation
           recreate: true
           path: mutation-reports/CombinedMutationReport.md

--- a/.gitignore
+++ b/.gitignore
@@ -482,3 +482,6 @@ $RECYCLE.BIN/
 *.swp
 
 .worktrees
+
+# Stryker mutation testing output
+StrykerOutput/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "MarkView.Avalonia.slnx"
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,8 +21,8 @@
     <!-- Test dependencies -->
     <PackageVersion Include="Avalonia.Headless.XUnit" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/tests/MarkView.Avalonia.Mermaid.Tests/packages.lock.json
+++ b/tests/MarkView.Avalonia.Mermaid.Tests/packages.lock.json
@@ -29,19 +29,19 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.8.1, )",
-        "resolved": "18.8.1",
-        "contentHash": "dknJL3/9Y3t4XuCBqnc0PevPxgLsUMmVhjwup/b1HNovA8zWcj3XsfIf7c6p05363DWcqL7X/YhDL9B+Zymv1w==",
+        "requested": "[18.9.0, )",
+        "resolved": "18.9.0",
+        "contentHash": "xIzVXa/VpKXqDWzyC/5Hw8JbFY5u9k3Jc53CpcjBiOXvkQGio484LD9FNwOiGUSMDcYL3Rcw9sNgGi5WrswlPQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.8.1",
-          "Microsoft.TestPlatform.TestHost": "18.8.1"
+          "Microsoft.CodeCoverage": "18.9.0",
+          "Microsoft.TestPlatform.TestHost": "18.9.0"
         }
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
-        "requested": "[3.1.5, )",
-        "resolved": "3.1.5",
-        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+        "requested": "[4.0.0, )",
+        "resolved": "4.0.0",
+        "contentHash": "kzLFyBYUnoidpGOXvpNOfIo8C92gVgVR6X8ncHwhcrDYugiOut5rrhDkr0L3cWHd7J2pKXf6LgaeXoBBDlx1ag=="
       },
       "xunit.v3": {
         "type": "Direct",
@@ -148,8 +148,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "Eclse/ZZjr4lmWzZFNN9h/OluhKL+SK/QbUyKUewgX139aGeyMEO/DkMPwuFs2MixvanTnz6891rF8UHDg+W4Q=="
+        "resolved": "18.9.0",
+        "contentHash": "MtegCIKGuG0r/LCdIjoR1HgzCGIUBhR3aNdbtQpts5vMXQuqBDZ2Jsd2uFKoHFM2XrQV6ZrDf3F5oLi3SLTp8w=="
       },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Transitive",
@@ -188,15 +188,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "qLbktNB1+b1XZLNJBTzaWVVJAd6PEzD7cgD406geMb6PcFZhp3EDNa1tctWx1+mtMU6MP/6ozVvFPC9vs2a9rw=="
+        "resolved": "18.9.0",
+        "contentHash": "Fz/qXC52VXXopzHj7v2reCKcCqSxkTDCkEDfkNAH0vni/7qK/KLMiEYtRmnUanxO2F2g2zZZ60qCpxF0AF7URA=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "FaQHPDTUOcE+SFTjssNPfrub2lT9Zyon4J2W/KLHt/efLJACb1TCeWXyOgh0D/4Q1e4n+S3E6mOKud+9nLZlEA==",
+        "resolved": "18.9.0",
+        "contentHash": "Oq+Pma/J86aZL72t71bcESvDszDsTjUfl6PIsuDdPoKTHZfNMhKamCfLD5fKx51W/u0KozXtJo2/3fnt0sgPxg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.8.1"
+          "Microsoft.TestPlatform.ObjectModel": "18.9.0"
         }
       },
       "Microsoft.Win32.Registry": {

--- a/tests/MarkView.Avalonia.Mermaid.Tests/stryker-config.json
+++ b/tests/MarkView.Avalonia.Mermaid.Tests/stryker-config.json
@@ -1,0 +1,15 @@
+{
+  "stryker-config": {
+    "project": "MarkView.Avalonia.Mermaid.csproj",
+    "test-runner": "mtp",
+    "reporters": [
+      "html",
+      "progress"
+    ],
+    "thresholds": {
+      "high": 80,
+      "low": 60,
+      "break": 0
+    }
+  }
+}

--- a/tests/MarkView.Avalonia.Mermaid.Tests/stryker-config.json
+++ b/tests/MarkView.Avalonia.Mermaid.Tests/stryker-config.json
@@ -4,7 +4,8 @@
     "test-runner": "mtp",
     "reporters": [
       "html",
-      "progress"
+      "progress",
+      "markdown"
     ],
     "thresholds": {
       "high": 80,

--- a/tests/MarkView.Avalonia.Svg.Tests/packages.lock.json
+++ b/tests/MarkView.Avalonia.Svg.Tests/packages.lock.json
@@ -29,19 +29,19 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.8.1, )",
-        "resolved": "18.8.1",
-        "contentHash": "dknJL3/9Y3t4XuCBqnc0PevPxgLsUMmVhjwup/b1HNovA8zWcj3XsfIf7c6p05363DWcqL7X/YhDL9B+Zymv1w==",
+        "requested": "[18.9.0, )",
+        "resolved": "18.9.0",
+        "contentHash": "xIzVXa/VpKXqDWzyC/5Hw8JbFY5u9k3Jc53CpcjBiOXvkQGio484LD9FNwOiGUSMDcYL3Rcw9sNgGi5WrswlPQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.8.1",
-          "Microsoft.TestPlatform.TestHost": "18.8.1"
+          "Microsoft.CodeCoverage": "18.9.0",
+          "Microsoft.TestPlatform.TestHost": "18.9.0"
         }
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
-        "requested": "[3.1.5, )",
-        "resolved": "3.1.5",
-        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+        "requested": "[4.0.0, )",
+        "resolved": "4.0.0",
+        "contentHash": "kzLFyBYUnoidpGOXvpNOfIo8C92gVgVR6X8ncHwhcrDYugiOut5rrhDkr0L3cWHd7J2pKXf6LgaeXoBBDlx1ag=="
       },
       "xunit.v3": {
         "type": "Direct",
@@ -148,8 +148,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "Eclse/ZZjr4lmWzZFNN9h/OluhKL+SK/QbUyKUewgX139aGeyMEO/DkMPwuFs2MixvanTnz6891rF8UHDg+W4Q=="
+        "resolved": "18.9.0",
+        "contentHash": "MtegCIKGuG0r/LCdIjoR1HgzCGIUBhR3aNdbtQpts5vMXQuqBDZ2Jsd2uFKoHFM2XrQV6ZrDf3F5oLi3SLTp8w=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -183,15 +183,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "qLbktNB1+b1XZLNJBTzaWVVJAd6PEzD7cgD406geMb6PcFZhp3EDNa1tctWx1+mtMU6MP/6ozVvFPC9vs2a9rw=="
+        "resolved": "18.9.0",
+        "contentHash": "Fz/qXC52VXXopzHj7v2reCKcCqSxkTDCkEDfkNAH0vni/7qK/KLMiEYtRmnUanxO2F2g2zZZ60qCpxF0AF7URA=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "FaQHPDTUOcE+SFTjssNPfrub2lT9Zyon4J2W/KLHt/efLJACb1TCeWXyOgh0D/4Q1e4n+S3E6mOKud+9nLZlEA==",
+        "resolved": "18.9.0",
+        "contentHash": "Oq+Pma/J86aZL72t71bcESvDszDsTjUfl6PIsuDdPoKTHZfNMhKamCfLD5fKx51W/u0KozXtJo2/3fnt0sgPxg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.8.1"
+          "Microsoft.TestPlatform.ObjectModel": "18.9.0"
         }
       },
       "Microsoft.Win32.Registry": {

--- a/tests/MarkView.Avalonia.Svg.Tests/stryker-config.json
+++ b/tests/MarkView.Avalonia.Svg.Tests/stryker-config.json
@@ -4,7 +4,8 @@
     "test-runner": "mtp",
     "reporters": [
       "html",
-      "progress"
+      "progress",
+      "markdown"
     ],
     "thresholds": {
       "high": 80,

--- a/tests/MarkView.Avalonia.Svg.Tests/stryker-config.json
+++ b/tests/MarkView.Avalonia.Svg.Tests/stryker-config.json
@@ -1,0 +1,15 @@
+{
+  "stryker-config": {
+    "project": "MarkView.Avalonia.Svg.csproj",
+    "test-runner": "mtp",
+    "reporters": [
+      "html",
+      "progress"
+    ],
+    "thresholds": {
+      "high": 80,
+      "low": 60,
+      "break": 0
+    }
+  }
+}

--- a/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/packages.lock.json
+++ b/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/packages.lock.json
@@ -29,19 +29,19 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.8.1, )",
-        "resolved": "18.8.1",
-        "contentHash": "dknJL3/9Y3t4XuCBqnc0PevPxgLsUMmVhjwup/b1HNovA8zWcj3XsfIf7c6p05363DWcqL7X/YhDL9B+Zymv1w==",
+        "requested": "[18.9.0, )",
+        "resolved": "18.9.0",
+        "contentHash": "xIzVXa/VpKXqDWzyC/5Hw8JbFY5u9k3Jc53CpcjBiOXvkQGio484LD9FNwOiGUSMDcYL3Rcw9sNgGi5WrswlPQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.8.1",
-          "Microsoft.TestPlatform.TestHost": "18.8.1"
+          "Microsoft.CodeCoverage": "18.9.0",
+          "Microsoft.TestPlatform.TestHost": "18.9.0"
         }
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
-        "requested": "[3.1.5, )",
-        "resolved": "3.1.5",
-        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+        "requested": "[4.0.0, )",
+        "resolved": "4.0.0",
+        "contentHash": "kzLFyBYUnoidpGOXvpNOfIo8C92gVgVR6X8ncHwhcrDYugiOut5rrhDkr0L3cWHd7J2pKXf6LgaeXoBBDlx1ag=="
       },
       "xunit.v3": {
         "type": "Direct",
@@ -129,8 +129,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "Eclse/ZZjr4lmWzZFNN9h/OluhKL+SK/QbUyKUewgX139aGeyMEO/DkMPwuFs2MixvanTnz6891rF8UHDg+W4Q=="
+        "resolved": "18.9.0",
+        "contentHash": "MtegCIKGuG0r/LCdIjoR1HgzCGIUBhR3aNdbtQpts5vMXQuqBDZ2Jsd2uFKoHFM2XrQV6ZrDf3F5oLi3SLTp8w=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -164,15 +164,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "qLbktNB1+b1XZLNJBTzaWVVJAd6PEzD7cgD406geMb6PcFZhp3EDNa1tctWx1+mtMU6MP/6ozVvFPC9vs2a9rw=="
+        "resolved": "18.9.0",
+        "contentHash": "Fz/qXC52VXXopzHj7v2reCKcCqSxkTDCkEDfkNAH0vni/7qK/KLMiEYtRmnUanxO2F2g2zZZ60qCpxF0AF7URA=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "FaQHPDTUOcE+SFTjssNPfrub2lT9Zyon4J2W/KLHt/efLJACb1TCeWXyOgh0D/4Q1e4n+S3E6mOKud+9nLZlEA==",
+        "resolved": "18.9.0",
+        "contentHash": "Oq+Pma/J86aZL72t71bcESvDszDsTjUfl6PIsuDdPoKTHZfNMhKamCfLD5fKx51W/u0KozXtJo2/3fnt0sgPxg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.8.1"
+          "Microsoft.TestPlatform.ObjectModel": "18.9.0"
         }
       },
       "Microsoft.Win32.Registry": {

--- a/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/stryker-config.json
+++ b/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/stryker-config.json
@@ -1,0 +1,15 @@
+{
+  "stryker-config": {
+    "project": "MarkView.Avalonia.SyntaxHighlighting.csproj",
+    "test-runner": "mtp",
+    "reporters": [
+      "html",
+      "progress"
+    ],
+    "thresholds": {
+      "high": 80,
+      "low": 60,
+      "break": 0
+    }
+  }
+}

--- a/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/stryker-config.json
+++ b/tests/MarkView.Avalonia.SyntaxHighlighting.Tests/stryker-config.json
@@ -4,7 +4,8 @@
     "test-runner": "mtp",
     "reporters": [
       "html",
-      "progress"
+      "progress",
+      "markdown"
     ],
     "thresholds": {
       "high": 80,

--- a/tests/MarkView.Avalonia.Tests/MarkdownExtensionsTests.cs
+++ b/tests/MarkView.Avalonia.Tests/MarkdownExtensionsTests.cs
@@ -91,24 +91,4 @@ public class MarkdownExtensionsTests : RenderTestBase
         var run = Assert.IsType<Run>(Assert.Single(textBlock.Inlines!));
         Assert.Equal("Great :) job", run.Text);
     }
-
-    private static T? FindFirst<T>(Control root) where T : Control
-    {
-        if (root is T match) return match;
-        if (root is Panel p) foreach (var child in p.Children) { var f = FindFirst<T>(child); if (f != null) return f; }
-        if (root is ContentControl cc && cc.Content is Control c) return FindFirst<T>(c);
-        if (root is Decorator d && d.Child is Control dc) return FindFirst<T>(dc);
-        if (root is TextBlock tb && tb.Inlines != null)
-        {
-            foreach (var inline in tb.Inlines)
-            {
-                if (inline is InlineUIContainer iuc && iuc.Child is Control iucChild)
-                {
-                    var f = FindFirst<T>(iucChild);
-                    if (f != null) return f;
-                }
-            }
-        }
-        return null;
-    }
 }

--- a/tests/MarkView.Avalonia.Tests/packages.lock.json
+++ b/tests/MarkView.Avalonia.Tests/packages.lock.json
@@ -29,19 +29,19 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[18.8.1, )",
-        "resolved": "18.8.1",
-        "contentHash": "dknJL3/9Y3t4XuCBqnc0PevPxgLsUMmVhjwup/b1HNovA8zWcj3XsfIf7c6p05363DWcqL7X/YhDL9B+Zymv1w==",
+        "requested": "[18.9.0, )",
+        "resolved": "18.9.0",
+        "contentHash": "xIzVXa/VpKXqDWzyC/5Hw8JbFY5u9k3Jc53CpcjBiOXvkQGio484LD9FNwOiGUSMDcYL3Rcw9sNgGi5WrswlPQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "18.8.1",
-          "Microsoft.TestPlatform.TestHost": "18.8.1"
+          "Microsoft.CodeCoverage": "18.9.0",
+          "Microsoft.TestPlatform.TestHost": "18.9.0"
         }
       },
       "xunit.runner.visualstudio": {
         "type": "Direct",
-        "requested": "[3.1.5, )",
-        "resolved": "3.1.5",
-        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+        "requested": "[4.0.0, )",
+        "resolved": "4.0.0",
+        "contentHash": "kzLFyBYUnoidpGOXvpNOfIo8C92gVgVR6X8ncHwhcrDYugiOut5rrhDkr0L3cWHd7J2pKXf6LgaeXoBBDlx1ag=="
       },
       "xunit.v3": {
         "type": "Direct",
@@ -129,8 +129,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "Eclse/ZZjr4lmWzZFNN9h/OluhKL+SK/QbUyKUewgX139aGeyMEO/DkMPwuFs2MixvanTnz6891rF8UHDg+W4Q=="
+        "resolved": "18.9.0",
+        "contentHash": "MtegCIKGuG0r/LCdIjoR1HgzCGIUBhR3aNdbtQpts5vMXQuqBDZ2Jsd2uFKoHFM2XrQV6ZrDf3F5oLi3SLTp8w=="
       },
       "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
@@ -164,15 +164,15 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "qLbktNB1+b1XZLNJBTzaWVVJAd6PEzD7cgD406geMb6PcFZhp3EDNa1tctWx1+mtMU6MP/6ozVvFPC9vs2a9rw=="
+        "resolved": "18.9.0",
+        "contentHash": "Fz/qXC52VXXopzHj7v2reCKcCqSxkTDCkEDfkNAH0vni/7qK/KLMiEYtRmnUanxO2F2g2zZZ60qCpxF0AF7URA=="
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "18.8.1",
-        "contentHash": "FaQHPDTUOcE+SFTjssNPfrub2lT9Zyon4J2W/KLHt/efLJACb1TCeWXyOgh0D/4Q1e4n+S3E6mOKud+9nLZlEA==",
+        "resolved": "18.9.0",
+        "contentHash": "Oq+Pma/J86aZL72t71bcESvDszDsTjUfl6PIsuDdPoKTHZfNMhKamCfLD5fKx51W/u0KozXtJo2/3fnt0sgPxg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "18.8.1"
+          "Microsoft.TestPlatform.ObjectModel": "18.9.0"
         }
       },
       "Microsoft.Win32.Registry": {

--- a/tests/MarkView.Avalonia.Tests/stryker-config.json
+++ b/tests/MarkView.Avalonia.Tests/stryker-config.json
@@ -4,7 +4,8 @@
     "test-runner": "mtp",
     "reporters": [
       "html",
-      "progress"
+      "progress",
+      "markdown"
     ],
     "thresholds": {
       "high": 80,

--- a/tests/MarkView.Avalonia.Tests/stryker-config.json
+++ b/tests/MarkView.Avalonia.Tests/stryker-config.json
@@ -1,0 +1,15 @@
+{
+  "stryker-config": {
+    "project": "MarkView.Avalonia.csproj",
+    "test-runner": "mtp",
+    "reporters": [
+      "html",
+      "progress"
+    ],
+    "thresholds": {
+      "high": 80,
+      "low": 60,
+      "break": 0
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Use `dotnet stryker` to mutate the tests, then generate a report that can be attached to each pull request.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [ ] Documentation
- [x] CI / build

## Test plan

- [ ] `dotnet test` — all tests pass
- [ ] Manual smoke-test in the demo app
