### PR TITLE
feat: include symbol in packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,5 +11,11 @@
     <RepositoryUrl>https://github.com/Kryptos-FR/MarkView.Avalonia</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <!-- Source Link / symbol packages -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

Symbols were missing from the nuget packages. This PR adds them. It also allow SourceLink to work properly for a richer debugging experience.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [ ] Documentation
- [x] CI / build

## Test plan

- [x] `dotnet test` — all tests pass
- [ ] Manual smoke-test in the demo app