### PR TITLE
feat: add Dependabot lock file fix workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
           dotnet-version: '10.x'
 
       - name: Restore
-        run: dotnet restore
+        run: dotnet restore --locked-mode
 
       - name: Build
         run: dotnet build --no-restore --configuration Release

--- a/.github/workflows/dependabot-lockfile-fix.yml
+++ b/.github/workflows/dependabot-lockfile-fix.yml
@@ -1,0 +1,45 @@
+name: Dependabot Lock File Fix
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+
+jobs:
+  fix-lock-files:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.x'
+
+      - name: Check lock files
+        id: check-lock-files
+        run: dotnet restore --locked-mode
+        continue-on-error: true
+
+      - name: Regenerate
+        if: steps.check-lock-files.outcome == 'failure'
+        run: dotnet restore --force-evaluate
+
+      - name: Build
+        if: steps.check-lock-files.outcome == 'failure'
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Push lock files
+        if: steps.check-lock-files.outcome == 'failure'
+        run:
+          if git diff --quiet -- '*packages.lock.json'; then
+            echo "Lock files already up to date."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -- '*packages.lock.json'
+          git commit -m "fix(build): regenerate packages.lock.json"
+          git push

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -31,7 +31,7 @@ jobs:
         run: dotnet tool restore
 
       - name: Restore solution
-        run: dotnet restore
+        run: dotnet restore --locked-mode
 
       - name: Run Stryker
         working-directory: tests/${{ matrix.test-project }}


### PR DESCRIPTION
## Summary

Add a workflow to automatically fixup dependabot PRs when it fails to update all `packages.lock.json` files.

Workaround for dependabot/dependabot-core#13950.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [ ] Documentation
- [ ] CI / build

## Test plan

- [ ] `dotnet test` — all tests pass
- [ ] Manual smoke-test in the demo app