### PR TITLE
ci: update dependabot-lockfile-fix.yml

### DIFF
--- a/.github/workflows/dependabot-lockfile-fix.yml
+++ b/.github/workflows/dependabot-lockfile-fix.yml
@@ -3,9 +3,20 @@ name: Dependabot Lock File Fix
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    branches:
+      - master
+    paths:
+      - Directory.Packages.props
+      - global.json
+      - "**/*.csproj"
+      - "**/packages.lock.json"
 
 permissions:
   contents: write
+
+concurrency:
+  group: dependabot-lockfile-fix-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   fix-lock-files:
@@ -13,6 +24,8 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.head_ref }}
 
       - uses: actions/setup-dotnet@v6
         with:


### PR DESCRIPTION
## Summary

Various fixes for the dependabot fix CI job:
- checkout the `ref` (branch) so that `push` can work
- prevent concurrent runs in case a rebase happens when the job is still running
- filter by path to limit when the job is triggered

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [ ] Documentation
- [x] CI / build
