### PR TITLE
feat(deps): add cooldown periods and grouping to nuget dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,29 @@ updates:
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    cooldown:
+      semver-major-days: 15
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      avalonia:
+        patterns:
+          - "Avalonia"
+          - "Avalonia.*"
+      csharpmath:
+        patterns:
+          - "CSharpMath"
+          - "CSharpMath.*"
+      textmatesharp:
+        patterns:
+          - "TextMateSharp"
+          - "TextMateSharp.*"
+      tests:
+        patterns:
+          - "Microsoft.Testing.Extensions.CodeCoverage"
+          - "Microsoft.NET.Test.Sdk"
+          - "xunit.v3"
     ignore:
       # Avalonia.Headless.XUnit isn't compatible with xunit.v3 4.0.0 (AvaloniaUI/Avalonia#22072).
       # Drop this ignore once Avalonia ships a compatible package.


### PR DESCRIPTION
## Summary

Cooldown avoids updating to freshly-released versions (major 15d, minor 7d, patch 3d); daily schedule keeps the effective wait close to those windows. Avalonia.*, TextMateSharp.* and CSharpMath.* updates group into single PRs.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring (no behaviour change)
- [ ] Documentation
- [x] CI / build
